### PR TITLE
[breaking] fix typo for `inactivity_timer`

### DIFF
--- a/docs/data-sources/service_template.md
+++ b/docs/data-sources/service_template.md
@@ -35,8 +35,8 @@ data "iosxe_service_template" "example" {
 - `access_groups` (Attributes List) Access list to be applied (see [below for nested schema](#nestedatt--access_groups))
 - `description` (String) Enter a description
 - `dns_acl_preauth` (String) pre-authentication
-- `ianctivity_timer` (Number) Enter a value between 1 and 65535
 - `id` (String) The path of the retrieved object.
+- `inactivity_timer` (Number) Enter a value between 1 and 65535
 - `inactivity_timer_probe` (Boolean) ARP probe
 - `interface_templates` (Attributes List) Interface template to be applied (see [below for nested schema](#nestedatt--interface_templates))
 - `linksec_policy` (String) Set the link security policy

--- a/docs/resources/service_template.md
+++ b/docs/resources/service_template.md
@@ -20,7 +20,7 @@ resource "iosxe_service_template" "example" {
       name = "ag1"
     }
   ]
-  ianctivity_timer       = 25
+  inactivity_timer       = 25
   inactivity_timer_probe = false
   vlan                   = 27
   voice_vlan             = false
@@ -66,7 +66,7 @@ resource "iosxe_service_template" "example" {
 - `description` (String) Enter a description
 - `device` (String) A device name from the provider configuration.
 - `dns_acl_preauth` (String) pre-authentication
-- `ianctivity_timer` (Number) Enter a value between 1 and 65535
+- `inactivity_timer` (Number) Enter a value between 1 and 65535
   - Range: `1`-`65535`
 - `inactivity_timer_probe` (Boolean) ARP probe
 - `interface_templates` (Attributes List) Interface template to be applied (see [below for nested schema](#nestedatt--interface_templates))

--- a/examples/resources/iosxe_service_template/resource.tf
+++ b/examples/resources/iosxe_service_template/resource.tf
@@ -5,7 +5,7 @@ resource "iosxe_service_template" "example" {
       name = "ag1"
     }
   ]
-  ianctivity_timer       = 25
+  inactivity_timer       = 25
   inactivity_timer_probe = false
   vlan                   = 27
   voice_vlan             = false

--- a/gen/definitions/service_template.yaml
+++ b/gen/definitions/service_template.yaml
@@ -15,7 +15,7 @@ attributes:
         id: true
         example: ag1
   - yang_name: inactivity-timer/value
-    tf_name: ianctivity_timer
+    tf_name: inactivity_timer
     example: 25
   - yang_name: inactivity-timer/probe
     example: false

--- a/internal/provider/data_source_iosxe_service_template.go
+++ b/internal/provider/data_source_iosxe_service_template.go
@@ -79,7 +79,7 @@ func (d *ServiceTemplateDataSource) Schema(ctx context.Context, req datasource.S
 					},
 				},
 			},
-			"ianctivity_timer": schema.Int64Attribute{
+			"inactivity_timer": schema.Int64Attribute{
 				MarkdownDescription: "Enter a value between 1 and 65535",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_iosxe_service_template_test.go
+++ b/internal/provider/data_source_iosxe_service_template_test.go
@@ -28,7 +28,7 @@ import (
 func TestAccDataSourceIosxeServiceTemplate(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "access_groups.0.name", "ag1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "ianctivity_timer", "25"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "inactivity_timer", "25"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "inactivity_timer_probe", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "vlan", "27"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_service_template.test", "voice_vlan", "false"))
@@ -66,7 +66,7 @@ func testAccDataSourceIosxeServiceTemplateConfig() string {
 	config += `	access_groups = [{` + "\n"
 	config += `		name = "ag1"` + "\n"
 	config += `	}]` + "\n"
-	config += `	ianctivity_timer = 25` + "\n"
+	config += `	inactivity_timer = 25` + "\n"
 	config += `	inactivity_timer_probe = false` + "\n"
 	config += `	vlan = 27` + "\n"
 	config += `	voice_vlan = false` + "\n"

--- a/internal/provider/model_iosxe_service_template.go
+++ b/internal/provider/model_iosxe_service_template.go
@@ -39,7 +39,7 @@ type ServiceTemplate struct {
 	Id                      types.String                        `tfsdk:"id"`
 	Name                    types.String                        `tfsdk:"name"`
 	AccessGroups            []ServiceTemplateAccessGroups       `tfsdk:"access_groups"`
-	IanctivityTimer         types.Int64                         `tfsdk:"ianctivity_timer"`
+	InactivityTimer         types.Int64                         `tfsdk:"inactivity_timer"`
 	InactivityTimerProbe    types.Bool                          `tfsdk:"inactivity_timer_probe"`
 	Vlan                    types.Int64                         `tfsdk:"vlan"`
 	VoiceVlan               types.Bool                          `tfsdk:"voice_vlan"`
@@ -67,7 +67,7 @@ type ServiceTemplateData struct {
 	Id                      types.String                        `tfsdk:"id"`
 	Name                    types.String                        `tfsdk:"name"`
 	AccessGroups            []ServiceTemplateAccessGroups       `tfsdk:"access_groups"`
-	IanctivityTimer         types.Int64                         `tfsdk:"ianctivity_timer"`
+	InactivityTimer         types.Int64                         `tfsdk:"inactivity_timer"`
 	InactivityTimerProbe    types.Bool                          `tfsdk:"inactivity_timer_probe"`
 	Vlan                    types.Int64                         `tfsdk:"vlan"`
 	VoiceVlan               types.Bool                          `tfsdk:"voice_vlan"`
@@ -123,8 +123,8 @@ func (data ServiceTemplate) toBody(ctx context.Context) string {
 	if !data.Name.IsNull() && !data.Name.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"word", data.Name.ValueString())
 	}
-	if !data.IanctivityTimer.IsNull() && !data.IanctivityTimer.IsUnknown() {
-		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"inactivity-timer.value", strconv.FormatInt(data.IanctivityTimer.ValueInt64(), 10))
+	if !data.InactivityTimer.IsNull() && !data.InactivityTimer.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"inactivity-timer.value", strconv.FormatInt(data.InactivityTimer.ValueInt64(), 10))
 	}
 	if !data.InactivityTimerProbe.IsNull() && !data.InactivityTimerProbe.IsUnknown() {
 		if data.InactivityTimerProbe.ValueBool() {
@@ -250,10 +250,10 @@ func (data *ServiceTemplate) updateFromBody(ctx context.Context, res gjson.Resul
 			data.AccessGroups[i].Name = types.StringNull()
 		}
 	}
-	if value := res.Get(prefix + "inactivity-timer.value"); value.Exists() && !data.IanctivityTimer.IsNull() {
-		data.IanctivityTimer = types.Int64Value(value.Int())
+	if value := res.Get(prefix + "inactivity-timer.value"); value.Exists() && !data.InactivityTimer.IsNull() {
+		data.InactivityTimer = types.Int64Value(value.Int())
 	} else {
-		data.IanctivityTimer = types.Int64Null()
+		data.InactivityTimer = types.Int64Null()
 	}
 	if value := res.Get(prefix + "inactivity-timer.probe"); !data.InactivityTimerProbe.IsNull() {
 		if value.Exists() {
@@ -430,7 +430,7 @@ func (data *ServiceTemplateData) fromBody(ctx context.Context, res gjson.Result)
 		})
 	}
 	if value := res.Get(prefix + "inactivity-timer.value"); value.Exists() {
-		data.IanctivityTimer = types.Int64Value(value.Int())
+		data.InactivityTimer = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "inactivity-timer.probe"); value.Exists() {
 		data.InactivityTimerProbe = types.BoolValue(true)
@@ -541,7 +541,7 @@ func (data *ServiceTemplate) getDeletedItems(ctx context.Context, state ServiceT
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/access-group-config=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 		}
 	}
-	if !state.IanctivityTimer.IsNull() && data.IanctivityTimer.IsNull() {
+	if !state.InactivityTimer.IsNull() && data.InactivityTimer.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/inactivity-timer/value", state.getPath()))
 	}
 	if !state.InactivityTimerProbe.IsNull() && data.InactivityTimerProbe.IsNull() {
@@ -671,7 +671,7 @@ func (data *ServiceTemplate) getDeletePaths(ctx context.Context) []string {
 
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/access-group-config=%v", data.getPath(), strings.Join(keyValues[:], ",")))
 	}
-	if !data.IanctivityTimer.IsNull() {
+	if !data.InactivityTimer.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/inactivity-timer/value", data.getPath()))
 	}
 	if !data.InactivityTimerProbe.IsNull() {

--- a/internal/provider/resource_iosxe_service_template.go
+++ b/internal/provider/resource_iosxe_service_template.go
@@ -88,7 +88,7 @@ func (r *ServiceTemplateResource) Schema(ctx context.Context, req resource.Schem
 					},
 				},
 			},
-			"ianctivity_timer": schema.Int64Attribute{
+			"inactivity_timer": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enter a value between 1 and 65535").AddIntegerRangeDescription(1, 65535).String,
 				Optional:            true,
 				Validators: []validator.Int64{

--- a/internal/provider/resource_iosxe_service_template_test.go
+++ b/internal/provider/resource_iosxe_service_template_test.go
@@ -29,7 +29,7 @@ func TestAccIosxeServiceTemplate(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "name", "MY_TEMPLATE"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "access_groups.0.name", "ag1"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "ianctivity_timer", "25"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "inactivity_timer", "25"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "inactivity_timer_probe", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "vlan", "27"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_service_template.test", "voice_vlan", "false"))
@@ -82,7 +82,7 @@ func testAccIosxeServiceTemplateConfig_all() string {
 	config += `	access_groups = [{` + "\n"
 	config += `		name = "ag1"` + "\n"
 	config += `	}]` + "\n"
-	config += `	ianctivity_timer = 25` + "\n"
+	config += `	inactivity_timer = 25` + "\n"
 	config += `	inactivity_timer_probe = false` + "\n"
 	config += `	vlan = 27` + "\n"
 	config += `	voice_vlan = false` + "\n"


### PR DESCRIPTION
It's only a typo, but it breaks backwards compatibility.

Closes #139