### PR TITLE
optimize `go generate` speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Additional documentation, including available resources and their arguments/attr
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
 
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+If any file in `gen` directory has been modified, run all the generators:
 
-To generate or update documentation, run `go generate`.
+```shell
+go generate -x
+```
+
+To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 In order to run the full suite of Acceptance tests, run `make testacc`. Make sure the respective environment variables are set (e.g., `IOSXE_USERNAME`, `IOSXE_PASSWORD`, `IOSXE_URL`).
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -23,7 +23,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -530,12 +529,12 @@ func renderTemplate(templatePath, outputPath string, config interface{}) {
 }
 
 func main() {
-	items, _ := ioutil.ReadDir(definitionsPath)
+	items, _ := os.ReadDir(definitionsPath)
 	configs := make([]YamlConfig, len(items))
 
 	// Load configs
 	for i, filename := range items {
-		yamlFile, err := ioutil.ReadFile(filepath.Join(definitionsPath, filename.Name()))
+		yamlFile, err := os.ReadFile(filepath.Join(definitionsPath, filename.Name()))
 		if err != nil {
 			log.Fatalf("Error reading file: %v", err)
 		}
@@ -548,7 +547,7 @@ func main() {
 		configs[i] = config
 	}
 
-	items, _ = ioutil.ReadDir(modelsPath)
+	items, _ = os.ReadDir(modelsPath)
 	modelPaths := make([]string, 0)
 
 	// Iterate over yang models
@@ -564,6 +563,8 @@ func main() {
 			augmentConfig(&configs[i], modelPaths)
 		}
 
+		fmt.Printf("Augumented %d/%d: %v\n", i+1, len(configs), configs[i].Name)
+
 		// Iterate over templates and render files
 		for _, t := range templates {
 			renderTemplate(t.path, t.prefix+SnakeCase(configs[i].Name)+t.suffix, configs[i])
@@ -573,7 +574,7 @@ func main() {
 	// render provider.go
 	renderTemplate(providerTemplate, providerLocation, configs)
 
-	changelog, err := ioutil.ReadFile(changelogOriginal)
+	changelog, err := os.ReadFile(changelogOriginal)
 	if err != nil {
 		log.Fatalf("Error reading changelog: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -25,21 +25,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
-// Run "go generate" to format example terraform files and generate the docs for the registry/website
-
-// Donwload YANG models.
+// Download the YANG models.
 //go:generate go run gen/load_models.go
 
-// Run the resource and datasource generation tool.
+// Having YANG models as input, generate code (Go and Terraform).
 //go:generate go run gen/generator.go
 
-// Format code and cleanup imports
+// Format Go code and cleanup imports.
 //go:generate go run golang.org/x/tools/cmd/goimports -w internal/provider/
 
-// If you do not have terraform installed, you can remove the formatting command, but its suggested to
-// ensure the documentation is formatted properly.
+// Format Terraform code.
 //go:generate terraform fmt -recursive ./examples/
 
+// Having Terraform code as input, generate documentation.
 // Run the docs generation tool, check its repository for more information on how it works and how docs
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs


### PR DESCRIPTION
Do not repeatedly parse the same yang files.
Saves about 7 seconds for me.

Bonus: recommend `go generate -x` as it adds just a few lines of output but adds a lot of clarity.