### PR TITLE
Crypto

### DIFF
--- a/docs/data-sources/crypto_ikev2.md
+++ b/docs/data-sources/crypto_ikev2.md
@@ -29,6 +29,6 @@ data "iosxe_crypto_ikev2" "example" {
 - `dpd` (Number) Enable IKE liveness check for peers
 - `dpd_query` (String)
 - `dpd_retry_interval` (Number)
-- `http_url_cert_leaf` (Boolean) Enable certificate lookup based on HTTP-based URL
+- `http_url_cert` (Boolean) Enable certificate lookup based on HTTP-based URL
 - `id` (String) The path of the retrieved object.
 - `nat_keepalive` (Number) Set NAT keepalive interval

--- a/docs/resources/crypto_ikev2.md
+++ b/docs/resources/crypto_ikev2.md
@@ -18,7 +18,7 @@ resource "iosxe_crypto_ikev2" "example" {
   dpd                = 10
   dpd_retry_interval = 5
   dpd_query          = "periodic"
-  http_url_cert_leaf = true
+  http_url_cert      = true
 }
 ```
 
@@ -34,7 +34,7 @@ resource "iosxe_crypto_ikev2" "example" {
   - Range: `10`-`3600`
 - `dpd_query` (String) - Choices: `on-demand`, `periodic`
 - `dpd_retry_interval` (Number) - Range: `2`-`60`
-- `http_url_cert_leaf` (Boolean) Enable certificate lookup based on HTTP-based URL
+- `http_url_cert` (Boolean) Enable certificate lookup based on HTTP-based URL
 - `nat_keepalive` (Number) Set NAT keepalive interval
   - Range: `5`-`3600`
 

--- a/examples/resources/iosxe_crypto_ikev2/resource.tf
+++ b/examples/resources/iosxe_crypto_ikev2/resource.tf
@@ -3,5 +3,5 @@ resource "iosxe_crypto_ikev2" "example" {
   dpd                = 10
   dpd_retry_interval = 5
   dpd_query          = "periodic"
-  http_url_cert_leaf = true
+  http_url_cert      = true
 }

--- a/gen/definitions/crypto_ikev2.yaml
+++ b/gen/definitions/crypto_ikev2.yaml
@@ -18,5 +18,6 @@ attributes:
     delete_parent: true
     example: periodic
   - yang_name: http-url/cert-leaf
+    tf_name: http_url_cert
     delete_parent: true
     example: true

--- a/internal/provider/data_source_iosxe_crypto_ikev2.go
+++ b/internal/provider/data_source_iosxe_crypto_ikev2.go
@@ -83,7 +83,7 @@ func (d *CryptoIKEv2DataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "",
 				Computed:            true,
 			},
-			"http_url_cert_leaf": schema.BoolAttribute{
+			"http_url_cert": schema.BoolAttribute{
 				MarkdownDescription: "Enable certificate lookup based on HTTP-based URL",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_iosxe_crypto_ikev2_test.go
+++ b/internal/provider/data_source_iosxe_crypto_ikev2_test.go
@@ -36,7 +36,7 @@ func TestAccDataSourceIosxeCryptoIKEv2(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2.test", "dpd", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2.test", "dpd_retry_interval", "5"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2.test", "dpd_query", "periodic"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2.test", "http_url_cert_leaf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2.test", "http_url_cert", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -63,7 +63,7 @@ func testAccDataSourceIosxeCryptoIKEv2Config() string {
 	config += `	dpd = 10` + "\n"
 	config += `	dpd_retry_interval = 5` + "\n"
 	config += `	dpd_query = "periodic"` + "\n"
-	config += `	http_url_cert_leaf = true` + "\n"
+	config += `	http_url_cert = true` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/model_iosxe_crypto_ikev2.go
+++ b/internal/provider/model_iosxe_crypto_ikev2.go
@@ -43,7 +43,7 @@ type CryptoIKEv2 struct {
 	Dpd              types.Int64  `tfsdk:"dpd"`
 	DpdRetryInterval types.Int64  `tfsdk:"dpd_retry_interval"`
 	DpdQuery         types.String `tfsdk:"dpd_query"`
-	HttpUrlCertLeaf  types.Bool   `tfsdk:"http_url_cert_leaf"`
+	HttpUrlCert      types.Bool   `tfsdk:"http_url_cert"`
 }
 
 type CryptoIKEv2Data struct {
@@ -53,7 +53,7 @@ type CryptoIKEv2Data struct {
 	Dpd              types.Int64  `tfsdk:"dpd"`
 	DpdRetryInterval types.Int64  `tfsdk:"dpd_retry_interval"`
 	DpdQuery         types.String `tfsdk:"dpd_query"`
-	HttpUrlCertLeaf  types.Bool   `tfsdk:"http_url_cert_leaf"`
+	HttpUrlCert      types.Bool   `tfsdk:"http_url_cert"`
 }
 
 // End of section. //template:end types
@@ -97,8 +97,8 @@ func (data CryptoIKEv2) toBody(ctx context.Context) string {
 	if !data.DpdQuery.IsNull() && !data.DpdQuery.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"dpd-container.dpd-query", data.DpdQuery.ValueString())
 	}
-	if !data.HttpUrlCertLeaf.IsNull() && !data.HttpUrlCertLeaf.IsUnknown() {
-		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"http-url.cert-leaf", data.HttpUrlCertLeaf.ValueBool())
+	if !data.HttpUrlCert.IsNull() && !data.HttpUrlCert.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"http-url.cert-leaf", data.HttpUrlCert.ValueBool())
 	}
 	return body
 }
@@ -132,12 +132,12 @@ func (data *CryptoIKEv2) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.DpdQuery = types.StringNull()
 	}
-	if value := res.Get(prefix + "http-url.cert-leaf"); !data.HttpUrlCertLeaf.IsNull() {
+	if value := res.Get(prefix + "http-url.cert-leaf"); !data.HttpUrlCert.IsNull() {
 		if value.Exists() {
-			data.HttpUrlCertLeaf = types.BoolValue(value.Bool())
+			data.HttpUrlCert = types.BoolValue(value.Bool())
 		}
 	} else {
-		data.HttpUrlCertLeaf = types.BoolNull()
+		data.HttpUrlCert = types.BoolNull()
 	}
 }
 
@@ -163,9 +163,9 @@ func (data *CryptoIKEv2) fromBody(ctx context.Context, res gjson.Result) {
 		data.DpdQuery = types.StringValue(value.String())
 	}
 	if value := res.Get(prefix + "http-url.cert-leaf"); value.Exists() {
-		data.HttpUrlCertLeaf = types.BoolValue(value.Bool())
+		data.HttpUrlCert = types.BoolValue(value.Bool())
 	} else {
-		data.HttpUrlCertLeaf = types.BoolNull()
+		data.HttpUrlCert = types.BoolNull()
 	}
 }
 
@@ -191,9 +191,9 @@ func (data *CryptoIKEv2Data) fromBody(ctx context.Context, res gjson.Result) {
 		data.DpdQuery = types.StringValue(value.String())
 	}
 	if value := res.Get(prefix + "http-url.cert-leaf"); value.Exists() {
-		data.HttpUrlCertLeaf = types.BoolValue(value.Bool())
+		data.HttpUrlCert = types.BoolValue(value.Bool())
 	} else {
-		data.HttpUrlCertLeaf = types.BoolNull()
+		data.HttpUrlCert = types.BoolNull()
 	}
 }
 
@@ -203,7 +203,7 @@ func (data *CryptoIKEv2Data) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *CryptoIKEv2) getDeletedItems(ctx context.Context, state CryptoIKEv2) []string {
 	deletedItems := make([]string, 0)
-	if !state.HttpUrlCertLeaf.IsNull() && data.HttpUrlCertLeaf.IsNull() {
+	if !state.HttpUrlCert.IsNull() && data.HttpUrlCert.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/http-url", state.getPath()))
 	}
 	if !state.DpdQuery.IsNull() && data.DpdQuery.IsNull() {
@@ -238,7 +238,7 @@ func (data *CryptoIKEv2) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *CryptoIKEv2) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
-	if !data.HttpUrlCertLeaf.IsNull() {
+	if !data.HttpUrlCert.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/http-url", data.getPath()))
 	}
 	if !data.DpdQuery.IsNull() {

--- a/internal/provider/resource_iosxe_crypto_ikev2.go
+++ b/internal/provider/resource_iosxe_crypto_ikev2.go
@@ -113,7 +113,7 @@ func (r *CryptoIKEv2Resource) Schema(ctx context.Context, req resource.SchemaReq
 					stringvalidator.OneOf("on-demand", "periodic"),
 				},
 			},
-			"http_url_cert_leaf": schema.BoolAttribute{
+			"http_url_cert": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enable certificate lookup based on HTTP-based URL").String,
 				Optional:            true,
 			},

--- a/internal/provider/resource_iosxe_crypto_ikev2_test.go
+++ b/internal/provider/resource_iosxe_crypto_ikev2_test.go
@@ -38,7 +38,7 @@ func TestAccIosxeCryptoIKEv2(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2.test", "dpd", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2.test", "dpd_retry_interval", "5"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2.test", "dpd_query", "periodic"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2.test", "http_url_cert_leaf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2.test", "http_url_cert", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -96,7 +96,7 @@ func testAccIosxeCryptoIKEv2Config_all() string {
 	config += `	dpd = 10` + "\n"
 	config += `	dpd_retry_interval = 5` + "\n"
 	config += `	dpd_query = "periodic"` + "\n"
-	config += `	http_url_cert_leaf = true` + "\n"
+	config += `	http_url_cert = true` + "\n"
 	config += `}` + "\n"
 	return config
 }


### PR DESCRIPTION
Added support for Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:ikev2/http-url/cert-leaf


The following have more current versions:
  - Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:pki/trustpoint/enrollment/pkcs12
  - Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:pki/trustpoint/enrollment/selfsigned

The following are deprecated:
  - Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:pki/certificate/chain/certificate/certtype
  - Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:pki/certificate/chain/certificate/serial
  - Cisco-IOS-XE-native:native/crypto/Cisco-IOS-XE-crypto:pki/certificate/chain/name