### PR TITLE
add peer-group attribute to bgp neighbor

### DIFF
--- a/docs/data-sources/bgp_neighbor.md
+++ b/docs/data-sources/bgp_neighbor.md
@@ -54,6 +54,7 @@ data "iosxe_bgp_neighbor" "example" {
 - `log_neighbor_changes` (Boolean) Log neighbor up/down and reset reason
 - `password` (String)
 - `password_type` (Number) Encryption type (0 to disable encryption, 7 for proprietary)
+- `peer_group` (String) peer-group name
 - `remote_as` (String) Specify a BGP peer-group remote-as
 - `shutdown` (Boolean) Administratively shut down this neighbor
 - `timers_holdtime` (Number)

--- a/docs/resources/bgp_neighbor.md
+++ b/docs/resources/bgp_neighbor.md
@@ -73,6 +73,7 @@ resource "iosxe_bgp_neighbor" "example" {
 - `password` (String)
 - `password_type` (Number) Encryption type (0 to disable encryption, 7 for proprietary)
   - Range: `0`-`7`
+- `peer_group` (String) peer-group name
 - `remote_as` (String) Specify a BGP peer-group remote-as
 - `shutdown` (Boolean) Administratively shut down this neighbor
 - `timers_holdtime` (Number) - Range: `0`-`65535`

--- a/gen/definitions/bgp_neighbor.yaml
+++ b/gen/definitions/bgp_neighbor.yaml
@@ -69,6 +69,10 @@ attributes:
     tf_name: password
     delete_parent: true
     example: test1234
+  - yang_name: peer-group/peer-group-name
+    tf_name: peer_group
+    example: PEERGRP
+    exclude_test: true
   - yang_name: timers/keepalive-interval
     delete_parent: true
     example: 655

--- a/internal/provider/data_source_iosxe_bgp_neighbor.go
+++ b/internal/provider/data_source_iosxe_bgp_neighbor.go
@@ -155,6 +155,10 @@ func (d *BGPNeighborDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "",
 				Computed:            true,
 			},
+			"peer_group": schema.StringAttribute{
+				MarkdownDescription: "peer-group name",
+				Computed:            true,
+			},
 			"timers_keepalive_interval": schema.Int64Attribute{
 				MarkdownDescription: "",
 				Computed:            true,

--- a/internal/provider/model_iosxe_bgp_neighbor.go
+++ b/internal/provider/model_iosxe_bgp_neighbor.go
@@ -59,6 +59,7 @@ type BGPNeighbor struct {
 	LogNeighborChanges                  types.Bool   `tfsdk:"log_neighbor_changes"`
 	PasswordType                        types.Int64  `tfsdk:"password_type"`
 	Password                            types.String `tfsdk:"password"`
+	PeerGroup                           types.String `tfsdk:"peer_group"`
 	TimersKeepaliveInterval             types.Int64  `tfsdk:"timers_keepalive_interval"`
 	TimersHoldtime                      types.Int64  `tfsdk:"timers_holdtime"`
 	TimersMinimumNeighborHold           types.Int64  `tfsdk:"timers_minimum_neighbor_hold"`
@@ -94,6 +95,7 @@ type BGPNeighborData struct {
 	LogNeighborChanges                  types.Bool   `tfsdk:"log_neighbor_changes"`
 	PasswordType                        types.Int64  `tfsdk:"password_type"`
 	Password                            types.String `tfsdk:"password"`
+	PeerGroup                           types.String `tfsdk:"peer_group"`
 	TimersKeepaliveInterval             types.Int64  `tfsdk:"timers_keepalive_interval"`
 	TimersHoldtime                      types.Int64  `tfsdk:"timers_holdtime"`
 	TimersMinimumNeighborHold           types.Int64  `tfsdk:"timers_minimum_neighbor_hold"`
@@ -213,6 +215,9 @@ func (data BGPNeighbor) toBody(ctx context.Context) string {
 	}
 	if !data.Password.IsNull() && !data.Password.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"password.text", data.Password.ValueString())
+	}
+	if !data.PeerGroup.IsNull() && !data.PeerGroup.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"peer-group.peer-group-name", data.PeerGroup.ValueString())
 	}
 	if !data.TimersKeepaliveInterval.IsNull() && !data.TimersKeepaliveInterval.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"timers.keepalive-interval", strconv.FormatInt(data.TimersKeepaliveInterval.ValueInt64(), 10))
@@ -403,6 +408,11 @@ func (data *BGPNeighbor) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Password = types.StringNull()
 	}
+	if value := res.Get(prefix + "peer-group.peer-group-name"); value.Exists() && !data.PeerGroup.IsNull() {
+		data.PeerGroup = types.StringValue(value.String())
+	} else {
+		data.PeerGroup = types.StringNull()
+	}
 	if value := res.Get(prefix + "timers.keepalive-interval"); value.Exists() && !data.TimersKeepaliveInterval.IsNull() {
 		data.TimersKeepaliveInterval = types.Int64Value(value.Int())
 	} else {
@@ -536,6 +546,9 @@ func (data *BGPNeighborData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "password.text"); value.Exists() {
 		data.Password = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "peer-group.peer-group-name"); value.Exists() {
+		data.PeerGroup = types.StringValue(value.String())
+	}
 	if value := res.Get(prefix + "timers.keepalive-interval"); value.Exists() {
 		data.TimersKeepaliveInterval = types.Int64Value(value.Int())
 	}
@@ -622,6 +635,9 @@ func (data *BGPNeighbor) getDeletedItems(ctx context.Context, state BGPNeighbor)
 	}
 	if !state.Password.IsNull() && data.Password.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/password", state.getPath()))
+	}
+	if !state.PeerGroup.IsNull() && data.PeerGroup.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/peer-group/peer-group-name", state.getPath()))
 	}
 	if !state.TimersKeepaliveInterval.IsNull() && data.TimersKeepaliveInterval.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/timers", state.getPath()))
@@ -752,6 +768,9 @@ func (data *BGPNeighbor) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.Password.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/password", data.getPath()))
+	}
+	if !data.PeerGroup.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/peer-group/peer-group-name", data.getPath()))
 	}
 	if !data.TimersKeepaliveInterval.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/timers", data.getPath()))

--- a/internal/provider/resource_iosxe_bgp_neighbor.go
+++ b/internal/provider/resource_iosxe_bgp_neighbor.go
@@ -182,6 +182,10 @@ func (r *BGPNeighborResource) Schema(ctx context.Context, req resource.SchemaReq
 					stringvalidator.RegexMatches(regexp.MustCompile(`.*`), ""),
 				},
 			},
+			"peer_group": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("peer-group name").String,
+				Optional:            true,
+			},
 			"timers_keepalive_interval": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(0, 65535).String,
 				Optional:            true,


### PR DESCRIPTION
Add BGP neighbor peer group attribute.

Assumes that the peer group is already configured.

```
router bgp 65421
 bgp log-neighbor-changes
 neighbor example peer-group
```

Example config

```hcl
resource "iosxe_bgp_neighbor" "name" {
  asn        = 65421
  ip         = "3.3.3.5"
  remote_as  = 65515
  peer_group = "example"
}
```