### PR TITLE
Add capabilities to CTS resource

### DIFF
--- a/docs/data-sources/cts.md
+++ b/docs/data-sources/cts.md
@@ -28,3 +28,53 @@ data "iosxe_cts" "example" {
 
 - `authorization_list` (String) Local authorization list to use for CTS
 - `id` (String) The path of the retrieved object.
+- `role_based_enforcement_logging_interval` (Number) Configure sgacl logging interval
+- `role_based_enforcement_vlan_list` (Attributes List) VLANs on which Role-based ACLs are enforced (see [below for nested schema](#nestedatt--role_based_enforcement_vlan_list))
+- `role_based_enforcement_vlan_lists` (List of Number) VLANs on which Role-based ACLs are enforced
+- `role_based_permissions_default_acl_name` (List of String) Role-based Access-list name
+- `sgt` (Number) Local device security group
+- `sxp_connection_peer_ipv4_no_vrf` (Attributes List) (see [below for nested schema](#nestedatt--sxp_connection_peer_ipv4_no_vrf))
+- `sxp_connection_peer_ipv4_with_vrf` (Attributes List) (see [below for nested schema](#nestedatt--sxp_connection_peer_ipv4_with_vrf))
+- `sxp_default_password_secret` (String)
+- `sxp_default_password_type` (String)
+- `sxp_enable` (Boolean) Enable CTS SXP support
+- `sxp_listener_hold_max_time` (Number) Enter maximum allowed Hold Time in seconds
+- `sxp_listener_hold_min_time` (Number) Enter minimum allowed Hold Time in seconds
+- `sxp_retry_period` (Number) Enter retry period value for sxp connection in seconds
+- `sxp_speaker_hold_time` (Number) Enter speaker hold-time value in seconds
+
+<a id="nestedatt--role_based_enforcement_vlan_list"></a>
+### Nested Schema for `role_based_enforcement_vlan_list`
+
+Read-Only:
+
+- `vlans` (String) VLAN id
+
+
+<a id="nestedatt--sxp_connection_peer_ipv4_no_vrf"></a>
+### Nested Schema for `sxp_connection_peer_ipv4_no_vrf`
+
+Read-Only:
+
+- `connection_mode` (String) Mode of connection
+- `hold_time` (Number) Minimum hold time period
+- `ip` (String) Enter SXP Peer IP address (IPv4)
+- `max_time` (Number) Maximum hold time period
+- `option` (String) Role of a device speaker/listener/both
+- `password` (String) Password type
+- `source_ip` (String) Enter SXP Source IP address (IPv4)
+
+
+<a id="nestedatt--sxp_connection_peer_ipv4_with_vrf"></a>
+### Nested Schema for `sxp_connection_peer_ipv4_with_vrf`
+
+Read-Only:
+
+- `connection_mode` (String) Mode of connection
+- `hold_time` (Number) Minimum hold time period
+- `ip` (String) Enter SXP Peer IP address (IPv4)
+- `max_time` (Number) Maximum hold time period
+- `option` (String) Role of a device speaker/listener/both
+- `password` (String) Password type
+- `source_ip` (String) Enter SXP Source IP address (IPv4)
+- `vrf` (String) VRF details

--- a/docs/resources/cts.md
+++ b/docs/resources/cts.md
@@ -14,7 +14,39 @@ This resource can manage the CTS configuration.
 
 ```terraform
 resource "iosxe_cts" "example" {
-  authorization_list = "Tacacs-GROUP"
+  authorization_list          = "Tacacs-GROUP"
+  sgt                         = 200
+  sxp_enable                  = true
+  sxp_default_password_type   = "0"
+  sxp_default_password_secret = "MySecretPassword"
+  sxp_retry_period            = 60
+  sxp_connection_peer_ipv4_no_vrf = [
+    {
+      ip              = "2.2.2.2"
+      source_ip       = "3.3.3.3"
+      password        = "default"
+      connection_mode = "local"
+      option          = "listener"
+      hold_time       = 60
+      max_time        = 300
+    }
+  ]
+  sxp_connection_peer_ipv4_with_vrf = [
+    {
+      ip              = "4.4.4.4"
+      vrf             = "VRF1"
+      source_ip       = "5.5.5.5"
+      password        = "default"
+      connection_mode = "local"
+      option          = "listener"
+      hold_time       = 60
+      max_time        = 300
+    }
+  ]
+  sxp_speaker_hold_time                   = 300
+  sxp_listener_hold_min_time              = 60
+  sxp_listener_hold_max_time              = 300
+  role_based_enforcement_logging_interval = 300
 }
 ```
 
@@ -27,10 +59,82 @@ resource "iosxe_cts" "example" {
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
+- `role_based_enforcement_logging_interval` (Number) Configure sgacl logging interval
+  - Range: `5`-`86400`
+- `role_based_enforcement_vlan_list` (Attributes List) VLANs on which Role-based ACLs are enforced (see [below for nested schema](#nestedatt--role_based_enforcement_vlan_list))
+- `role_based_enforcement_vlan_lists` (List of Number) VLANs on which Role-based ACLs are enforced
+- `role_based_permissions_default_acl_name` (List of String) Role-based Access-list name
+- `sgt` (Number) Local device security group
+  - Range: `2`-`65519`
+- `sxp_connection_peer_ipv4_no_vrf` (Attributes List) (see [below for nested schema](#nestedatt--sxp_connection_peer_ipv4_no_vrf))
+- `sxp_connection_peer_ipv4_with_vrf` (Attributes List) (see [below for nested schema](#nestedatt--sxp_connection_peer_ipv4_with_vrf))
+- `sxp_default_password_secret` (String)
+- `sxp_default_password_type` (String) - Choices: `0`, `6`, `7`
+- `sxp_enable` (Boolean) Enable CTS SXP support
+- `sxp_listener_hold_max_time` (Number) Enter maximum allowed Hold Time in seconds
+  - Range: `1`-`65534`
+- `sxp_listener_hold_min_time` (Number) Enter minimum allowed Hold Time in seconds
+  - Range: `1`-`65534`
+- `sxp_retry_period` (Number) Enter retry period value for sxp connection in seconds
+  - Range: `0`-`64000`
+- `sxp_speaker_hold_time` (Number) Enter speaker hold-time value in seconds
+  - Range: `1`-`65534`
 
 ### Read-Only
 
 - `id` (String) The path of the object.
+
+<a id="nestedatt--role_based_enforcement_vlan_list"></a>
+### Nested Schema for `role_based_enforcement_vlan_list`
+
+Required:
+
+- `vlans` (String) VLAN id
+
+
+<a id="nestedatt--sxp_connection_peer_ipv4_no_vrf"></a>
+### Nested Schema for `sxp_connection_peer_ipv4_no_vrf`
+
+Required:
+
+- `ip` (String) Enter SXP Peer IP address (IPv4)
+
+Optional:
+
+- `connection_mode` (String) Mode of connection
+  - Choices: `local`, `peer`
+- `hold_time` (Number) Minimum hold time period
+  - Range: `0`-`65535`
+- `max_time` (Number) Maximum hold time period
+  - Range: `0`-`65535`
+- `option` (String) Role of a device speaker/listener/both
+  - Choices: `both`, `listener`, `speaker`
+- `password` (String) Password type
+  - Choices: `default`, `key-chain`, `none`
+- `source_ip` (String) Enter SXP Source IP address (IPv4)
+
+
+<a id="nestedatt--sxp_connection_peer_ipv4_with_vrf"></a>
+### Nested Schema for `sxp_connection_peer_ipv4_with_vrf`
+
+Required:
+
+- `ip` (String) Enter SXP Peer IP address (IPv4)
+- `vrf` (String) VRF details
+
+Optional:
+
+- `connection_mode` (String) Mode of connection
+  - Choices: `local`, `peer`
+- `hold_time` (Number) Minimum hold time period
+  - Range: `0`-`65535`
+- `max_time` (Number) Maximum hold time period
+  - Range: `0`-`65535`
+- `option` (String) Role of a device speaker/listener/both
+  - Choices: `both`, `listener`, `speaker`
+- `password` (String) Password type
+  - Choices: `default`, `key-chain`, `none`
+- `source_ip` (String) Enter SXP Source IP address (IPv4)
 
 ## Import
 

--- a/examples/resources/iosxe_cts/resource.tf
+++ b/examples/resources/iosxe_cts/resource.tf
@@ -1,3 +1,35 @@
 resource "iosxe_cts" "example" {
-  authorization_list = "Tacacs-GROUP"
+  authorization_list          = "Tacacs-GROUP"
+  sgt                         = 200
+  sxp_enable                  = true
+  sxp_default_password_type   = "0"
+  sxp_default_password_secret = "MySecretPassword"
+  sxp_retry_period            = 60
+  sxp_connection_peer_ipv4_no_vrf = [
+    {
+      ip              = "2.2.2.2"
+      source_ip       = "3.3.3.3"
+      password        = "default"
+      connection_mode = "local"
+      option          = "listener"
+      hold_time       = 60
+      max_time        = 300
+    }
+  ]
+  sxp_connection_peer_ipv4_with_vrf = [
+    {
+      ip              = "4.4.4.4"
+      vrf             = "VRF1"
+      source_ip       = "5.5.5.5"
+      password        = "default"
+      connection_mode = "local"
+      option          = "listener"
+      hold_time       = 60
+      max_time        = 300
+    }
+  ]
+  sxp_speaker_hold_time                   = 300
+  sxp_listener_hold_min_time              = 60
+  sxp_listener_hold_max_time              = 300
+  role_based_enforcement_logging_interval = 300
 }

--- a/gen/definitions/cts.yaml
+++ b/gen/definitions/cts.yaml
@@ -2,6 +2,111 @@
 name: CTS
 path: Cisco-IOS-XE-native:native/cts
 doc_category: CTS
+test_tags: [C9000V]
 attributes:
   - yang_name: Cisco-IOS-XE-cts:authorization/list
     example: Tacacs-GROUP
+  - yang_name: Cisco-IOS-XE-cts:sgt
+    tf_name: sgt
+    example: 200
+  - yang_name: Cisco-IOS-XE-cts:sxp/sxp-def-enable
+    tf_name: sxp_enable
+    example: true
+  - yang_name: Cisco-IOS-XE-cts:sxp/default/password/type
+    tf_name: sxp_default_password_type
+    example: 0
+  - yang_name: Cisco-IOS-XE-cts:sxp/default/password/secret
+    tf_name: sxp_default_password_secret
+    example: MySecretPassword
+  - yang_name: Cisco-IOS-XE-cts:sxp/retry/period
+    tf_name: sxp_retry_period
+    example: 60
+  - yang_name: Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf
+    tf_name: sxp_connection_peer_ipv4_no_vrf
+    type: List
+    attributes:
+      - yang_name: ipv4
+        tf_name: ip
+        example: 2.2.2.2
+        id: true
+      - yang_name: source
+        tf_name: source_ip
+        example: 3.3.3.3
+      - yang_name: password
+        tf_name: password
+        example: default
+      - yang_name: mode
+        tf_name: connection_mode
+        example: local
+      - yang_name: option
+        example: listener
+      - yang_name: hold-time
+        example: 60
+      - yang_name: max-time
+        example: 300
+  - yang_name: Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf
+    tf_name: sxp_connection_peer_ipv4_with_vrf
+    type: List
+    attributes:
+      - yang_name: ipv4
+        tf_name: ip
+        example: 4.4.4.4
+        id: true
+      - yang_name: vrf
+        example: VRF1
+        id: true
+      - yang_name: source
+        tf_name: source_ip
+        example: 5.5.5.5
+      - yang_name: password
+        tf_name: password
+        example: default
+      - yang_name: mode
+        tf_name: connection_mode
+        example: local
+      - yang_name: option
+        example: listener
+      - yang_name: hold-time
+        example: 60
+      - yang_name: max-time
+        example: 300
+  - yang_name: Cisco-IOS-XE-cts:sxp/speaker/hold-time
+    tf_name: sxp_speaker_hold_time
+    example: 300
+  - yang_name: Cisco-IOS-XE-cts:sxp/listener/hold-time/min-time
+    tf_name: sxp_listener_hold_min_time
+    example: 60
+  - yang_name: Cisco-IOS-XE-cts:sxp/listener/hold-time/max-time
+    tf_name: sxp_listener_hold_max_time
+    example: 300
+  - yang_name: Cisco-IOS-XE-cts:role-based/enforcement/logging-interval
+    tf_name: role_based_enforcement_logging_interval
+    example: 300
+  - yang_name: Cisco-IOS-XE-cts:role-based/enforcement/vlan-list
+    tf_name: role_based_enforcement_vlan_list
+    type: List
+    exclude_test: true
+    attributes:
+      - yang_name: id
+        tf_name: vlans
+        id: true
+        example: 100
+  - yang_name: Cisco-IOS-XE-cts:role-based/enforcement/vlan-lists
+    tf_name: role_based_enforcement_vlan_lists
+    exclude_test: true
+    example: 300
+  - yang_name: Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new
+    tf_name: role_based_permissions_default_acl_name
+    example: ACL1
+    exclude_test: true
+
+test_prerequisites:
+  - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1
+    no_delete: true
+    attributes:
+      - name: name
+        value: VRF1
+      - name: rd
+        value: 1:1
+      - name: address-family/ipv4
+        value: ""

--- a/internal/provider/data_source_iosxe_cts.go
+++ b/internal/provider/data_source_iosxe_cts.go
@@ -71,6 +71,140 @@ func (d *CTSDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "Local authorization list to use for CTS",
 				Computed:            true,
 			},
+			"sgt": schema.Int64Attribute{
+				MarkdownDescription: "Local device security group",
+				Computed:            true,
+			},
+			"sxp_enable": schema.BoolAttribute{
+				MarkdownDescription: "Enable CTS SXP support",
+				Computed:            true,
+			},
+			"sxp_default_password_type": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"sxp_default_password_secret": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"sxp_retry_period": schema.Int64Attribute{
+				MarkdownDescription: "Enter retry period value for sxp connection in seconds",
+				Computed:            true,
+			},
+			"sxp_connection_peer_ipv4_no_vrf": schema.ListNestedAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ip": schema.StringAttribute{
+							MarkdownDescription: "Enter SXP Peer IP address (IPv4)",
+							Computed:            true,
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: "Enter SXP Source IP address (IPv4)",
+							Computed:            true,
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: "Password type",
+							Computed:            true,
+						},
+						"connection_mode": schema.StringAttribute{
+							MarkdownDescription: "Mode of connection",
+							Computed:            true,
+						},
+						"option": schema.StringAttribute{
+							MarkdownDescription: "Role of a device speaker/listener/both",
+							Computed:            true,
+						},
+						"hold_time": schema.Int64Attribute{
+							MarkdownDescription: "Minimum hold time period",
+							Computed:            true,
+						},
+						"max_time": schema.Int64Attribute{
+							MarkdownDescription: "Maximum hold time period",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"sxp_connection_peer_ipv4_with_vrf": schema.ListNestedAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ip": schema.StringAttribute{
+							MarkdownDescription: "Enter SXP Peer IP address (IPv4)",
+							Computed:            true,
+						},
+						"vrf": schema.StringAttribute{
+							MarkdownDescription: "VRF details",
+							Computed:            true,
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: "Enter SXP Source IP address (IPv4)",
+							Computed:            true,
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: "Password type",
+							Computed:            true,
+						},
+						"connection_mode": schema.StringAttribute{
+							MarkdownDescription: "Mode of connection",
+							Computed:            true,
+						},
+						"option": schema.StringAttribute{
+							MarkdownDescription: "Role of a device speaker/listener/both",
+							Computed:            true,
+						},
+						"hold_time": schema.Int64Attribute{
+							MarkdownDescription: "Minimum hold time period",
+							Computed:            true,
+						},
+						"max_time": schema.Int64Attribute{
+							MarkdownDescription: "Maximum hold time period",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"sxp_speaker_hold_time": schema.Int64Attribute{
+				MarkdownDescription: "Enter speaker hold-time value in seconds",
+				Computed:            true,
+			},
+			"sxp_listener_hold_min_time": schema.Int64Attribute{
+				MarkdownDescription: "Enter minimum allowed Hold Time in seconds",
+				Computed:            true,
+			},
+			"sxp_listener_hold_max_time": schema.Int64Attribute{
+				MarkdownDescription: "Enter maximum allowed Hold Time in seconds",
+				Computed:            true,
+			},
+			"role_based_enforcement_logging_interval": schema.Int64Attribute{
+				MarkdownDescription: "Configure sgacl logging interval",
+				Computed:            true,
+			},
+			"role_based_enforcement_vlan_list": schema.ListNestedAttribute{
+				MarkdownDescription: "VLANs on which Role-based ACLs are enforced",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vlans": schema.StringAttribute{
+							MarkdownDescription: "VLAN id",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"role_based_enforcement_vlan_lists": schema.ListAttribute{
+				MarkdownDescription: "VLANs on which Role-based ACLs are enforced",
+				ElementType:         types.Int64Type,
+				Computed:            true,
+			},
+			"role_based_permissions_default_acl_name": schema.ListAttribute{
+				MarkdownDescription: "Role-based Access-list name",
+				ElementType:         types.StringType,
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_cts_test.go
+++ b/internal/provider/data_source_iosxe_cts_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,14 +32,41 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeCTS(t *testing.T) {
+	if os.Getenv("C9000V") == "" {
+		t.Skip("skipping test, set environment variable C9000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "authorization_list", "Tacacs-GROUP"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sgt", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_enable", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_default_password_type", "0"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_default_password_secret", "MySecretPassword"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_retry_period", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.ip", "2.2.2.2"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.source_ip", "3.3.3.3"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.password", "default"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.connection_mode", "local"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.option", "listener"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.hold_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.ip", "4.4.4.4"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.vrf", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.source_ip", "5.5.5.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.password", "default"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.connection_mode", "local"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.option", "listener"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.hold_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_speaker_hold_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_listener_hold_min_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_listener_hold_max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "role_based_enforcement_logging_interval", "300"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIosxeCTSConfig(),
+				Config: testAccDataSourceIosxeCTSPrerequisitesConfig + testAccDataSourceIosxeCTSConfig(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -48,6 +76,19 @@ func TestAccDataSourceIosxeCTS(t *testing.T) {
 // End of section. //template:end testAccDataSource
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccDataSourceIosxeCTSPrerequisitesConfig = `
+resource "iosxe_restconf" "PreReq0" {
+	path = "Cisco-IOS-XE-native:native/vrf/definition=VRF1"
+	delete = false
+	attributes = {
+		"name" = "VRF1"
+		"rd" = "1:1"
+		"address-family/ipv4" = ""
+	}
+}
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSourceConfig
@@ -56,6 +97,35 @@ func testAccDataSourceIosxeCTSConfig() string {
 	config := `resource "iosxe_cts" "test" {` + "\n"
 	config += `	delete_mode = "attributes"` + "\n"
 	config += `	authorization_list = "Tacacs-GROUP"` + "\n"
+	config += `	sgt = 200` + "\n"
+	config += `	sxp_enable = true` + "\n"
+	config += `	sxp_default_password_type = "0"` + "\n"
+	config += `	sxp_default_password_secret = "MySecretPassword"` + "\n"
+	config += `	sxp_retry_period = 60` + "\n"
+	config += `	sxp_connection_peer_ipv4_no_vrf = [{` + "\n"
+	config += `		ip = "2.2.2.2"` + "\n"
+	config += `		source_ip = "3.3.3.3"` + "\n"
+	config += `		password = "default"` + "\n"
+	config += `		connection_mode = "local"` + "\n"
+	config += `		option = "listener"` + "\n"
+	config += `		hold_time = 60` + "\n"
+	config += `		max_time = 300` + "\n"
+	config += `	}]` + "\n"
+	config += `	sxp_connection_peer_ipv4_with_vrf = [{` + "\n"
+	config += `		ip = "4.4.4.4"` + "\n"
+	config += `		vrf = "VRF1"` + "\n"
+	config += `		source_ip = "5.5.5.5"` + "\n"
+	config += `		password = "default"` + "\n"
+	config += `		connection_mode = "local"` + "\n"
+	config += `		option = "listener"` + "\n"
+	config += `		hold_time = 60` + "\n"
+	config += `		max_time = 300` + "\n"
+	config += `	}]` + "\n"
+	config += `	sxp_speaker_hold_time = 300` + "\n"
+	config += `	sxp_listener_hold_min_time = 60` + "\n"
+	config += `	sxp_listener_hold_max_time = 300` + "\n"
+	config += `	role_based_enforcement_logging_interval = 300` + "\n"
+	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/model_iosxe_cts.go
+++ b/internal/provider/model_iosxe_cts.go
@@ -23,7 +23,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,16 +38,66 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 type CTS struct {
-	Device            types.String `tfsdk:"device"`
-	Id                types.String `tfsdk:"id"`
-	DeleteMode        types.String `tfsdk:"delete_mode"`
-	AuthorizationList types.String `tfsdk:"authorization_list"`
+	Device                              types.String                      `tfsdk:"device"`
+	Id                                  types.String                      `tfsdk:"id"`
+	DeleteMode                          types.String                      `tfsdk:"delete_mode"`
+	AuthorizationList                   types.String                      `tfsdk:"authorization_list"`
+	Sgt                                 types.Int64                       `tfsdk:"sgt"`
+	SxpEnable                           types.Bool                        `tfsdk:"sxp_enable"`
+	SxpDefaultPasswordType              types.String                      `tfsdk:"sxp_default_password_type"`
+	SxpDefaultPasswordSecret            types.String                      `tfsdk:"sxp_default_password_secret"`
+	SxpRetryPeriod                      types.Int64                       `tfsdk:"sxp_retry_period"`
+	SxpConnectionPeerIpv4NoVrf          []CTSSxpConnectionPeerIpv4NoVrf   `tfsdk:"sxp_connection_peer_ipv4_no_vrf"`
+	SxpConnectionPeerIpv4WithVrf        []CTSSxpConnectionPeerIpv4WithVrf `tfsdk:"sxp_connection_peer_ipv4_with_vrf"`
+	SxpSpeakerHoldTime                  types.Int64                       `tfsdk:"sxp_speaker_hold_time"`
+	SxpListenerHoldMinTime              types.Int64                       `tfsdk:"sxp_listener_hold_min_time"`
+	SxpListenerHoldMaxTime              types.Int64                       `tfsdk:"sxp_listener_hold_max_time"`
+	RoleBasedEnforcementLoggingInterval types.Int64                       `tfsdk:"role_based_enforcement_logging_interval"`
+	RoleBasedEnforcementVlanList        []CTSRoleBasedEnforcementVlanList `tfsdk:"role_based_enforcement_vlan_list"`
+	RoleBasedEnforcementVlanLists       types.List                        `tfsdk:"role_based_enforcement_vlan_lists"`
+	RoleBasedPermissionsDefaultAclName  types.List                        `tfsdk:"role_based_permissions_default_acl_name"`
 }
 
 type CTSData struct {
-	Device            types.String `tfsdk:"device"`
-	Id                types.String `tfsdk:"id"`
-	AuthorizationList types.String `tfsdk:"authorization_list"`
+	Device                              types.String                      `tfsdk:"device"`
+	Id                                  types.String                      `tfsdk:"id"`
+	AuthorizationList                   types.String                      `tfsdk:"authorization_list"`
+	Sgt                                 types.Int64                       `tfsdk:"sgt"`
+	SxpEnable                           types.Bool                        `tfsdk:"sxp_enable"`
+	SxpDefaultPasswordType              types.String                      `tfsdk:"sxp_default_password_type"`
+	SxpDefaultPasswordSecret            types.String                      `tfsdk:"sxp_default_password_secret"`
+	SxpRetryPeriod                      types.Int64                       `tfsdk:"sxp_retry_period"`
+	SxpConnectionPeerIpv4NoVrf          []CTSSxpConnectionPeerIpv4NoVrf   `tfsdk:"sxp_connection_peer_ipv4_no_vrf"`
+	SxpConnectionPeerIpv4WithVrf        []CTSSxpConnectionPeerIpv4WithVrf `tfsdk:"sxp_connection_peer_ipv4_with_vrf"`
+	SxpSpeakerHoldTime                  types.Int64                       `tfsdk:"sxp_speaker_hold_time"`
+	SxpListenerHoldMinTime              types.Int64                       `tfsdk:"sxp_listener_hold_min_time"`
+	SxpListenerHoldMaxTime              types.Int64                       `tfsdk:"sxp_listener_hold_max_time"`
+	RoleBasedEnforcementLoggingInterval types.Int64                       `tfsdk:"role_based_enforcement_logging_interval"`
+	RoleBasedEnforcementVlanList        []CTSRoleBasedEnforcementVlanList `tfsdk:"role_based_enforcement_vlan_list"`
+	RoleBasedEnforcementVlanLists       types.List                        `tfsdk:"role_based_enforcement_vlan_lists"`
+	RoleBasedPermissionsDefaultAclName  types.List                        `tfsdk:"role_based_permissions_default_acl_name"`
+}
+type CTSSxpConnectionPeerIpv4NoVrf struct {
+	Ip             types.String `tfsdk:"ip"`
+	SourceIp       types.String `tfsdk:"source_ip"`
+	Password       types.String `tfsdk:"password"`
+	ConnectionMode types.String `tfsdk:"connection_mode"`
+	Option         types.String `tfsdk:"option"`
+	HoldTime       types.Int64  `tfsdk:"hold_time"`
+	MaxTime        types.Int64  `tfsdk:"max_time"`
+}
+type CTSSxpConnectionPeerIpv4WithVrf struct {
+	Ip             types.String `tfsdk:"ip"`
+	Vrf            types.String `tfsdk:"vrf"`
+	SourceIp       types.String `tfsdk:"source_ip"`
+	Password       types.String `tfsdk:"password"`
+	ConnectionMode types.String `tfsdk:"connection_mode"`
+	Option         types.String `tfsdk:"option"`
+	HoldTime       types.Int64  `tfsdk:"hold_time"`
+	MaxTime        types.Int64  `tfsdk:"max_time"`
+}
+type CTSRoleBasedEnforcementVlanList struct {
+	Vlans types.String `tfsdk:"vlans"`
 }
 
 // End of section. //template:end types
@@ -79,6 +132,106 @@ func (data CTS) toBody(ctx context.Context) string {
 	if !data.AuthorizationList.IsNull() && !data.AuthorizationList.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:authorization.list", data.AuthorizationList.ValueString())
 	}
+	if !data.Sgt.IsNull() && !data.Sgt.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sgt", strconv.FormatInt(data.Sgt.ValueInt64(), 10))
+	}
+	if !data.SxpEnable.IsNull() && !data.SxpEnable.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.sxp-def-enable", data.SxpEnable.ValueBool())
+	}
+	if !data.SxpDefaultPasswordType.IsNull() && !data.SxpDefaultPasswordType.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.default.password.type", data.SxpDefaultPasswordType.ValueString())
+	}
+	if !data.SxpDefaultPasswordSecret.IsNull() && !data.SxpDefaultPasswordSecret.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.default.password.secret", data.SxpDefaultPasswordSecret.ValueString())
+	}
+	if !data.SxpRetryPeriod.IsNull() && !data.SxpRetryPeriod.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.retry.period", strconv.FormatInt(data.SxpRetryPeriod.ValueInt64(), 10))
+	}
+	if !data.SxpSpeakerHoldTime.IsNull() && !data.SxpSpeakerHoldTime.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.speaker.hold-time", strconv.FormatInt(data.SxpSpeakerHoldTime.ValueInt64(), 10))
+	}
+	if !data.SxpListenerHoldMinTime.IsNull() && !data.SxpListenerHoldMinTime.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.listener.hold-time.min-time", strconv.FormatInt(data.SxpListenerHoldMinTime.ValueInt64(), 10))
+	}
+	if !data.SxpListenerHoldMaxTime.IsNull() && !data.SxpListenerHoldMaxTime.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.listener.hold-time.max-time", strconv.FormatInt(data.SxpListenerHoldMaxTime.ValueInt64(), 10))
+	}
+	if !data.RoleBasedEnforcementLoggingInterval.IsNull() && !data.RoleBasedEnforcementLoggingInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.enforcement.logging-interval", strconv.FormatInt(data.RoleBasedEnforcementLoggingInterval.ValueInt64(), 10))
+	}
+	if !data.RoleBasedEnforcementVlanLists.IsNull() && !data.RoleBasedEnforcementVlanLists.IsUnknown() {
+		var values []int
+		data.RoleBasedEnforcementVlanLists.ElementsAs(ctx, &values, false)
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.enforcement.vlan-lists", values)
+	}
+	if !data.RoleBasedPermissionsDefaultAclName.IsNull() && !data.RoleBasedPermissionsDefaultAclName.IsUnknown() {
+		var values []string
+		data.RoleBasedPermissionsDefaultAclName.ElementsAs(ctx, &values, false)
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.permissions.default.ACL-name-new", values)
+	}
+	if len(data.SxpConnectionPeerIpv4NoVrf) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf", []interface{}{})
+		for index, item := range data.SxpConnectionPeerIpv4NoVrf {
+			if !item.Ip.IsNull() && !item.Ip.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"ipv4", item.Ip.ValueString())
+			}
+			if !item.SourceIp.IsNull() && !item.SourceIp.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"source", item.SourceIp.ValueString())
+			}
+			if !item.Password.IsNull() && !item.Password.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"password", item.Password.ValueString())
+			}
+			if !item.ConnectionMode.IsNull() && !item.ConnectionMode.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"mode", item.ConnectionMode.ValueString())
+			}
+			if !item.Option.IsNull() && !item.Option.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"option", item.Option.ValueString())
+			}
+			if !item.HoldTime.IsNull() && !item.HoldTime.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"hold-time", strconv.FormatInt(item.HoldTime.ValueInt64(), 10))
+			}
+			if !item.MaxTime.IsNull() && !item.MaxTime.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"+"."+strconv.Itoa(index)+"."+"max-time", strconv.FormatInt(item.MaxTime.ValueInt64(), 10))
+			}
+		}
+	}
+	if len(data.SxpConnectionPeerIpv4WithVrf) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf", []interface{}{})
+		for index, item := range data.SxpConnectionPeerIpv4WithVrf {
+			if !item.Ip.IsNull() && !item.Ip.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"ipv4", item.Ip.ValueString())
+			}
+			if !item.Vrf.IsNull() && !item.Vrf.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"vrf", item.Vrf.ValueString())
+			}
+			if !item.SourceIp.IsNull() && !item.SourceIp.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"source", item.SourceIp.ValueString())
+			}
+			if !item.Password.IsNull() && !item.Password.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"password", item.Password.ValueString())
+			}
+			if !item.ConnectionMode.IsNull() && !item.ConnectionMode.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"mode", item.ConnectionMode.ValueString())
+			}
+			if !item.Option.IsNull() && !item.Option.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"option", item.Option.ValueString())
+			}
+			if !item.HoldTime.IsNull() && !item.HoldTime.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"hold-time", strconv.FormatInt(item.HoldTime.ValueInt64(), 10))
+			}
+			if !item.MaxTime.IsNull() && !item.MaxTime.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"+"."+strconv.Itoa(index)+"."+"max-time", strconv.FormatInt(item.MaxTime.ValueInt64(), 10))
+			}
+		}
+	}
+	if len(data.RoleBasedEnforcementVlanList) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.enforcement.vlan-list", []interface{}{})
+		for index, item := range data.RoleBasedEnforcementVlanList {
+			if !item.Vlans.IsNull() && !item.Vlans.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.enforcement.vlan-list"+"."+strconv.Itoa(index)+"."+"id", item.Vlans.ValueString())
+			}
+		}
+	}
 	return body
 }
 
@@ -96,6 +249,215 @@ func (data *CTS) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.AuthorizationList = types.StringNull()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sgt"); value.Exists() && !data.Sgt.IsNull() {
+		data.Sgt = types.Int64Value(value.Int())
+	} else {
+		data.Sgt = types.Int64Null()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.sxp-def-enable"); !data.SxpEnable.IsNull() {
+		if value.Exists() {
+			data.SxpEnable = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.SxpEnable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.type"); value.Exists() && !data.SxpDefaultPasswordType.IsNull() {
+		data.SxpDefaultPasswordType = types.StringValue(value.String())
+	} else {
+		data.SxpDefaultPasswordType = types.StringNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.secret"); value.Exists() && !data.SxpDefaultPasswordSecret.IsNull() {
+		data.SxpDefaultPasswordSecret = types.StringValue(value.String())
+	} else {
+		data.SxpDefaultPasswordSecret = types.StringNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.retry.period"); value.Exists() && !data.SxpRetryPeriod.IsNull() {
+		data.SxpRetryPeriod = types.Int64Value(value.Int())
+	} else {
+		data.SxpRetryPeriod = types.Int64Null()
+	}
+	for i := range data.SxpConnectionPeerIpv4NoVrf {
+		keys := [...]string{"ipv4"}
+		keyValues := [...]string{data.SxpConnectionPeerIpv4NoVrf[i].Ip.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("ipv4"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].Ip.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].Ip = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].Ip = types.StringNull()
+		}
+		if value := r.Get("source"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].SourceIp.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].SourceIp = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].SourceIp = types.StringNull()
+		}
+		if value := r.Get("password"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].Password.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].Password = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].Password = types.StringNull()
+		}
+		if value := r.Get("mode"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].ConnectionMode.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].ConnectionMode = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].ConnectionMode = types.StringNull()
+		}
+		if value := r.Get("option"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].Option.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].Option = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].Option = types.StringNull()
+		}
+		if value := r.Get("hold-time"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].HoldTime.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].HoldTime = types.Int64Value(value.Int())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].HoldTime = types.Int64Null()
+		}
+		if value := r.Get("max-time"); value.Exists() && !data.SxpConnectionPeerIpv4NoVrf[i].MaxTime.IsNull() {
+			data.SxpConnectionPeerIpv4NoVrf[i].MaxTime = types.Int64Value(value.Int())
+		} else {
+			data.SxpConnectionPeerIpv4NoVrf[i].MaxTime = types.Int64Null()
+		}
+	}
+	for i := range data.SxpConnectionPeerIpv4WithVrf {
+		keys := [...]string{"ipv4", "vrf"}
+		keyValues := [...]string{data.SxpConnectionPeerIpv4WithVrf[i].Ip.ValueString(), data.SxpConnectionPeerIpv4WithVrf[i].Vrf.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("ipv4"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].Ip.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].Ip = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].Ip = types.StringNull()
+		}
+		if value := r.Get("vrf"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].Vrf.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].Vrf = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].Vrf = types.StringNull()
+		}
+		if value := r.Get("source"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].SourceIp.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].SourceIp = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].SourceIp = types.StringNull()
+		}
+		if value := r.Get("password"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].Password.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].Password = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].Password = types.StringNull()
+		}
+		if value := r.Get("mode"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].ConnectionMode.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].ConnectionMode = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].ConnectionMode = types.StringNull()
+		}
+		if value := r.Get("option"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].Option.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].Option = types.StringValue(value.String())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].Option = types.StringNull()
+		}
+		if value := r.Get("hold-time"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].HoldTime.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].HoldTime = types.Int64Value(value.Int())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].HoldTime = types.Int64Null()
+		}
+		if value := r.Get("max-time"); value.Exists() && !data.SxpConnectionPeerIpv4WithVrf[i].MaxTime.IsNull() {
+			data.SxpConnectionPeerIpv4WithVrf[i].MaxTime = types.Int64Value(value.Int())
+		} else {
+			data.SxpConnectionPeerIpv4WithVrf[i].MaxTime = types.Int64Null()
+		}
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.speaker.hold-time"); value.Exists() && !data.SxpSpeakerHoldTime.IsNull() {
+		data.SxpSpeakerHoldTime = types.Int64Value(value.Int())
+	} else {
+		data.SxpSpeakerHoldTime = types.Int64Null()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.min-time"); value.Exists() && !data.SxpListenerHoldMinTime.IsNull() {
+		data.SxpListenerHoldMinTime = types.Int64Value(value.Int())
+	} else {
+		data.SxpListenerHoldMinTime = types.Int64Null()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.max-time"); value.Exists() && !data.SxpListenerHoldMaxTime.IsNull() {
+		data.SxpListenerHoldMaxTime = types.Int64Value(value.Int())
+	} else {
+		data.SxpListenerHoldMaxTime = types.Int64Null()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.logging-interval"); value.Exists() && !data.RoleBasedEnforcementLoggingInterval.IsNull() {
+		data.RoleBasedEnforcementLoggingInterval = types.Int64Value(value.Int())
+	} else {
+		data.RoleBasedEnforcementLoggingInterval = types.Int64Null()
+	}
+	for i := range data.RoleBasedEnforcementVlanList {
+		keys := [...]string{"id"}
+		keyValues := [...]string{data.RoleBasedEnforcementVlanList[i].Vlans.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-list").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("id"); value.Exists() && !data.RoleBasedEnforcementVlanList[i].Vlans.IsNull() {
+			data.RoleBasedEnforcementVlanList[i].Vlans = types.StringValue(value.String())
+		} else {
+			data.RoleBasedEnforcementVlanList[i].Vlans = types.StringNull()
+		}
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-lists"); value.Exists() && !data.RoleBasedEnforcementVlanLists.IsNull() {
+		data.RoleBasedEnforcementVlanLists = helpers.GetInt64List(value.Array())
+	} else {
+		data.RoleBasedEnforcementVlanLists = types.ListNull(types.Int64Type)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.permissions.default.ACL-name-new"); value.Exists() && !data.RoleBasedPermissionsDefaultAclName.IsNull() {
+		data.RoleBasedPermissionsDefaultAclName = helpers.GetStringList(value.Array())
+	} else {
+		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -109,6 +471,117 @@ func (data *CTS) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "Cisco-IOS-XE-cts:authorization.list"); value.Exists() {
 		data.AuthorizationList = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sgt"); value.Exists() {
+		data.Sgt = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.sxp-def-enable"); value.Exists() {
+		data.SxpEnable = types.BoolValue(value.Bool())
+	} else {
+		data.SxpEnable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.type"); value.Exists() {
+		data.SxpDefaultPasswordType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.secret"); value.Exists() {
+		data.SxpDefaultPasswordSecret = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.retry.period"); value.Exists() {
+		data.SxpRetryPeriod = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"); value.Exists() {
+		data.SxpConnectionPeerIpv4NoVrf = make([]CTSSxpConnectionPeerIpv4NoVrf, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSSxpConnectionPeerIpv4NoVrf{}
+			if cValue := v.Get("ipv4"); cValue.Exists() {
+				item.Ip = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("source"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("password"); cValue.Exists() {
+				item.Password = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("mode"); cValue.Exists() {
+				item.ConnectionMode = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("option"); cValue.Exists() {
+				item.Option = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("hold-time"); cValue.Exists() {
+				item.HoldTime = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("max-time"); cValue.Exists() {
+				item.MaxTime = types.Int64Value(cValue.Int())
+			}
+			data.SxpConnectionPeerIpv4NoVrf = append(data.SxpConnectionPeerIpv4NoVrf, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"); value.Exists() {
+		data.SxpConnectionPeerIpv4WithVrf = make([]CTSSxpConnectionPeerIpv4WithVrf, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSSxpConnectionPeerIpv4WithVrf{}
+			if cValue := v.Get("ipv4"); cValue.Exists() {
+				item.Ip = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("vrf"); cValue.Exists() {
+				item.Vrf = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("source"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("password"); cValue.Exists() {
+				item.Password = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("mode"); cValue.Exists() {
+				item.ConnectionMode = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("option"); cValue.Exists() {
+				item.Option = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("hold-time"); cValue.Exists() {
+				item.HoldTime = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("max-time"); cValue.Exists() {
+				item.MaxTime = types.Int64Value(cValue.Int())
+			}
+			data.SxpConnectionPeerIpv4WithVrf = append(data.SxpConnectionPeerIpv4WithVrf, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.speaker.hold-time"); value.Exists() {
+		data.SxpSpeakerHoldTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.min-time"); value.Exists() {
+		data.SxpListenerHoldMinTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.max-time"); value.Exists() {
+		data.SxpListenerHoldMaxTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.logging-interval"); value.Exists() {
+		data.RoleBasedEnforcementLoggingInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-list"); value.Exists() {
+		data.RoleBasedEnforcementVlanList = make([]CTSRoleBasedEnforcementVlanList, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSRoleBasedEnforcementVlanList{}
+			if cValue := v.Get("id"); cValue.Exists() {
+				item.Vlans = types.StringValue(cValue.String())
+			}
+			data.RoleBasedEnforcementVlanList = append(data.RoleBasedEnforcementVlanList, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-lists"); value.Exists() {
+		data.RoleBasedEnforcementVlanLists = helpers.GetInt64List(value.Array())
+	} else {
+		data.RoleBasedEnforcementVlanLists = types.ListNull(types.Int64Type)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.permissions.default.ACL-name-new"); value.Exists() {
+		data.RoleBasedPermissionsDefaultAclName = helpers.GetStringList(value.Array())
+	} else {
+		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
 	}
 }
 
@@ -124,6 +597,117 @@ func (data *CTSData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "Cisco-IOS-XE-cts:authorization.list"); value.Exists() {
 		data.AuthorizationList = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sgt"); value.Exists() {
+		data.Sgt = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.sxp-def-enable"); value.Exists() {
+		data.SxpEnable = types.BoolValue(value.Bool())
+	} else {
+		data.SxpEnable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.type"); value.Exists() {
+		data.SxpDefaultPasswordType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.default.password.secret"); value.Exists() {
+		data.SxpDefaultPasswordSecret = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.retry.period"); value.Exists() {
+		data.SxpRetryPeriod = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf"); value.Exists() {
+		data.SxpConnectionPeerIpv4NoVrf = make([]CTSSxpConnectionPeerIpv4NoVrf, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSSxpConnectionPeerIpv4NoVrf{}
+			if cValue := v.Get("ipv4"); cValue.Exists() {
+				item.Ip = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("source"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("password"); cValue.Exists() {
+				item.Password = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("mode"); cValue.Exists() {
+				item.ConnectionMode = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("option"); cValue.Exists() {
+				item.Option = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("hold-time"); cValue.Exists() {
+				item.HoldTime = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("max-time"); cValue.Exists() {
+				item.MaxTime = types.Int64Value(cValue.Int())
+			}
+			data.SxpConnectionPeerIpv4NoVrf = append(data.SxpConnectionPeerIpv4NoVrf, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-with-vrf"); value.Exists() {
+		data.SxpConnectionPeerIpv4WithVrf = make([]CTSSxpConnectionPeerIpv4WithVrf, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSSxpConnectionPeerIpv4WithVrf{}
+			if cValue := v.Get("ipv4"); cValue.Exists() {
+				item.Ip = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("vrf"); cValue.Exists() {
+				item.Vrf = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("source"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("password"); cValue.Exists() {
+				item.Password = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("mode"); cValue.Exists() {
+				item.ConnectionMode = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("option"); cValue.Exists() {
+				item.Option = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("hold-time"); cValue.Exists() {
+				item.HoldTime = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("max-time"); cValue.Exists() {
+				item.MaxTime = types.Int64Value(cValue.Int())
+			}
+			data.SxpConnectionPeerIpv4WithVrf = append(data.SxpConnectionPeerIpv4WithVrf, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.speaker.hold-time"); value.Exists() {
+		data.SxpSpeakerHoldTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.min-time"); value.Exists() {
+		data.SxpListenerHoldMinTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:sxp.listener.hold-time.max-time"); value.Exists() {
+		data.SxpListenerHoldMaxTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.logging-interval"); value.Exists() {
+		data.RoleBasedEnforcementLoggingInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-list"); value.Exists() {
+		data.RoleBasedEnforcementVlanList = make([]CTSRoleBasedEnforcementVlanList, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := CTSRoleBasedEnforcementVlanList{}
+			if cValue := v.Get("id"); cValue.Exists() {
+				item.Vlans = types.StringValue(cValue.String())
+			}
+			data.RoleBasedEnforcementVlanList = append(data.RoleBasedEnforcementVlanList, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.enforcement.vlan-lists"); value.Exists() {
+		data.RoleBasedEnforcementVlanLists = helpers.GetInt64List(value.Array())
+	} else {
+		data.RoleBasedEnforcementVlanLists = types.ListNull(types.Int64Type)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:role-based.permissions.default.ACL-name-new"); value.Exists() {
+		data.RoleBasedPermissionsDefaultAclName = helpers.GetStringList(value.Array())
+	} else {
+		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -132,6 +716,192 @@ func (data *CTSData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *CTS) getDeletedItems(ctx context.Context, state CTS) []string {
 	deletedItems := make([]string, 0)
+	if !state.RoleBasedPermissionsDefaultAclName.IsNull() {
+		if data.RoleBasedPermissionsDefaultAclName.IsNull() {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new", state.getPath()))
+		} else {
+			var dataValues, stateValues []string
+			data.RoleBasedPermissionsDefaultAclName.ElementsAs(ctx, &dataValues, false)
+			state.RoleBasedPermissionsDefaultAclName.ElementsAs(ctx, &stateValues, false)
+			for _, v := range stateValues {
+				found := false
+				for _, vv := range dataValues {
+					if v == vv {
+						found = true
+						break
+					}
+				}
+				if !found {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new=%v", state.getPath(), v))
+				}
+			}
+		}
+	}
+	if !state.RoleBasedEnforcementVlanLists.IsNull() {
+		if data.RoleBasedEnforcementVlanLists.IsNull() {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/vlan-lists", state.getPath()))
+		} else {
+			var dataValues, stateValues []int
+			data.RoleBasedEnforcementVlanLists.ElementsAs(ctx, &dataValues, false)
+			state.RoleBasedEnforcementVlanLists.ElementsAs(ctx, &stateValues, false)
+			for _, v := range stateValues {
+				found := false
+				for _, vv := range dataValues {
+					if v == vv {
+						found = true
+						break
+					}
+				}
+				if !found {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/vlan-lists=%v", state.getPath(), v))
+				}
+			}
+		}
+	}
+	for i := range state.RoleBasedEnforcementVlanList {
+		stateKeyValues := [...]string{state.RoleBasedEnforcementVlanList[i].Vlans.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.RoleBasedEnforcementVlanList[i].Vlans.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.RoleBasedEnforcementVlanList {
+			found = true
+			if state.RoleBasedEnforcementVlanList[i].Vlans.ValueString() != data.RoleBasedEnforcementVlanList[j].Vlans.ValueString() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/vlan-list=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
+	if !state.RoleBasedEnforcementLoggingInterval.IsNull() && data.RoleBasedEnforcementLoggingInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/logging-interval", state.getPath()))
+	}
+	if !state.SxpListenerHoldMaxTime.IsNull() && data.SxpListenerHoldMaxTime.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/listener/hold-time/max-time", state.getPath()))
+	}
+	if !state.SxpListenerHoldMinTime.IsNull() && data.SxpListenerHoldMinTime.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/listener/hold-time/min-time", state.getPath()))
+	}
+	if !state.SxpSpeakerHoldTime.IsNull() && data.SxpSpeakerHoldTime.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/speaker/hold-time", state.getPath()))
+	}
+	for i := range state.SxpConnectionPeerIpv4WithVrf {
+		stateKeyValues := [...]string{state.SxpConnectionPeerIpv4WithVrf[i].Ip.ValueString(), state.SxpConnectionPeerIpv4WithVrf[i].Vrf.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.SxpConnectionPeerIpv4WithVrf[i].Ip.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if !reflect.ValueOf(state.SxpConnectionPeerIpv4WithVrf[i].Vrf.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.SxpConnectionPeerIpv4WithVrf {
+			found = true
+			if state.SxpConnectionPeerIpv4WithVrf[i].Ip.ValueString() != data.SxpConnectionPeerIpv4WithVrf[j].Ip.ValueString() {
+				found = false
+			}
+			if state.SxpConnectionPeerIpv4WithVrf[i].Vrf.ValueString() != data.SxpConnectionPeerIpv4WithVrf[j].Vrf.ValueString() {
+				found = false
+			}
+			if found {
+				if !state.SxpConnectionPeerIpv4WithVrf[i].MaxTime.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].MaxTime.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/max-time", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4WithVrf[i].HoldTime.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].HoldTime.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/hold-time", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4WithVrf[i].Option.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].Option.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/option", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4WithVrf[i].ConnectionMode.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].ConnectionMode.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/mode", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4WithVrf[i].Password.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].Password.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/password", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4WithVrf[i].SourceIp.IsNull() && data.SxpConnectionPeerIpv4WithVrf[j].SourceIp.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v/source", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
+	for i := range state.SxpConnectionPeerIpv4NoVrf {
+		stateKeyValues := [...]string{state.SxpConnectionPeerIpv4NoVrf[i].Ip.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.SxpConnectionPeerIpv4NoVrf[i].Ip.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.SxpConnectionPeerIpv4NoVrf {
+			found = true
+			if state.SxpConnectionPeerIpv4NoVrf[i].Ip.ValueString() != data.SxpConnectionPeerIpv4NoVrf[j].Ip.ValueString() {
+				found = false
+			}
+			if found {
+				if !state.SxpConnectionPeerIpv4NoVrf[i].MaxTime.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].MaxTime.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/max-time", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4NoVrf[i].HoldTime.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].HoldTime.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/hold-time", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4NoVrf[i].Option.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].Option.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/option", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4NoVrf[i].ConnectionMode.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].ConnectionMode.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/mode", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4NoVrf[i].Password.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].Password.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/password", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.SxpConnectionPeerIpv4NoVrf[i].SourceIp.IsNull() && data.SxpConnectionPeerIpv4NoVrf[j].SourceIp.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v/source", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
+	if !state.SxpRetryPeriod.IsNull() && data.SxpRetryPeriod.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/retry/period", state.getPath()))
+	}
+	if !state.SxpDefaultPasswordSecret.IsNull() && data.SxpDefaultPasswordSecret.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/default/password/secret", state.getPath()))
+	}
+	if !state.SxpDefaultPasswordType.IsNull() && data.SxpDefaultPasswordType.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/default/password/type", state.getPath()))
+	}
+	if !state.SxpEnable.IsNull() && data.SxpEnable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/sxp-def-enable", state.getPath()))
+	}
+	if !state.Sgt.IsNull() && data.Sgt.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sgt", state.getPath()))
+	}
 	if !state.AuthorizationList.IsNull() && data.AuthorizationList.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:authorization/list", state.getPath()))
 	}
@@ -155,6 +925,54 @@ func (data *CTS) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *CTS) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.RoleBasedPermissionsDefaultAclName.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new", data.getPath()))
+	}
+	if !data.RoleBasedEnforcementVlanLists.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/vlan-lists", data.getPath()))
+	}
+	for i := range data.RoleBasedEnforcementVlanList {
+		keyValues := [...]string{data.RoleBasedEnforcementVlanList[i].Vlans.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/vlan-list=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	if !data.RoleBasedEnforcementLoggingInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement/logging-interval", data.getPath()))
+	}
+	if !data.SxpListenerHoldMaxTime.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/listener/hold-time/max-time", data.getPath()))
+	}
+	if !data.SxpListenerHoldMinTime.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/listener/hold-time/min-time", data.getPath()))
+	}
+	if !data.SxpSpeakerHoldTime.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/speaker/hold-time", data.getPath()))
+	}
+	for i := range data.SxpConnectionPeerIpv4WithVrf {
+		keyValues := [...]string{data.SxpConnectionPeerIpv4WithVrf[i].Ip.ValueString(), data.SxpConnectionPeerIpv4WithVrf[i].Vrf.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-with-vrf=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	for i := range data.SxpConnectionPeerIpv4NoVrf {
+		keyValues := [...]string{data.SxpConnectionPeerIpv4NoVrf[i].Ip.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/connection/peer/ipv4-no-vrf=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	if !data.SxpRetryPeriod.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/retry/period", data.getPath()))
+	}
+	if !data.SxpDefaultPasswordSecret.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/default/password/secret", data.getPath()))
+	}
+	if !data.SxpDefaultPasswordType.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/default/password/type", data.getPath()))
+	}
+	if !data.SxpEnable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sxp/sxp-def-enable", data.getPath()))
+	}
+	if !data.Sgt.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:sgt", data.getPath()))
+	}
 	if !data.AuthorizationList.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:authorization/list", data.getPath()))
 	}

--- a/internal/provider/resource_iosxe_cts.go
+++ b/internal/provider/resource_iosxe_cts.go
@@ -23,9 +23,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -90,6 +92,206 @@ func (r *CTSResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 64),
 				},
+			},
+			"sgt": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Local device security group").AddIntegerRangeDescription(2, 65519).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(2, 65519),
+				},
+			},
+			"sxp_enable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable CTS SXP support").String,
+				Optional:            true,
+			},
+			"sxp_default_password_type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddStringEnumDescription("0", "6", "7").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("0", "6", "7"),
+				},
+			},
+			"sxp_default_password_secret": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 162),
+				},
+			},
+			"sxp_retry_period": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter retry period value for sxp connection in seconds").AddIntegerRangeDescription(0, 64000).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 64000),
+				},
+			},
+			"sxp_connection_peer_ipv4_no_vrf": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter SXP Peer IP address (IPv4)").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter SXP Source IP address (IPv4)").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Password type").AddStringEnumDescription("default", "key-chain", "none").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("default", "key-chain", "none"),
+							},
+						},
+						"connection_mode": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Mode of connection").AddStringEnumDescription("local", "peer").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("local", "peer"),
+							},
+						},
+						"option": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Role of a device speaker/listener/both").AddStringEnumDescription("both", "listener", "speaker").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("both", "listener", "speaker"),
+							},
+						},
+						"hold_time": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Minimum hold time period").AddIntegerRangeDescription(0, 65535).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(0, 65535),
+							},
+						},
+						"max_time": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Maximum hold time period").AddIntegerRangeDescription(0, 65535).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(0, 65535),
+							},
+						},
+					},
+				},
+			},
+			"sxp_connection_peer_ipv4_with_vrf": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter SXP Peer IP address (IPv4)").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"vrf": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("VRF details").String,
+							Required:            true,
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter SXP Source IP address (IPv4)").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Password type").AddStringEnumDescription("default", "key-chain", "none").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("default", "key-chain", "none"),
+							},
+						},
+						"connection_mode": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Mode of connection").AddStringEnumDescription("local", "peer").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("local", "peer"),
+							},
+						},
+						"option": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Role of a device speaker/listener/both").AddStringEnumDescription("both", "listener", "speaker").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("both", "listener", "speaker"),
+							},
+						},
+						"hold_time": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Minimum hold time period").AddIntegerRangeDescription(0, 65535).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(0, 65535),
+							},
+						},
+						"max_time": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Maximum hold time period").AddIntegerRangeDescription(0, 65535).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(0, 65535),
+							},
+						},
+					},
+				},
+			},
+			"sxp_speaker_hold_time": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter speaker hold-time value in seconds").AddIntegerRangeDescription(1, 65534).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65534),
+				},
+			},
+			"sxp_listener_hold_min_time": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter minimum allowed Hold Time in seconds").AddIntegerRangeDescription(1, 65534).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65534),
+				},
+			},
+			"sxp_listener_hold_max_time": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter maximum allowed Hold Time in seconds").AddIntegerRangeDescription(1, 65534).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65534),
+				},
+			},
+			"role_based_enforcement_logging_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Configure sgacl logging interval").AddIntegerRangeDescription(5, 86400).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(5, 86400),
+				},
+			},
+			"role_based_enforcement_vlan_list": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("VLANs on which Role-based ACLs are enforced").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vlans": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("VLAN id").String,
+							Required:            true,
+						},
+					},
+				},
+			},
+			"role_based_enforcement_vlan_lists": schema.ListAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("VLANs on which Role-based ACLs are enforced").String,
+				ElementType:         types.Int64Type,
+				Optional:            true,
+			},
+			"role_based_permissions_default_acl_name": schema.ListAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Role-based Access-list name").String,
+				ElementType:         types.StringType,
+				Optional:            true,
 			},
 		},
 	}

--- a/internal/provider/resource_iosxe_cts_test.go
+++ b/internal/provider/resource_iosxe_cts_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,17 +34,44 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeCTS(t *testing.T) {
+	if os.Getenv("C9000V") == "" {
+		t.Skip("skipping test, set environment variable C9000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "authorization_list", "Tacacs-GROUP"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sgt", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_enable", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_default_password_type", "0"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_default_password_secret", "MySecretPassword"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_retry_period", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.ip", "2.2.2.2"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.source_ip", "3.3.3.3"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.password", "default"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.connection_mode", "local"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.option", "listener"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.hold_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_no_vrf.0.max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.ip", "4.4.4.4"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.vrf", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.source_ip", "5.5.5.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.password", "default"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.connection_mode", "local"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.option", "listener"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.hold_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_connection_peer_ipv4_with_vrf.0.max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_speaker_hold_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_listener_hold_min_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_listener_hold_max_time", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "role_based_enforcement_logging_interval", "300"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIosxeCTSConfig_minimum(),
+				Config: testAccIosxeCTSPrerequisitesConfig + testAccIosxeCTSConfig_minimum(),
 			},
 			{
-				Config: testAccIosxeCTSConfig_all(),
+				Config: testAccIosxeCTSPrerequisitesConfig + testAccIosxeCTSConfig_all(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 			{
@@ -72,12 +100,26 @@ func iosxeCTSImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 // End of section. //template:end importStateIdFunc
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccIosxeCTSPrerequisitesConfig = `
+resource "iosxe_restconf" "PreReq0" {
+	path = "Cisco-IOS-XE-native:native/vrf/definition=VRF1"
+	delete = false
+	attributes = {
+		"name" = "VRF1"
+		"rd" = "1:1"
+		"address-family/ipv4" = ""
+	}
+}
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigMinimal
 
 func testAccIosxeCTSConfig_minimum() string {
 	config := `resource "iosxe_cts" "test" {` + "\n"
+	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -89,6 +131,35 @@ func testAccIosxeCTSConfig_minimum() string {
 func testAccIosxeCTSConfig_all() string {
 	config := `resource "iosxe_cts" "test" {` + "\n"
 	config += `	authorization_list = "Tacacs-GROUP"` + "\n"
+	config += `	sgt = 200` + "\n"
+	config += `	sxp_enable = true` + "\n"
+	config += `	sxp_default_password_type = "0"` + "\n"
+	config += `	sxp_default_password_secret = "MySecretPassword"` + "\n"
+	config += `	sxp_retry_period = 60` + "\n"
+	config += `	sxp_connection_peer_ipv4_no_vrf = [{` + "\n"
+	config += `		ip = "2.2.2.2"` + "\n"
+	config += `		source_ip = "3.3.3.3"` + "\n"
+	config += `		password = "default"` + "\n"
+	config += `		connection_mode = "local"` + "\n"
+	config += `		option = "listener"` + "\n"
+	config += `		hold_time = 60` + "\n"
+	config += `		max_time = 300` + "\n"
+	config += `	}]` + "\n"
+	config += `	sxp_connection_peer_ipv4_with_vrf = [{` + "\n"
+	config += `		ip = "4.4.4.4"` + "\n"
+	config += `		vrf = "VRF1"` + "\n"
+	config += `		source_ip = "5.5.5.5"` + "\n"
+	config += `		password = "default"` + "\n"
+	config += `		connection_mode = "local"` + "\n"
+	config += `		option = "listener"` + "\n"
+	config += `		hold_time = 60` + "\n"
+	config += `		max_time = 300` + "\n"
+	config += `	}]` + "\n"
+	config += `	sxp_speaker_hold_time = 300` + "\n"
+	config += `	sxp_listener_hold_min_time = 60` + "\n"
+	config += `	sxp_listener_hold_max_time = 300` + "\n"
+	config += `	role_based_enforcement_logging_interval = 300` + "\n"
+	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config
 }


### PR DESCRIPTION
Add `sxp_default_password_type`, `sxp_default_password_secret`, `sxp_connection_peer_ipv4_no_vrf`, `ip`, `source_ip`, `password`, `connection_mode`, `sxp_connection_peer_ipv4_with_vrf`, `ip`, `source_ip`, `password`, `connection_mode`, `sxp_listener_hold_min_time`, `sxp_listener_hold_max_time`, `role_based_enforcement_logging_interval`, `role_based_enforcement_vlan_list`, `vlans`, `role_based_enforcement_vlan_lists`, `role_based_permissions_default_acl_name`, `sgt`, `sxp_enable`, `sxp_retry_period`, `sxp_speaker_hold_time` attributes to `iosxe_cts` resource and data source

**NOTE:** Following commands DO NOT have YANG models in 17.15.1 dataset, hence, to apply, CLI module needs to be used.

```
cts sxp limit export peer-sequence-nodes 3
cts sxp limit import peer-sequence-nodes 3
```