### PR TITLE
Added support for `boot` and `enable` commands

### DIFF
--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -33,9 +33,14 @@ data "iosxe_system" "example" {
 - `archive_path` (String) path for backups
 - `archive_time_period` (Number) Period of time in minutes to automatically archive the running-config
 - `archive_write_memory` (Boolean) Enable automatic backup generation during write memory
+- `boot_system_bootfiles` (Attributes List) (see [below for nested schema](#nestedatt--boot_system_bootfiles))
+- `boot_system_flash_files` (Attributes List) (see [below for nested schema](#nestedatt--boot_system_flash_files))
 - `cisp_enable` (Boolean) Enable CISP
 - `control_plane_service_policy_input` (String) Assign policy-map to the input of an interface
 - `diagnostic_bootup_level` (String) Select diagnostic level
+- `enable_secret` (String)
+- `enable_secret_level` (Number) Set exec level password
+- `enable_secret_type` (String)
 - `epm_logging` (Boolean) Enable EPM logging
 - `hostname` (String) Set system's network name
 - `id` (String) The path of the retrieved object.
@@ -98,6 +103,22 @@ data "iosxe_system" "example" {
 - `redundancy` (Boolean) Enter redundancy mode
 - `redundancy_mode` (String) redundancy mode for this chassis
 - `transceiver_type_all_monitoring` (Boolean) Enable/disable monitoring
+
+<a id="nestedatt--boot_system_bootfiles"></a>
+### Nested Schema for `boot_system_bootfiles`
+
+Read-Only:
+
+- `path` (String) WORD - TFTP filename or URL
+
+
+<a id="nestedatt--boot_system_flash_files"></a>
+### Nested Schema for `boot_system_flash_files`
+
+Read-Only:
+
+- `path` (String)
+
 
 <a id="nestedatt--ip_http_authentication_aaa_command_authorization"></a>
 ### Nested Schema for `ip_http_authentication_aaa_command_authorization`

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -55,11 +55,17 @@ resource "iosxe_system" "example" {
 - `archive_time_period` (Number) Period of time in minutes to automatically archive the running-config
   - Range: `1`-`525600`
 - `archive_write_memory` (Boolean) Enable automatic backup generation during write memory
+- `boot_system_bootfiles` (Attributes List) (see [below for nested schema](#nestedatt--boot_system_bootfiles))
+- `boot_system_flash_files` (Attributes List) (see [below for nested schema](#nestedatt--boot_system_flash_files))
 - `cisp_enable` (Boolean) Enable CISP
 - `control_plane_service_policy_input` (String) Assign policy-map to the input of an interface
 - `device` (String) A device name from the provider configuration.
 - `diagnostic_bootup_level` (String) Select diagnostic level
   - Choices: `complete`, `minimal`
+- `enable_secret` (String)
+- `enable_secret_level` (Number) Set exec level password
+  - Range: `0`-`255`
+- `enable_secret_type` (String) - Choices: `0`, `4`, `5`, `8`, `9`
 - `epm_logging` (Boolean) Enable EPM logging
 - `hostname` (String) Set system's network name
 - `ip_bgp_community_new_format` (Boolean) select aa:nn format for BGP community
@@ -136,6 +142,22 @@ resource "iosxe_system" "example" {
 ### Read-Only
 
 - `id` (String) The path of the object.
+
+<a id="nestedatt--boot_system_bootfiles"></a>
+### Nested Schema for `boot_system_bootfiles`
+
+Required:
+
+- `path` (String) WORD - TFTP filename or URL
+
+
+<a id="nestedatt--boot_system_flash_files"></a>
+### Nested Schema for `boot_system_flash_files`
+
+Required:
+
+- `path` (String)
+
 
 <a id="nestedatt--ip_http_authentication_aaa_command_authorization"></a>
 ### Nested Schema for `ip_http_authentication_aaa_command_authorization`

--- a/gen/definitions/system.yaml
+++ b/gen/definitions/system.yaml
@@ -293,6 +293,36 @@ attributes:
         example: 1.1.1.1
       - yang_name: transport/https/ipv4/port
         example: 443
+  - yang_name: boot/system/flash/flash-list-ordered-by-user
+    tf_name: boot_system_flash_files
+    type: List
+    exclude_test: true
+    attributes:
+      - yang_name: flash-leaf
+        tf_name: path
+        id: true
+        example: bootflash:c8000v-rpboot.17.15.01a.SPA.pkg
+  - yang_name: boot/system/bootfile/filename-list-ordered-by-user
+    tf_name: boot_system_bootfiles
+    type: List
+    exclude_test: true
+    attributes:
+      - yang_name: filename
+        tf_name: path
+        id: true
+        example: bootflash:c8000v-rpboot.17.15.01a.SPA.pkg
+  - yang_name: enable/secret/secret
+    tf_name: enable_secret
+    delete_parent: true
+    exclude_test: true
+    write_only: true
+    example: MySecretPassword
+  - yang_name: enable/secret/type
+    exclude_test: true
+    example: 0
+  - yang_name: enable/secret/level
+    exclude_test: true
+    example: 15
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/internal/provider/data_source_iosxe_system.go
+++ b/internal/provider/data_source_iosxe_system.go
@@ -400,6 +400,42 @@ func (d *SystemDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 					},
 				},
 			},
+			"boot_system_flash_files": schema.ListNestedAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"path": schema.StringAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"boot_system_bootfiles": schema.ListNestedAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"path": schema.StringAttribute{
+							MarkdownDescription: "WORD - TFTP filename or URL",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"enable_secret": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"enable_secret_type": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"enable_secret_level": schema.Int64Attribute{
+				MarkdownDescription: "Set exec level password",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/model_iosxe_system.go
+++ b/internal/provider/model_iosxe_system.go
@@ -107,6 +107,11 @@ type System struct {
 	IpSshSourceInterfaceHundredGigabitEthernet             types.String                                        `tfsdk:"ip_ssh_source_interface_hundred_gigabit_ethernet"`
 	ControlPlaneServicePolicyInput                         types.String                                        `tfsdk:"control_plane_service_policy_input"`
 	PnpProfiles                                            []SystemPnpProfiles                                 `tfsdk:"pnp_profiles"`
+	BootSystemFlashFiles                                   []SystemBootSystemFlashFiles                        `tfsdk:"boot_system_flash_files"`
+	BootSystemBootfiles                                    []SystemBootSystemBootfiles                         `tfsdk:"boot_system_bootfiles"`
+	EnableSecret                                           types.String                                        `tfsdk:"enable_secret"`
+	EnableSecretType                                       types.String                                        `tfsdk:"enable_secret_type"`
+	EnableSecretLevel                                      types.Int64                                         `tfsdk:"enable_secret_level"`
 }
 
 type SystemData struct {
@@ -183,6 +188,11 @@ type SystemData struct {
 	IpSshSourceInterfaceHundredGigabitEthernet             types.String                                        `tfsdk:"ip_ssh_source_interface_hundred_gigabit_ethernet"`
 	ControlPlaneServicePolicyInput                         types.String                                        `tfsdk:"control_plane_service_policy_input"`
 	PnpProfiles                                            []SystemPnpProfiles                                 `tfsdk:"pnp_profiles"`
+	BootSystemFlashFiles                                   []SystemBootSystemFlashFiles                        `tfsdk:"boot_system_flash_files"`
+	BootSystemBootfiles                                    []SystemBootSystemBootfiles                         `tfsdk:"boot_system_bootfiles"`
+	EnableSecret                                           types.String                                        `tfsdk:"enable_secret"`
+	EnableSecretType                                       types.String                                        `tfsdk:"enable_secret_type"`
+	EnableSecretLevel                                      types.Int64                                         `tfsdk:"enable_secret_level"`
 }
 type SystemMulticastRoutingVrfs struct {
 	Vrf         types.String `tfsdk:"vrf"`
@@ -200,6 +210,12 @@ type SystemPnpProfiles struct {
 	Name                          types.String `tfsdk:"name"`
 	TransportHttpsIpv4Ipv4Address types.String `tfsdk:"transport_https_ipv4_ipv4_address"`
 	TransportHttpsIpv4Port        types.Int64  `tfsdk:"transport_https_ipv4_port"`
+}
+type SystemBootSystemFlashFiles struct {
+	Path types.String `tfsdk:"path"`
+}
+type SystemBootSystemBootfiles struct {
+	Path types.String `tfsdk:"path"`
 }
 
 func (data System) getPath() string {
@@ -464,6 +480,15 @@ func (data System) toBody(ctx context.Context) string {
 	if !data.ControlPlaneServicePolicyInput.IsNull() && !data.ControlPlaneServicePolicyInput.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"control-plane.Cisco-IOS-XE-policy:service-policy.input", data.ControlPlaneServicePolicyInput.ValueString())
 	}
+	if !data.EnableSecret.IsNull() && !data.EnableSecret.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"enable.secret.secret", data.EnableSecret.ValueString())
+	}
+	if !data.EnableSecretType.IsNull() && !data.EnableSecretType.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"enable.secret.type", data.EnableSecretType.ValueString())
+	}
+	if !data.EnableSecretLevel.IsNull() && !data.EnableSecretLevel.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"enable.secret.level", strconv.FormatInt(data.EnableSecretLevel.ValueInt64(), 10))
+	}
 	if len(data.MulticastRoutingVrfs) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.Cisco-IOS-XE-multicast:multicast-routing.vrf", []interface{}{})
 		for index, item := range data.MulticastRoutingVrfs {
@@ -512,6 +537,22 @@ func (data System) toBody(ctx context.Context) string {
 			}
 			if !item.TransportHttpsIpv4Port.IsNull() && !item.TransportHttpsIpv4Port.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-pnp:pnp.profile"+"."+strconv.Itoa(index)+"."+"transport.https.ipv4.port", strconv.FormatInt(item.TransportHttpsIpv4Port.ValueInt64(), 10))
+			}
+		}
+	}
+	if len(data.BootSystemFlashFiles) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"boot.system.flash.flash-list-ordered-by-user", []interface{}{})
+		for index, item := range data.BootSystemFlashFiles {
+			if !item.Path.IsNull() && !item.Path.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"boot.system.flash.flash-list-ordered-by-user"+"."+strconv.Itoa(index)+"."+"flash-leaf", item.Path.ValueString())
+			}
+		}
+	}
+	if len(data.BootSystemBootfiles) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"boot.system.bootfile.filename-list-ordered-by-user", []interface{}{})
+		for index, item := range data.BootSystemBootfiles {
+			if !item.Path.IsNull() && !item.Path.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"boot.system.bootfile.filename-list-ordered-by-user"+"."+strconv.Itoa(index)+"."+"filename", item.Path.ValueString())
 			}
 		}
 	}
@@ -1091,6 +1132,74 @@ func (data *System) updateFromBody(ctx context.Context, res gjson.Result) {
 			data.PnpProfiles[i].TransportHttpsIpv4Port = types.Int64Null()
 		}
 	}
+	for i := range data.BootSystemFlashFiles {
+		keys := [...]string{"flash-leaf"}
+		keyValues := [...]string{data.BootSystemFlashFiles[i].Path.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "boot.system.flash.flash-list-ordered-by-user").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("flash-leaf"); value.Exists() && !data.BootSystemFlashFiles[i].Path.IsNull() {
+			data.BootSystemFlashFiles[i].Path = types.StringValue(value.String())
+		} else {
+			data.BootSystemFlashFiles[i].Path = types.StringNull()
+		}
+	}
+	for i := range data.BootSystemBootfiles {
+		keys := [...]string{"filename"}
+		keyValues := [...]string{data.BootSystemBootfiles[i].Path.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "boot.system.bootfile.filename-list-ordered-by-user").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("filename"); value.Exists() && !data.BootSystemBootfiles[i].Path.IsNull() {
+			data.BootSystemBootfiles[i].Path = types.StringValue(value.String())
+		} else {
+			data.BootSystemBootfiles[i].Path = types.StringNull()
+		}
+	}
+	if value := res.Get(prefix + "enable.secret.type"); value.Exists() && !data.EnableSecretType.IsNull() {
+		data.EnableSecretType = types.StringValue(value.String())
+	} else {
+		data.EnableSecretType = types.StringNull()
+	}
+	if value := res.Get(prefix + "enable.secret.level"); value.Exists() && !data.EnableSecretLevel.IsNull() {
+		data.EnableSecretLevel = types.Int64Value(value.Int())
+	} else {
+		data.EnableSecretLevel = types.Int64Null()
+	}
 }
 
 func (data *System) fromBody(ctx context.Context, res gjson.Result) {
@@ -1414,6 +1523,34 @@ func (data *System) fromBody(ctx context.Context, res gjson.Result) {
 			return true
 		})
 	}
+	if value := res.Get(prefix + "boot.system.flash.flash-list-ordered-by-user"); value.Exists() {
+		data.BootSystemFlashFiles = make([]SystemBootSystemFlashFiles, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SystemBootSystemFlashFiles{}
+			if cValue := v.Get("flash-leaf"); cValue.Exists() {
+				item.Path = types.StringValue(cValue.String())
+			}
+			data.BootSystemFlashFiles = append(data.BootSystemFlashFiles, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "boot.system.bootfile.filename-list-ordered-by-user"); value.Exists() {
+		data.BootSystemBootfiles = make([]SystemBootSystemBootfiles, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SystemBootSystemBootfiles{}
+			if cValue := v.Get("filename"); cValue.Exists() {
+				item.Path = types.StringValue(cValue.String())
+			}
+			data.BootSystemBootfiles = append(data.BootSystemBootfiles, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "enable.secret.type"); value.Exists() {
+		data.EnableSecretType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "enable.secret.level"); value.Exists() {
+		data.EnableSecretLevel = types.Int64Value(value.Int())
+	}
 }
 
 func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
@@ -1736,6 +1873,34 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 			data.PnpProfiles = append(data.PnpProfiles, item)
 			return true
 		})
+	}
+	if value := res.Get(prefix + "boot.system.flash.flash-list-ordered-by-user"); value.Exists() {
+		data.BootSystemFlashFiles = make([]SystemBootSystemFlashFiles, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SystemBootSystemFlashFiles{}
+			if cValue := v.Get("flash-leaf"); cValue.Exists() {
+				item.Path = types.StringValue(cValue.String())
+			}
+			data.BootSystemFlashFiles = append(data.BootSystemFlashFiles, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "boot.system.bootfile.filename-list-ordered-by-user"); value.Exists() {
+		data.BootSystemBootfiles = make([]SystemBootSystemBootfiles, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SystemBootSystemBootfiles{}
+			if cValue := v.Get("filename"); cValue.Exists() {
+				item.Path = types.StringValue(cValue.String())
+			}
+			data.BootSystemBootfiles = append(data.BootSystemBootfiles, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "enable.secret.type"); value.Exists() {
+		data.EnableSecretType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "enable.secret.level"); value.Exists() {
+		data.EnableSecretLevel = types.Int64Value(value.Int())
 	}
 }
 
@@ -2093,6 +2258,65 @@ func (data *System) getDeletedItems(ctx context.Context, state System) []string 
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-pnp:pnp/profile=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 		}
 	}
+	for i := range state.BootSystemFlashFiles {
+		stateKeyValues := [...]string{state.BootSystemFlashFiles[i].Path.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.BootSystemFlashFiles[i].Path.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.BootSystemFlashFiles {
+			found = true
+			if state.BootSystemFlashFiles[i].Path.ValueString() != data.BootSystemFlashFiles[j].Path.ValueString() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/boot/system/flash/flash-list-ordered-by-user=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
+	for i := range state.BootSystemBootfiles {
+		stateKeyValues := [...]string{state.BootSystemBootfiles[i].Path.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.BootSystemBootfiles[i].Path.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.BootSystemBootfiles {
+			found = true
+			if state.BootSystemBootfiles[i].Path.ValueString() != data.BootSystemBootfiles[j].Path.ValueString() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/boot/system/bootfile/filename-list-ordered-by-user=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
+	if !state.EnableSecret.IsNull() && data.EnableSecret.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/enable/secret", state.getPath()))
+	}
+	if !state.EnableSecretType.IsNull() && data.EnableSecretType.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/enable/secret/type", state.getPath()))
+	}
+	if !state.EnableSecretLevel.IsNull() && data.EnableSecretLevel.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/enable/secret/level", state.getPath()))
+	}
 	return deletedItems
 }
 
@@ -2390,6 +2614,25 @@ func (data *System) getDeletePaths(ctx context.Context) []string {
 		keyValues := [...]string{data.PnpProfiles[i].Name.ValueString()}
 
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-pnp:pnp/profile=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	for i := range data.BootSystemFlashFiles {
+		keyValues := [...]string{data.BootSystemFlashFiles[i].Path.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/boot/system/flash/flash-list-ordered-by-user=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	for i := range data.BootSystemBootfiles {
+		keyValues := [...]string{data.BootSystemBootfiles[i].Path.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/boot/system/bootfile/filename-list-ordered-by-user=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	if !data.EnableSecret.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/enable/secret", data.getPath()))
+	}
+	if !data.EnableSecretType.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/enable/secret/type", data.getPath()))
+	}
+	if !data.EnableSecretLevel.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/enable/secret/level", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/resource_iosxe_system.go
+++ b/internal/provider/resource_iosxe_system.go
@@ -475,6 +475,48 @@ func (r *SystemResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					},
 				},
 			},
+			"boot_system_flash_files": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"path": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							Required:            true,
+						},
+					},
+				},
+			},
+			"boot_system_bootfiles": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"path": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("WORD - TFTP filename or URL").String,
+							Required:            true,
+						},
+					},
+				},
+			},
+			"enable_secret": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+			},
+			"enable_secret_type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddStringEnumDescription("0", "4", "5", "8", "9").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("0", "4", "5", "8", "9"),
+				},
+			},
+			"enable_secret_level": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Set exec level password").AddIntegerRangeDescription(0, 255).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 255),
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Added support for Boot and System commands in the provider.
```
Cisco-IOS-XE-native:native/boot/system/bootfile/filename-list-ordered-by-user/filename
Cisco-IOS-XE-native:native/boot/system/flash/flash-list-ordered-by-user/flash-leaf
Cisco-IOS-XE-native:native/enable/secret/type
Cisco-IOS-XE-native:native/enable/secret/secret
```
Go tests were run and verified.

Previous [Pull Request](https://github.com/CiscoDevNet/terraform-provider-iosxe/pull/260)