### PR TITLE
interfaces: add load-interval, link-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
-- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`, `iosxe_interface_tunnel` resources and data sources
 - Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5
 

--- a/docs/data-sources/interface_ethernet.md
+++ b/docs/data-sources/interface_ethernet.md
@@ -112,6 +112,7 @@ data "iosxe_interface_ethernet" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `mab` (Boolean) MAC Authentication Bypass Interface Config Commands
 - `mab_eap` (Boolean) Use EAP authentication for MAC Auth Bypass
 - `media_type` (String) Media type

--- a/docs/data-sources/interface_ethernet.md
+++ b/docs/data-sources/interface_ethernet.md
@@ -119,6 +119,7 @@ data "iosxe_interface_ethernet" "example" {
 - `service_policy_input` (String) Assign policy-map to the input of an interface
 - `service_policy_output` (String) Assign policy-map to the output of an interface
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `source_template` (Attributes List) (see [below for nested schema](#nestedatt--source_template))
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use

--- a/docs/data-sources/interface_ethernet.md
+++ b/docs/data-sources/interface_ethernet.md
@@ -111,6 +111,7 @@ data "iosxe_interface_ethernet" "example" {
 - `ipv6_link_local_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_link_local_addresses))
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
 - `mab` (Boolean) MAC Authentication Bypass Interface Config Commands
 - `mab_eap` (Boolean) Use EAP authentication for MAC Auth Bypass
 - `media_type` (String) Media type

--- a/docs/data-sources/interface_port_channel.md
+++ b/docs/data-sources/interface_port_channel.md
@@ -75,7 +75,9 @@ data "iosxe_interface_port_channel" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use
 - `switchport` (Boolean)

--- a/docs/data-sources/interface_port_channel.md
+++ b/docs/data-sources/interface_port_channel.md
@@ -74,6 +74,7 @@ data "iosxe_interface_port_channel" "example" {
 - `ipv6_link_local_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_link_local_addresses))
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
 - `shutdown` (Boolean) Shutdown the selected interface
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use

--- a/docs/data-sources/interface_tunnel.md
+++ b/docs/data-sources/interface_tunnel.md
@@ -60,6 +60,7 @@ data "iosxe_interface_tunnel" "example" {
 - `ipv6_link_local_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_link_local_addresses))
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
 - `shutdown` (Boolean) Shutdown the selected interface
 - `tunnel_destination_ipv4` (String) ip address or host name
 - `tunnel_mode_ipsec_ipv4` (Boolean) over IPv4

--- a/docs/data-sources/interface_tunnel.md
+++ b/docs/data-sources/interface_tunnel.md
@@ -61,7 +61,9 @@ data "iosxe_interface_tunnel" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `tunnel_destination_ipv4` (String) ip address or host name
 - `tunnel_mode_ipsec_ipv4` (Boolean) over IPv4
 - `tunnel_protection_ipsec_profile` (String) Determine the ipsec policy profile to use.

--- a/docs/data-sources/interface_vlan.md
+++ b/docs/data-sources/interface_vlan.md
@@ -59,6 +59,7 @@ data "iosxe_interface_vlan" "example" {
 - `ipv6_link_local_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_link_local_addresses))
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
 - `shutdown` (Boolean) Shutdown the selected interface
 - `unnumbered` (String) Enable IP processing without an explicit address
 - `vrf_forwarding` (String) Configure forwarding table

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -16,8 +16,10 @@ description: |-
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -16,9 +16,9 @@ description: |-
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
-- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`, `iosxe_interface_tunnel` resources and data sources
 - Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -69,8 +69,8 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
-  load_interval         = 30
-  snmp_trap_link_status = true
+  load_interval                    = 30
+  logging_event_link_status_enable = false
 }
 ```
 
@@ -185,6 +185,7 @@ resource "iosxe_interface_ethernet" "example" {
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
   - Range: `30`-`600`
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `mab` (Boolean) MAC Authentication Bypass Interface Config Commands
 - `mab_eap` (Boolean) Use EAP authentication for MAC Auth Bypass
 - `media_type` (String) Media type

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -36,12 +36,6 @@ resource "iosxe_interface_ethernet" "example" {
       vrf     = "VRF1"
     }
   ]
-  source_template = [
-    {
-      template_name = "TEMP1"
-      merge         = false
-    }
-  ]
   ipv6_enable             = true
   ipv6_mtu                = 1300
   ipv6_nd_ra_suppress_all = true

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -70,6 +70,7 @@ resource "iosxe_interface_ethernet" "example" {
     }
   ]
   load_interval                    = 30
+  snmp_trap_link_status            = true
   logging_event_link_status_enable = false
 }
 ```

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -69,6 +69,7 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
+  load_interval = 30
 }
 ```
 
@@ -181,6 +182,8 @@ resource "iosxe_interface_ethernet" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
   - Range: `1280`-`9976`
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
+  - Range: `30`-`600`
 - `mab` (Boolean) MAC Authentication Bypass Interface Config Commands
 - `mab_eap` (Boolean) Use EAP authentication for MAC Auth Bypass
 - `media_type` (String) Media type

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -69,7 +69,8 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
-  load_interval = 30
+  load_interval         = 30
+  snmp_trap_link_status = true
 }
 ```
 
@@ -192,6 +193,7 @@ resource "iosxe_interface_ethernet" "example" {
 - `service_policy_input` (String) Assign policy-map to the input of an interface
 - `service_policy_output` (String) Assign policy-map to the output of an interface
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `source_template` (Attributes List) (see [below for nested schema](#nestedatt--source_template))
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
   - Choices: `loop`, `none`, `root`

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -71,7 +71,7 @@ resource "iosxe_interface_ethernet" "example" {
   ]
   load_interval                    = 30
   snmp_trap_link_status            = true
-  logging_event_link_status_enable = false
+  logging_event_link_status_enable = true
 }
 ```
 

--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -47,8 +47,10 @@ resource "iosxe_interface_port_channel" "example" {
       eui_64 = true
     }
   ]
-  arp_timeout   = 2147
-  load_interval = 30
+  arp_timeout                      = 2147
+  load_interval                    = 30
+  snmp_trap_link_status            = true
+  logging_event_link_status_enable = false
 }
 ```
 
@@ -113,7 +115,9 @@ resource "iosxe_interface_port_channel" "example" {
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
   - Range: `30`-`600`
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
   - Choices: `loop`, `none`, `root`
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use

--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -47,7 +47,8 @@ resource "iosxe_interface_port_channel" "example" {
       eui_64 = true
     }
   ]
-  arp_timeout = 2147
+  arp_timeout   = 2147
+  load_interval = 30
 }
 ```
 
@@ -110,6 +111,8 @@ resource "iosxe_interface_port_channel" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
   - Range: `1280`-`9976`
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
+  - Range: `30`-`600`
 - `shutdown` (Boolean) Shutdown the selected interface
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
   - Choices: `loop`, `none`, `root`

--- a/docs/resources/interface_tunnel.md
+++ b/docs/resources/interface_tunnel.md
@@ -53,7 +53,9 @@ resource "iosxe_interface_tunnel" "example" {
       vrf     = "VRF1"
     }
   ]
-  load_interval = 30
+  load_interval                    = 30
+  snmp_trap_link_status            = true
+  logging_event_link_status_enable = true
 }
 ```
 
@@ -104,7 +106,9 @@ resource "iosxe_interface_tunnel" "example" {
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
   - Range: `30`-`600`
+- `logging_event_link_status_enable` (Boolean) UPDOWN and CHANGE messages
 - `shutdown` (Boolean) Shutdown the selected interface
+- `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `tunnel_destination_ipv4` (String) ip address or host name
 - `tunnel_mode_ipsec_ipv4` (Boolean) over IPv4
 - `tunnel_protection_ipsec_profile` (String) Determine the ipsec policy profile to use.

--- a/docs/resources/interface_tunnel.md
+++ b/docs/resources/interface_tunnel.md
@@ -53,6 +53,7 @@ resource "iosxe_interface_tunnel" "example" {
       vrf     = "VRF1"
     }
   ]
+  load_interval = 30
 }
 ```
 
@@ -101,6 +102,8 @@ resource "iosxe_interface_tunnel" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
   - Range: `1280`-`9976`
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
+  - Range: `30`-`600`
 - `shutdown` (Boolean) Shutdown the selected interface
 - `tunnel_destination_ipv4` (String) ip address or host name
 - `tunnel_mode_ipsec_ipv4` (Boolean) over IPv4

--- a/docs/resources/interface_tunnel.md
+++ b/docs/resources/interface_tunnel.md
@@ -54,7 +54,7 @@ resource "iosxe_interface_tunnel" "example" {
     }
   ]
   load_interval                    = 30
-  snmp_trap_link_status            = true
+  snmp_trap_link_status            = false
   logging_event_link_status_enable = true
 }
 ```

--- a/docs/resources/interface_vlan.md
+++ b/docs/resources/interface_vlan.md
@@ -55,6 +55,7 @@ resource "iosxe_interface_vlan" "example" {
       eui_64 = true
     }
   ]
+  load_interval = 30
 }
 ```
 
@@ -100,6 +101,8 @@ resource "iosxe_interface_vlan" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
   - Range: `1280`-`9976`
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
+- `load_interval` (Number) Specify interval for load calculation for an interface
+  - Range: `30`-`600`
 - `shutdown` (Boolean) Shutdown the selected interface
 - `unnumbered` (String) Enable IP processing without an explicit address
 - `vrf_forwarding` (String) Configure forwarding table

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -54,4 +54,5 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
+  load_interval = 30
 }

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -55,5 +55,6 @@ resource "iosxe_interface_ethernet" "example" {
     }
   ]
   load_interval                    = 30
+  snmp_trap_link_status            = true
   logging_event_link_status_enable = false
 }

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -21,12 +21,6 @@ resource "iosxe_interface_ethernet" "example" {
       vrf     = "VRF1"
     }
   ]
-  source_template = [
-    {
-      template_name = "TEMP1"
-      merge         = false
-    }
-  ]
   ipv6_enable             = true
   ipv6_mtu                = 1300
   ipv6_nd_ra_suppress_all = true

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -54,6 +54,6 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
-  load_interval         = 30
-  snmp_trap_link_status = true
+  load_interval                    = 30
+  logging_event_link_status_enable = false
 }

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -54,5 +54,6 @@ resource "iosxe_interface_ethernet" "example" {
       direction = "input"
     }
   ]
-  load_interval = 30
+  load_interval         = 30
+  snmp_trap_link_status = true
 }

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -56,5 +56,5 @@ resource "iosxe_interface_ethernet" "example" {
   ]
   load_interval                    = 30
   snmp_trap_link_status            = true
-  logging_event_link_status_enable = false
+  logging_event_link_status_enable = true
 }

--- a/examples/resources/iosxe_interface_port_channel/resource.tf
+++ b/examples/resources/iosxe_interface_port_channel/resource.tf
@@ -32,5 +32,6 @@ resource "iosxe_interface_port_channel" "example" {
       eui_64 = true
     }
   ]
-  arp_timeout = 2147
+  arp_timeout   = 2147
+  load_interval = 30
 }

--- a/examples/resources/iosxe_interface_port_channel/resource.tf
+++ b/examples/resources/iosxe_interface_port_channel/resource.tf
@@ -32,6 +32,8 @@ resource "iosxe_interface_port_channel" "example" {
       eui_64 = true
     }
   ]
-  arp_timeout   = 2147
-  load_interval = 30
+  arp_timeout                      = 2147
+  load_interval                    = 30
+  snmp_trap_link_status            = true
+  logging_event_link_status_enable = false
 }

--- a/examples/resources/iosxe_interface_tunnel/resource.tf
+++ b/examples/resources/iosxe_interface_tunnel/resource.tf
@@ -38,4 +38,5 @@ resource "iosxe_interface_tunnel" "example" {
       vrf     = "VRF1"
     }
   ]
+  load_interval = 30
 }

--- a/examples/resources/iosxe_interface_tunnel/resource.tf
+++ b/examples/resources/iosxe_interface_tunnel/resource.tf
@@ -38,5 +38,7 @@ resource "iosxe_interface_tunnel" "example" {
       vrf     = "VRF1"
     }
   ]
-  load_interval = 30
+  load_interval                    = 30
+  snmp_trap_link_status            = true
+  logging_event_link_status_enable = true
 }

--- a/examples/resources/iosxe_interface_tunnel/resource.tf
+++ b/examples/resources/iosxe_interface_tunnel/resource.tf
@@ -39,6 +39,6 @@ resource "iosxe_interface_tunnel" "example" {
     }
   ]
   load_interval                    = 30
-  snmp_trap_link_status            = true
+  snmp_trap_link_status            = false
   logging_event_link_status_enable = true
 }

--- a/examples/resources/iosxe_interface_vlan/resource.tf
+++ b/examples/resources/iosxe_interface_vlan/resource.tf
@@ -40,4 +40,5 @@ resource "iosxe_interface_vlan" "example" {
       eui_64 = true
     }
   ]
+  load_interval = 30
 }

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -433,9 +433,11 @@ attributes:
   - yang_name: load-interval
     example: 30
   - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
+    write_only: true
     example: true
   - yang_name: logging/event/link-status-enable
-    example: false
+    write_only: true
+    example: true
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -156,6 +156,7 @@ attributes:
   - yang_name: source/template/template-name
     tf_name: source_template
     type: List
+    exclude_test: true
     attributes:
       - yang_name: template-name
         example: TEMP1
@@ -433,10 +434,8 @@ attributes:
   - yang_name: load-interval
     example: 30
   - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
-    write_only: true
     example: true
   - yang_name: logging/event/link-status-enable
-    write_only: true
     example: true
 
 test_prerequisites:

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -434,7 +434,6 @@ attributes:
     example: 30
   - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
     example: true
-    exclude_test: true
   - yang_name: logging/event/link-status-enable
     example: false
 

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -432,6 +432,9 @@ attributes:
         example: input
   - yang_name: load-interval
     example: 30
+  - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
+    example: true
+    exclude_test: true
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -435,6 +435,8 @@ attributes:
   - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
     example: true
     exclude_test: true
+  - yang_name: logging/event/link-status-enable
+    example: false
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -430,6 +430,8 @@ attributes:
       - yang_name: direction
         id: true
         example: input
+  - yang_name: load-interval
+    example: 30
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -190,6 +190,8 @@ attributes:
   - yang_name: ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust
     example: true
     exclude_test: true
+  - yang_name: load-interval
+    example: 30
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -192,6 +192,10 @@ attributes:
     exclude_test: true
   - yang_name: load-interval
     example: 30
+  - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
+    example: true
+  - yang_name: logging/event/link-status-enable
+    example: false
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_tunnel.yaml
+++ b/gen/definitions/interface_tunnel.yaml
@@ -157,6 +157,10 @@ attributes:
     test_tags: [IOSXE179, IOSXE1713]
   - yang_name: load-interval
     example: 30
+  - yang_name: Cisco-IOS-XE-snmp:snmp/trap/link-status
+    example: false
+  - yang_name: logging/event/link-status-enable
+    example: true
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_tunnel.yaml
+++ b/gen/definitions/interface_tunnel.yaml
@@ -155,6 +155,8 @@ attributes:
     example: true
     exclude_test: true
     test_tags: [IOSXE179, IOSXE1713]
+  - yang_name: load-interval
+    example: 30
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/gen/definitions/interface_vlan.yaml
+++ b/gen/definitions/interface_vlan.yaml
@@ -129,6 +129,9 @@ attributes:
         example: 2006:DB8::/32
       - yang_name: eui-64
         example: true
+  - yang_name: load-interval
+    example: 30
+
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1
     no_delete: true

--- a/internal/provider/data_source_iosxe_interface_ethernet.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet.go
@@ -543,6 +543,10 @@ func (d *InterfaceEthernetDataSource) Schema(ctx context.Context, req datasource
 				MarkdownDescription: "Specify interval for load calculation for an interface",
 				Computed:            true,
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: "Allow SNMP LINKUP and LINKDOWN traps",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_ethernet.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet.go
@@ -539,6 +539,10 @@ func (d *InterfaceEthernetDataSource) Schema(ctx context.Context, req datasource
 					},
 				},
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: "Specify interval for load calculation for an interface",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_ethernet.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet.go
@@ -547,6 +547,10 @@ func (d *InterfaceEthernetDataSource) Schema(ctx context.Context, req datasource
 				MarkdownDescription: "Allow SNMP LINKUP and LINKDOWN traps",
 				Computed:            true,
 			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: "UPDOWN and CHANGE messages",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -47,8 +47,6 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "helper_addresses.0.address", "10.10.10.10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "helper_addresses.0.global", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "helper_addresses.0.vrf", "VRF1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "source_template.0.template_name", "TEMP1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "source_template.0.merge", "false"))
 	if os.Getenv("IOSXE179") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "bfd_template", "bfd_template1"))
 	}
@@ -83,6 +81,8 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -153,10 +153,6 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		address = "10.10.10.10"` + "\n"
 	config += `		global = false` + "\n"
 	config += `		vrf = "VRF1"` + "\n"
-	config += `	}]` + "\n"
-	config += `	source_template = [{` + "\n"
-	config += `		template_name = "TEMP1"` + "\n"
-	config += `		merge = false` + "\n"
 	config += `	}]` + "\n"
 	if os.Getenv("IOSXE179") != "" {
 		config += `	bfd_template = "bfd_template1"` + "\n"

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -82,6 +82,7 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "service_policy_output", "POLICY1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -196,6 +197,7 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		name = "MON1"` + "\n"
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -83,6 +83,7 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "snmp_trap_link_status", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -199,7 +200,8 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
-	config += `	logging_event_link_status_enable = false` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -83,8 +83,6 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "snmp_trap_link_status", "false"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -83,7 +83,7 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -199,7 +199,7 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
-	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = false` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -83,6 +83,7 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -198,6 +199,7 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_port_channel.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel.go
@@ -303,6 +303,14 @@ func (d *InterfacePortChannelDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "Specify interval for load calculation for an interface",
 				Computed:            true,
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: "Allow SNMP LINKUP and LINKDOWN traps",
+				Computed:            true,
+			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: "UPDOWN and CHANGE messages",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_port_channel.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel.go
@@ -299,6 +299,10 @@ func (d *InterfacePortChannelDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "DHCP Snooping trust config",
 				Computed:            true,
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: "Specify interval for load calculation for an interface",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -77,6 +77,8 @@ func TestAccDataSourceIosxeInterfacePortChannel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -160,6 +162,8 @@ func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 		config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = false` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -76,6 +76,7 @@ func TestAccDataSourceIosxeInterfacePortChannel(t *testing.T) {
 	if os.Getenv("C9000V") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	}
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -158,6 +159,7 @@ func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 	if os.Getenv("C9000V") != "" {
 		config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	}
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_tunnel.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel.go
@@ -247,6 +247,10 @@ func (d *InterfaceTunnelDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: "Use echo adjunct as bfd detection mechanism",
 				Computed:            true,
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: "Specify interval for load calculation for an interface",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_tunnel.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel.go
@@ -251,6 +251,14 @@ func (d *InterfaceTunnelDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: "Specify interval for load calculation for an interface",
 				Computed:            true,
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: "Allow SNMP LINKUP and LINKDOWN traps",
+				Computed:            true,
+			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: "UPDOWN and CHANGE messages",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_tunnel_test.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel_test.go
@@ -70,7 +70,7 @@ func TestAccDataSourceIosxeInterfaceTunnel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "snmp_trap_link_status", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -149,7 +149,7 @@ func testAccDataSourceIosxeInterfaceTunnelConfig() string {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
-	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	snmp_trap_link_status = false` + "\n"
 	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_iosxe_interface_tunnel_test.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel_test.go
@@ -70,6 +70,8 @@ func TestAccDataSourceIosxeInterfaceTunnel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -147,6 +149,8 @@ func testAccDataSourceIosxeInterfaceTunnelConfig() string {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_tunnel_test.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel_test.go
@@ -69,6 +69,7 @@ func TestAccDataSourceIosxeInterfaceTunnel(t *testing.T) {
 	if os.Getenv("IOSXE179") != "" || os.Getenv("IOSXE1713") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -145,6 +146,7 @@ func testAccDataSourceIosxeInterfaceTunnelConfig() string {
 	if os.Getenv("IOSXE179") != "" || os.Getenv("IOSXE1713") != "" {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_vlan.go
+++ b/internal/provider/data_source_iosxe_interface_vlan.go
@@ -227,6 +227,10 @@ func (d *InterfaceVLANDataSource) Schema(ctx context.Context, req datasource.Sch
 					},
 				},
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: "Specify interval for load calculation for an interface",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_vlan_test.go
+++ b/internal/provider/data_source_iosxe_interface_vlan_test.go
@@ -59,6 +59,7 @@ func TestAccDataSourceIosxeInterfaceVLAN(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "ipv6_link_local_addresses.0.link_local", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "ipv6_addresses.0.prefix", "2006:DB8::/32"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "ipv6_addresses.0.eui_64", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -121,6 +122,7 @@ func testAccDataSourceIosxeInterfaceVLANConfig() string {
 	config += `		prefix = "2006:DB8::/32"` + "\n"
 	config += `		eui_64 = true` + "\n"
 	config += `	}]` + "\n"
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -142,6 +142,7 @@ type InterfaceEthernet struct {
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
 	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
 	SnmpTrapLinkStatus                      types.Bool                                `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable            types.Bool                                `tfsdk:"logging_event_link_status_enable"`
 }
 
 type InterfaceEthernetData struct {
@@ -252,6 +253,7 @@ type InterfaceEthernetData struct {
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
 	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
 	SnmpTrapLinkStatus                      types.Bool                                `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable            types.Bool                                `tfsdk:"logging_event_link_status_enable"`
 }
 type InterfaceEthernetHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -690,6 +692,9 @@ func (data InterfaceEthernet) toBody(ctx context.Context) string {
 	}
 	if !data.SnmpTrapLinkStatus.IsNull() && !data.SnmpTrapLinkStatus.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-snmp:snmp.trap.link-status", data.SnmpTrapLinkStatus.ValueBool())
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() && !data.LoggingEventLinkStatusEnable.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"logging.event.link-status-enable", data.LoggingEventLinkStatusEnable.ValueBool())
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -1663,6 +1668,13 @@ func (data *InterfaceEthernet) updateFromBody(ctx context.Context, res gjson.Res
 	} else {
 		data.SnmpTrapLinkStatus = types.BoolNull()
 	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); !data.LoggingEventLinkStatusEnable.IsNull() {
+		if value.Exists() {
+			data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolNull()
+	}
 }
 
 func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Result) {
@@ -2159,6 +2171,11 @@ func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Resul
 	} else {
 		data.SnmpTrapLinkStatus = types.BoolValue(false)
 	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); value.Exists() {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(false)
+	}
 }
 
 func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state InterfaceEthernet) []string {
@@ -2602,6 +2619,9 @@ func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state Interf
 	}
 	if !state.SnmpTrapLinkStatus.IsNull() && data.SnmpTrapLinkStatus.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", state.getPath()))
+	}
+	if !state.LoggingEventLinkStatusEnable.IsNull() && data.LoggingEventLinkStatusEnable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/logging/event/link-status-enable", state.getPath()))
 	}
 	return deletedItems
 }
@@ -3107,6 +3127,9 @@ func (data *InterfaceEthernet) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.SnmpTrapLinkStatus.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", data.getPath()))
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/logging/event/link-status-enable", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -140,6 +140,7 @@ type InterfaceEthernet struct {
 	ServicePolicyInput                      types.String                              `tfsdk:"service_policy_input"`
 	ServicePolicyOutput                     types.String                              `tfsdk:"service_policy_output"`
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
+	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
 }
 
 type InterfaceEthernetData struct {
@@ -248,6 +249,7 @@ type InterfaceEthernetData struct {
 	ServicePolicyInput                      types.String                              `tfsdk:"service_policy_input"`
 	ServicePolicyOutput                     types.String                              `tfsdk:"service_policy_output"`
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
+	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
 }
 type InterfaceEthernetHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -680,6 +682,9 @@ func (data InterfaceEthernet) toBody(ctx context.Context) string {
 	}
 	if !data.ServicePolicyOutput.IsNull() && !data.ServicePolicyOutput.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-policy:service-policy.output", data.ServicePolicyOutput.ValueString())
+	}
+	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -1641,6 +1646,11 @@ func (data *InterfaceEthernet) updateFromBody(ctx context.Context, res gjson.Res
 			data.IpFlowMonitors[i].Direction = types.StringNull()
 		}
 	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() && !data.LoadInterval.IsNull() {
+		data.LoadInterval = types.Int64Value(value.Int())
+	} else {
+		data.LoadInterval = types.Int64Null()
+	}
 }
 
 func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Result) {
@@ -2129,6 +2139,9 @@ func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Resul
 			return true
 		})
 	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() {
+		data.LoadInterval = types.Int64Value(value.Int())
+	}
 }
 
 func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state InterfaceEthernet) []string {
@@ -2566,6 +2579,9 @@ func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state Interf
 		if !found {
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/Cisco-IOS-XE-flow:flow/monitor-new=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 		}
+	}
+	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
 	}
 	return deletedItems
 }
@@ -3065,6 +3081,9 @@ func (data *InterfaceEthernet) getDeletePaths(ctx context.Context) []string {
 		keyValues := [...]string{data.IpFlowMonitors[i].Name.ValueString(), data.IpFlowMonitors[i].Direction.ValueString()}
 
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/Cisco-IOS-XE-flow:flow/monitor-new=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	if !data.LoadInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -1661,6 +1661,20 @@ func (data *InterfaceEthernet) updateFromBody(ctx context.Context, res gjson.Res
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); !data.SnmpTrapLinkStatus.IsNull() {
+		if value.Exists() {
+			data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolNull()
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); !data.LoggingEventLinkStatusEnable.IsNull() {
+		if value.Exists() {
+			data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolNull()
+	}
 }
 
 func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Result) {
@@ -2151,6 +2165,16 @@ func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Resul
 	}
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); value.Exists() {
+		data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); value.Exists() {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(false)
 	}
 }
 

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -1661,20 +1661,6 @@ func (data *InterfaceEthernet) updateFromBody(ctx context.Context, res gjson.Res
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
-	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); !data.SnmpTrapLinkStatus.IsNull() {
-		if value.Exists() {
-			data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
-		}
-	} else {
-		data.SnmpTrapLinkStatus = types.BoolNull()
-	}
-	if value := res.Get(prefix + "logging.event.link-status-enable"); !data.LoggingEventLinkStatusEnable.IsNull() {
-		if value.Exists() {
-			data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
-		}
-	} else {
-		data.LoggingEventLinkStatusEnable = types.BoolNull()
-	}
 }
 
 func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Result) {
@@ -2165,16 +2151,6 @@ func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Resul
 	}
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
-	}
-	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); value.Exists() {
-		data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
-	} else {
-		data.SnmpTrapLinkStatus = types.BoolValue(false)
-	}
-	if value := res.Get(prefix + "logging.event.link-status-enable"); value.Exists() {
-		data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
-	} else {
-		data.LoggingEventLinkStatusEnable = types.BoolValue(false)
 	}
 }
 

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -141,6 +141,7 @@ type InterfaceEthernet struct {
 	ServicePolicyOutput                     types.String                              `tfsdk:"service_policy_output"`
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
 	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus                      types.Bool                                `tfsdk:"snmp_trap_link_status"`
 }
 
 type InterfaceEthernetData struct {
@@ -250,6 +251,7 @@ type InterfaceEthernetData struct {
 	ServicePolicyOutput                     types.String                              `tfsdk:"service_policy_output"`
 	IpFlowMonitors                          []InterfaceEthernetIpFlowMonitors         `tfsdk:"ip_flow_monitors"`
 	LoadInterval                            types.Int64                               `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus                      types.Bool                                `tfsdk:"snmp_trap_link_status"`
 }
 type InterfaceEthernetHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -685,6 +687,9 @@ func (data InterfaceEthernet) toBody(ctx context.Context) string {
 	}
 	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() && !data.SnmpTrapLinkStatus.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-snmp:snmp.trap.link-status", data.SnmpTrapLinkStatus.ValueBool())
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -1651,6 +1656,13 @@ func (data *InterfaceEthernet) updateFromBody(ctx context.Context, res gjson.Res
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); !data.SnmpTrapLinkStatus.IsNull() {
+		if value.Exists() {
+			data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolNull()
+	}
 }
 
 func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Result) {
@@ -2142,6 +2154,11 @@ func (data *InterfaceEthernetData) fromBody(ctx context.Context, res gjson.Resul
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); value.Exists() {
+		data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolValue(false)
+	}
 }
 
 func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state InterfaceEthernet) []string {
@@ -2582,6 +2599,9 @@ func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state Interf
 	}
 	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
+	}
+	if !state.SnmpTrapLinkStatus.IsNull() && data.SnmpTrapLinkStatus.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", state.getPath()))
 	}
 	return deletedItems
 }
@@ -3084,6 +3104,9 @@ func (data *InterfaceEthernet) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.LoadInterval.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_port_channel.go
+++ b/internal/provider/model_iosxe_interface_port_channel.go
@@ -87,6 +87,7 @@ type InterfacePortChannel struct {
 	IpArpInspectionLimitRate     types.Int64                                  `tfsdk:"ip_arp_inspection_limit_rate"`
 	SpanningTreeLinkType         types.String                                 `tfsdk:"spanning_tree_link_type"`
 	IpDhcpSnoopingTrust          types.Bool                                   `tfsdk:"ip_dhcp_snooping_trust"`
+	LoadInterval                 types.Int64                                  `tfsdk:"load_interval"`
 }
 
 type InterfacePortChannelData struct {
@@ -141,6 +142,7 @@ type InterfacePortChannelData struct {
 	IpArpInspectionLimitRate     types.Int64                                  `tfsdk:"ip_arp_inspection_limit_rate"`
 	SpanningTreeLinkType         types.String                                 `tfsdk:"spanning_tree_link_type"`
 	IpDhcpSnoopingTrust          types.Bool                                   `tfsdk:"ip_dhcp_snooping_trust"`
+	LoadInterval                 types.Int64                                  `tfsdk:"load_interval"`
 }
 type InterfacePortChannelHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -356,6 +358,9 @@ func (data InterfacePortChannel) toBody(ctx context.Context) string {
 		if data.IpDhcpSnoopingTrust.ValueBool() {
 			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.dhcp.Cisco-IOS-XE-dhcp:snooping.trust", map[string]string{})
 		}
+	}
+	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -852,6 +857,11 @@ func (data *InterfacePortChannel) updateFromBody(ctx context.Context, res gjson.
 	} else {
 		data.IpDhcpSnoopingTrust = types.BoolNull()
 	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() && !data.LoadInterval.IsNull() {
+		data.LoadInterval = types.Int64Value(value.Int())
+	} else {
+		data.LoadInterval = types.Int64Null()
+	}
 }
 
 func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Result) {
@@ -1099,6 +1109,9 @@ func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Re
 	} else {
 		data.IpDhcpSnoopingTrust = types.BoolValue(false)
 	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() {
+		data.LoadInterval = types.Int64Value(value.Int())
+	}
 }
 
 func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state InterfacePortChannel) []string {
@@ -1324,6 +1337,9 @@ func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state Int
 	}
 	if !state.IpDhcpSnoopingTrust.IsNull() && data.IpDhcpSnoopingTrust.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust", state.getPath()))
+	}
+	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
 	}
 	return deletedItems
 }
@@ -1568,6 +1584,9 @@ func (data *InterfacePortChannel) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.IpDhcpSnoopingTrust.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust", data.getPath()))
+	}
+	if !data.LoadInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_port_channel.go
+++ b/internal/provider/model_iosxe_interface_port_channel.go
@@ -88,6 +88,8 @@ type InterfacePortChannel struct {
 	SpanningTreeLinkType         types.String                                 `tfsdk:"spanning_tree_link_type"`
 	IpDhcpSnoopingTrust          types.Bool                                   `tfsdk:"ip_dhcp_snooping_trust"`
 	LoadInterval                 types.Int64                                  `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus           types.Bool                                   `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable types.Bool                                   `tfsdk:"logging_event_link_status_enable"`
 }
 
 type InterfacePortChannelData struct {
@@ -143,6 +145,8 @@ type InterfacePortChannelData struct {
 	SpanningTreeLinkType         types.String                                 `tfsdk:"spanning_tree_link_type"`
 	IpDhcpSnoopingTrust          types.Bool                                   `tfsdk:"ip_dhcp_snooping_trust"`
 	LoadInterval                 types.Int64                                  `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus           types.Bool                                   `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable types.Bool                                   `tfsdk:"logging_event_link_status_enable"`
 }
 type InterfacePortChannelHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -361,6 +365,12 @@ func (data InterfacePortChannel) toBody(ctx context.Context) string {
 	}
 	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() && !data.SnmpTrapLinkStatus.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-snmp:snmp.trap.link-status", data.SnmpTrapLinkStatus.ValueBool())
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() && !data.LoggingEventLinkStatusEnable.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"logging.event.link-status-enable", data.LoggingEventLinkStatusEnable.ValueBool())
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -862,6 +872,20 @@ func (data *InterfacePortChannel) updateFromBody(ctx context.Context, res gjson.
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); !data.SnmpTrapLinkStatus.IsNull() {
+		if value.Exists() {
+			data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolNull()
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); !data.LoggingEventLinkStatusEnable.IsNull() {
+		if value.Exists() {
+			data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolNull()
+	}
 }
 
 func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Result) {
@@ -1112,6 +1136,16 @@ func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Re
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); value.Exists() {
+		data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); value.Exists() {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(false)
+	}
 }
 
 func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state InterfacePortChannel) []string {
@@ -1340,6 +1374,12 @@ func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state Int
 	}
 	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
+	}
+	if !state.SnmpTrapLinkStatus.IsNull() && data.SnmpTrapLinkStatus.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", state.getPath()))
+	}
+	if !state.LoggingEventLinkStatusEnable.IsNull() && data.LoggingEventLinkStatusEnable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/logging/event/link-status-enable", state.getPath()))
 	}
 	return deletedItems
 }
@@ -1587,6 +1627,12 @@ func (data *InterfacePortChannel) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.LoadInterval.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", data.getPath()))
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/logging/event/link-status-enable", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_tunnel.go
+++ b/internal/provider/model_iosxe_interface_tunnel.go
@@ -75,6 +75,8 @@ type InterfaceTunnel struct {
 	BfdIntervalMultiplier        types.Int64                             `tfsdk:"bfd_interval_multiplier"`
 	BfdEcho                      types.Bool                              `tfsdk:"bfd_echo"`
 	LoadInterval                 types.Int64                             `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus           types.Bool                              `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable types.Bool                              `tfsdk:"logging_event_link_status_enable"`
 }
 
 type InterfaceTunnelData struct {
@@ -117,6 +119,8 @@ type InterfaceTunnelData struct {
 	BfdIntervalMultiplier        types.Int64                             `tfsdk:"bfd_interval_multiplier"`
 	BfdEcho                      types.Bool                              `tfsdk:"bfd_echo"`
 	LoadInterval                 types.Int64                             `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus           types.Bool                              `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable types.Bool                              `tfsdk:"logging_event_link_status_enable"`
 }
 type InterfaceTunnelIpv6LinkLocalAddresses struct {
 	Address   types.String `tfsdk:"address"`
@@ -270,6 +274,12 @@ func (data InterfaceTunnel) toBody(ctx context.Context) string {
 	}
 	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() && !data.SnmpTrapLinkStatus.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-snmp:snmp.trap.link-status", data.SnmpTrapLinkStatus.ValueBool())
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() && !data.LoggingEventLinkStatusEnable.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"logging.event.link-status-enable", data.LoggingEventLinkStatusEnable.ValueBool())
 	}
 	if len(data.Ipv6LinkLocalAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv6.address.link-local-address", []interface{}{})
@@ -652,6 +662,20 @@ func (data *InterfaceTunnel) updateFromBody(ctx context.Context, res gjson.Resul
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); !data.SnmpTrapLinkStatus.IsNull() {
+		if value.Exists() {
+			data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolNull()
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); !data.LoggingEventLinkStatusEnable.IsNull() {
+		if value.Exists() {
+			data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolNull()
+	}
 }
 
 func (data *InterfaceTunnelData) fromBody(ctx context.Context, res gjson.Result) {
@@ -834,6 +858,16 @@ func (data *InterfaceTunnelData) fromBody(ctx context.Context, res gjson.Result)
 	}
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-snmp:snmp.trap.link-status"); value.Exists() {
+		data.SnmpTrapLinkStatus = types.BoolValue(value.Bool())
+	} else {
+		data.SnmpTrapLinkStatus = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "logging.event.link-status-enable"); value.Exists() {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(value.Bool())
+	} else {
+		data.LoggingEventLinkStatusEnable = types.BoolValue(false)
 	}
 }
 
@@ -1025,6 +1059,12 @@ func (data *InterfaceTunnel) getDeletedItems(ctx context.Context, state Interfac
 	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
 	}
+	if !state.SnmpTrapLinkStatus.IsNull() && data.SnmpTrapLinkStatus.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", state.getPath()))
+	}
+	if !state.LoggingEventLinkStatusEnable.IsNull() && data.LoggingEventLinkStatusEnable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/logging/event/link-status-enable", state.getPath()))
+	}
 	return deletedItems
 }
 
@@ -1193,6 +1233,12 @@ func (data *InterfaceTunnel) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.LoadInterval.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
+	}
+	if !data.SnmpTrapLinkStatus.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-snmp:snmp/trap/link-status", data.getPath()))
+	}
+	if !data.LoggingEventLinkStatusEnable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/logging/event/link-status-enable", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/model_iosxe_interface_tunnel.go
+++ b/internal/provider/model_iosxe_interface_tunnel.go
@@ -74,6 +74,7 @@ type InterfaceTunnel struct {
 	BfdIntervalMinRx             types.Int64                             `tfsdk:"bfd_interval_min_rx"`
 	BfdIntervalMultiplier        types.Int64                             `tfsdk:"bfd_interval_multiplier"`
 	BfdEcho                      types.Bool                              `tfsdk:"bfd_echo"`
+	LoadInterval                 types.Int64                             `tfsdk:"load_interval"`
 }
 
 type InterfaceTunnelData struct {
@@ -115,6 +116,7 @@ type InterfaceTunnelData struct {
 	BfdIntervalMinRx             types.Int64                             `tfsdk:"bfd_interval_min_rx"`
 	BfdIntervalMultiplier        types.Int64                             `tfsdk:"bfd_interval_multiplier"`
 	BfdEcho                      types.Bool                              `tfsdk:"bfd_echo"`
+	LoadInterval                 types.Int64                             `tfsdk:"load_interval"`
 }
 type InterfaceTunnelIpv6LinkLocalAddresses struct {
 	Address   types.String `tfsdk:"address"`
@@ -265,6 +267,9 @@ func (data InterfaceTunnel) toBody(ctx context.Context) string {
 	}
 	if !data.BfdEcho.IsNull() && !data.BfdEcho.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"bfd.Cisco-IOS-XE-bfd:echo", data.BfdEcho.ValueBool())
+	}
+	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
 	}
 	if len(data.Ipv6LinkLocalAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv6.address.link-local-address", []interface{}{})
@@ -642,6 +647,11 @@ func (data *InterfaceTunnel) updateFromBody(ctx context.Context, res gjson.Resul
 	} else {
 		data.BfdEcho = types.BoolNull()
 	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() && !data.LoadInterval.IsNull() {
+		data.LoadInterval = types.Int64Value(value.Int())
+	} else {
+		data.LoadInterval = types.Int64Null()
+	}
 }
 
 func (data *InterfaceTunnelData) fromBody(ctx context.Context, res gjson.Result) {
@@ -821,6 +831,9 @@ func (data *InterfaceTunnelData) fromBody(ctx context.Context, res gjson.Result)
 		data.BfdEcho = types.BoolValue(value.Bool())
 	} else {
 		data.BfdEcho = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "load-interval"); value.Exists() {
+		data.LoadInterval = types.Int64Value(value.Int())
 	}
 }
 
@@ -1009,6 +1022,9 @@ func (data *InterfaceTunnel) getDeletedItems(ctx context.Context, state Interfac
 	if !state.BfdEcho.IsNull() && data.BfdEcho.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/bfd/Cisco-IOS-XE-bfd:echo", state.getPath()))
 	}
+	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
+	}
 	return deletedItems
 }
 
@@ -1174,6 +1190,9 @@ func (data *InterfaceTunnel) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.BfdEcho.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/bfd/Cisco-IOS-XE-bfd:echo", data.getPath()))
+	}
+	if !data.LoadInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/resource_iosxe_interface_ethernet.go
+++ b/internal/provider/resource_iosxe_interface_ethernet.go
@@ -670,6 +670,10 @@ func (r *InterfaceEthernetResource) Schema(ctx context.Context, req resource.Sch
 					int64validator.Between(30, 600),
 				},
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Allow SNMP LINKUP and LINKDOWN traps").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_ethernet.go
+++ b/internal/provider/resource_iosxe_interface_ethernet.go
@@ -674,6 +674,10 @@ func (r *InterfaceEthernetResource) Schema(ctx context.Context, req resource.Sch
 				MarkdownDescription: helpers.NewAttributeDescription("Allow SNMP LINKUP and LINKDOWN traps").String,
 				Optional:            true,
 			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("UPDOWN and CHANGE messages").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_ethernet.go
+++ b/internal/provider/resource_iosxe_interface_ethernet.go
@@ -663,6 +663,13 @@ func (r *InterfaceEthernetResource) Schema(ctx context.Context, req resource.Sch
 					},
 				},
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify interval for load calculation for an interface").AddIntegerRangeDescription(30, 600).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(30, 600),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -48,8 +48,6 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "helper_addresses.0.address", "10.10.10.10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "helper_addresses.0.global", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "helper_addresses.0.vrf", "VRF1"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "source_template.0.template_name", "TEMP1"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "source_template.0.merge", "false"))
 	if os.Getenv("IOSXE179") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "bfd_template", "bfd_template1"))
 	}
@@ -84,6 +82,8 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -171,10 +171,6 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		address = "10.10.10.10"` + "\n"
 	config += `		global = false` + "\n"
 	config += `		vrf = "VRF1"` + "\n"
-	config += `	}]` + "\n"
-	config += `	source_template = [{` + "\n"
-	config += `		template_name = "TEMP1"` + "\n"
-	config += `		merge = false` + "\n"
 	config += `	}]` + "\n"
 	if os.Getenv("IOSXE179") != "" {
 		config += `	bfd_template = "bfd_template1"` + "\n"

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -83,6 +83,7 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "service_policy_output", "POLICY1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -214,6 +215,7 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		name = "MON1"` + "\n"
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -84,8 +84,6 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -219,7 +217,7 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
 	config += `	snmp_trap_link_status = true` + "\n"
-	config += `	logging_event_link_status_enable = false` + "\n"
+	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -84,7 +84,7 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -217,7 +217,7 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
-	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = false` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -84,6 +84,7 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -216,6 +217,7 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -84,6 +84,7 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_flow_monitors.0.direction", "input"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "snmp_trap_link_status", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -217,6 +218,7 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
 	config += `	logging_event_link_status_enable = false` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, iosxe_restconf.PreReq3, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -372,6 +372,14 @@ func (r *InterfacePortChannelResource) Schema(ctx context.Context, req resource.
 					int64validator.Between(30, 600),
 				},
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Allow SNMP LINKUP and LINKDOWN traps").String,
+				Optional:            true,
+			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("UPDOWN and CHANGE messages").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -365,6 +365,13 @@ func (r *InterfacePortChannelResource) Schema(ctx context.Context, req resource.
 				MarkdownDescription: helpers.NewAttributeDescription("DHCP Snooping trust config").String,
 				Optional:            true,
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify interval for load calculation for an interface").AddIntegerRangeDescription(30, 600).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(30, 600),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -78,6 +78,8 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "logging_event_link_status_enable", "false"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -176,6 +178,8 @@ func testAccIosxeInterfacePortChannelConfig_all() string {
 		config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = false` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -77,6 +77,7 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 	if os.Getenv("C9000V") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	}
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -174,6 +175,7 @@ func testAccIosxeInterfacePortChannelConfig_all() string {
 	if os.Getenv("C9000V") != "" {
 		config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	}
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_tunnel.go
+++ b/internal/provider/resource_iosxe_interface_tunnel.go
@@ -307,6 +307,13 @@ func (r *InterfaceTunnelResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: helpers.NewAttributeDescription("Use echo adjunct as bfd detection mechanism").String,
 				Optional:            true,
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify interval for load calculation for an interface").AddIntegerRangeDescription(30, 600).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(30, 600),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_tunnel.go
+++ b/internal/provider/resource_iosxe_interface_tunnel.go
@@ -314,6 +314,14 @@ func (r *InterfaceTunnelResource) Schema(ctx context.Context, req resource.Schem
 					int64validator.Between(30, 600),
 				},
 			},
+			"snmp_trap_link_status": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Allow SNMP LINKUP and LINKDOWN traps").String,
+				Optional:            true,
+			},
+			"logging_event_link_status_enable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("UPDOWN and CHANGE messages").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_tunnel_test.go
+++ b/internal/provider/resource_iosxe_interface_tunnel_test.go
@@ -71,7 +71,7 @@ func TestAccIosxeInterfaceTunnel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "load_interval", "30"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "snmp_trap_link_status", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -165,7 +165,7 @@ func testAccIosxeInterfaceTunnelConfig_all() string {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
-	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	snmp_trap_link_status = false` + "\n"
 	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_interface_tunnel_test.go
+++ b/internal/provider/resource_iosxe_interface_tunnel_test.go
@@ -71,6 +71,8 @@ func TestAccIosxeInterfaceTunnel(t *testing.T) {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "snmp_trap_link_status", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "logging_event_link_status_enable", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -163,6 +165,8 @@ func testAccIosxeInterfaceTunnelConfig_all() string {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
 	config += `	load_interval = 30` + "\n"
+	config += `	snmp_trap_link_status = true` + "\n"
+	config += `	logging_event_link_status_enable = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_tunnel_test.go
+++ b/internal/provider/resource_iosxe_interface_tunnel_test.go
@@ -70,6 +70,7 @@ func TestAccIosxeInterfaceTunnel(t *testing.T) {
 	if os.Getenv("IOSXE179") != "" || os.Getenv("IOSXE1713") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "bfd_local_address", "1.2.3.4"))
 	}
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -161,6 +162,7 @@ func testAccIosxeInterfaceTunnelConfig_all() string {
 	if os.Getenv("IOSXE179") != "" || os.Getenv("IOSXE1713") != "" {
 		config += `	bfd_local_address = "1.2.3.4"` + "\n"
 	}
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_vlan.go
+++ b/internal/provider/resource_iosxe_interface_vlan.go
@@ -278,6 +278,13 @@ func (r *InterfaceVLANResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 				},
 			},
+			"load_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify interval for load calculation for an interface").AddIntegerRangeDescription(30, 600).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(30, 600),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_vlan_test.go
+++ b/internal/provider/resource_iosxe_interface_vlan_test.go
@@ -60,6 +60,7 @@ func TestAccIosxeInterfaceVLAN(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "ipv6_link_local_addresses.0.link_local", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "ipv6_addresses.0.prefix", "2006:DB8::/32"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "ipv6_addresses.0.eui_64", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "load_interval", "30"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -137,6 +138,7 @@ func testAccIosxeInterfaceVLANConfig_all() string {
 	config += `		prefix = "2006:DB8::/32"` + "\n"
 	config += `		eui_64 = true` + "\n"
 	config += `	}]` + "\n"
+	config += `	load_interval = 30` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -16,8 +16,10 @@ description: |-
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -16,9 +16,9 @@ description: |-
 - Add `iosxe_flow_monitor` resource and data source
 - Add `ip_flow_monitors` attribute to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_ethernet` resource and data source
-- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet` resource and data source
 - BREAKING CHANGE: Rename `ianctivity_timer` attribute to `inactivity_timer` of `iosxe_service_template` resource and data source
 - Add `Tunnel` option to `iosxe_interface_ospf` and `iosxe_interface_ospfv3` resource and data source
+- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`, `iosxe_interface_tunnel` resources and data sources
 - Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources
 
 ## 0.5.5


### PR DESCRIPTION
Closes #148 

- Add `logging_event_link_status_enable` and `snmp_trap_link_status` attributes to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`, `iosxe_interface_tunnel` resources and data sources
- Add `load_interval` attribute to `iosxe_interface_ethernet`, `iosxe_interface_port_channel`,  `iosxe_interface_tunnel`, `iosxe_interface_vlan` resources and data sources