### PR TITLE
Added support for distance attributes to `iosxe_iosxe_bgp_address_family_ipv4` and `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `cdp_enable`, `cdp_tlv_app`, `cdp_tlv_location`, `cdp_tlv_server_location`, `ip_nat_inside`, and `ip_nat_outside` attributes to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_port_channel` resource and data source
 - Add `ip_hosts`, `ip_hosts_vrf`, `name`, `ips`, `vrf`, `hosts`, `subscriber_templating`, `call_home_contact_email`, `call_home_cisco_tac_1_profile_active`, `call_home_cisco_tac_1_destination_transport_method`, `ip_ftp_passive`, `tftp_source_interface_gigabit_ethernet`, `tftp_source_interface_loopback`, `version`, and `multilink_ppp_bundle_name` attributes to `iosxe_system` resource and data source
+- Add `admin_distances`, `distance_bgp_external`, `distance_bgp_internal`, `distance_bgp_local`, `distance`, `source_ip`, `wildcard`, and `acl` attributes to `iosxe_iosxe_bgp_address_family_ipv4` and `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
 
 ## 0.7.1
 

--- a/docs/data-sources/bgp_address_family_ipv4.md
+++ b/docs/data-sources/bgp_address_family_ipv4.md
@@ -33,12 +33,27 @@ data "iosxe_bgp_address_family_ipv4" "example" {
 
 ### Read-Only
 
+- `admin_distances` (Attributes List) (see [below for nested schema](#nestedatt--admin_distances))
+- `distance_bgp_external` (Number)
+- `distance_bgp_internal` (Number)
+- `distance_bgp_local` (Number)
 - `id` (String) The path of the retrieved object.
 - `ipv4_unicast_aggregate_addresses` (Attributes List) Configure BGP aggregate entries (see [below for nested schema](#nestedatt--ipv4_unicast_aggregate_addresses))
 - `ipv4_unicast_networks` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--ipv4_unicast_networks))
 - `ipv4_unicast_networks_mask` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--ipv4_unicast_networks_mask))
 - `ipv4_unicast_redistribute_connected` (Boolean) Connected
 - `ipv4_unicast_redistribute_static` (Boolean) Static routes
+
+<a id="nestedatt--admin_distances"></a>
+### Nested Schema for `admin_distances`
+
+Read-Only:
+
+- `acl` (String)
+- `distance` (Number)
+- `source_ip` (String)
+- `wildcard` (String)
+
 
 <a id="nestedatt--ipv4_unicast_aggregate_addresses"></a>
 ### Nested Schema for `ipv4_unicast_aggregate_addresses`

--- a/docs/data-sources/bgp_address_family_ipv4_vrf.md
+++ b/docs/data-sources/bgp_address_family_ipv4_vrf.md
@@ -41,6 +41,10 @@ data "iosxe_bgp_address_family_ipv4_vrf" "example" {
 
 Read-Only:
 
+- `admin_distances` (Attributes List) (see [below for nested schema](#nestedatt--vrfs--admin_distances))
+- `distance_bgp_external` (Number)
+- `distance_bgp_internal` (Number)
+- `distance_bgp_local` (Number)
 - `ipv4_unicast_advertise_l2vpn_evpn` (Boolean) Advertise/export prefixes to l2vpn evpn table
 - `ipv4_unicast_aggregate_addresses` (Attributes List) Configure BGP aggregate entries (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_aggregate_addresses))
 - `ipv4_unicast_networks` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_networks))
@@ -49,6 +53,17 @@ Read-Only:
 - `ipv4_unicast_redistribute_static` (Boolean) Static routes
 - `ipv4_unicast_router_id_loopback` (Number) Loopback interface
 - `name` (String)
+
+<a id="nestedatt--vrfs--admin_distances"></a>
+### Nested Schema for `vrfs.admin_distances`
+
+Read-Only:
+
+- `acl` (String)
+- `distance` (Number)
+- `source_ip` (String)
+- `wildcard` (String)
+
 
 <a id="nestedatt--vrfs--ipv4_unicast_aggregate_addresses"></a>
 ### Nested Schema for `vrfs.ipv4_unicast_aggregate_addresses`

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -28,6 +28,7 @@ description: |-
 - Add `cdp_enable`, `cdp_tlv_app`, `cdp_tlv_location`, `cdp_tlv_server_location`, `ip_nat_inside`, and `ip_nat_outside` attributes to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_port_channel` resource and data source
 - Add `ip_hosts`, `ip_hosts_vrf`, `name`, `ips`, `vrf`, `hosts`, `subscriber_templating`, `call_home_contact_email`, `call_home_cisco_tac_1_profile_active`, `call_home_cisco_tac_1_destination_transport_method`, `ip_ftp_passive`, `tftp_source_interface_gigabit_ethernet`, `tftp_source_interface_loopback`, `version`, and `multilink_ppp_bundle_name` attributes to `iosxe_system` resource and data source
+- Add `admin_distances`, `distance_bgp_external`, `distance_bgp_internal`, `distance_bgp_local`, `distance`, `source_ip`, `wildcard`, and `acl` attributes to `iosxe_iosxe_bgp_address_family_ipv4` and `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
 
 ## 0.7.1
 

--- a/docs/resources/bgp_address_family_ipv4.md
+++ b/docs/resources/bgp_address_family_ipv4.md
@@ -39,6 +39,16 @@ resource "iosxe_bgp_address_family_ipv4" "example" {
       backdoor  = true
     }
   ]
+  admin_distances = [
+    {
+      distance  = 200
+      source_ip = "10.1.1.1"
+      wildcard  = "0.0.0.0"
+    }
+  ]
+  distance_bgp_external = 20
+  distance_bgp_internal = 200
+  distance_bgp_local    = 200
 }
 ```
 
@@ -52,9 +62,13 @@ resource "iosxe_bgp_address_family_ipv4" "example" {
 
 ### Optional
 
+- `admin_distances` (Attributes List) (see [below for nested schema](#nestedatt--admin_distances))
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
+- `distance_bgp_external` (Number) - Range: `1`-`255`
+- `distance_bgp_internal` (Number) - Range: `1`-`255`
+- `distance_bgp_local` (Number) - Range: `1`-`255`
 - `ipv4_unicast_aggregate_addresses` (Attributes List) Configure BGP aggregate entries (see [below for nested schema](#nestedatt--ipv4_unicast_aggregate_addresses))
 - `ipv4_unicast_networks` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--ipv4_unicast_networks))
 - `ipv4_unicast_networks_mask` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--ipv4_unicast_networks_mask))
@@ -64,6 +78,20 @@ resource "iosxe_bgp_address_family_ipv4" "example" {
 ### Read-Only
 
 - `id` (String) The path of the object.
+
+<a id="nestedatt--admin_distances"></a>
+### Nested Schema for `admin_distances`
+
+Required:
+
+- `distance` (Number) - Range: `1`-`255`
+- `source_ip` (String)
+- `wildcard` (String)
+
+Optional:
+
+- `acl` (String)
+
 
 <a id="nestedatt--ipv4_unicast_aggregate_addresses"></a>
 ### Nested Schema for `ipv4_unicast_aggregate_addresses`

--- a/docs/resources/bgp_address_family_ipv4_vrf.md
+++ b/docs/resources/bgp_address_family_ipv4_vrf.md
@@ -44,6 +44,16 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
           backdoor  = true
         }
       ]
+      admin_distances = [
+        {
+          distance  = 200
+          source_ip = "10.1.1.1"
+          wildcard  = "0.0.0.0"
+        }
+      ]
+      distance_bgp_external = 20
+      distance_bgp_internal = 200
+      distance_bgp_local    = 200
     }
   ]
 }
@@ -77,6 +87,10 @@ Required:
 
 Optional:
 
+- `admin_distances` (Attributes List) (see [below for nested schema](#nestedatt--vrfs--admin_distances))
+- `distance_bgp_external` (Number) - Range: `1`-`255`
+- `distance_bgp_internal` (Number) - Range: `1`-`255`
+- `distance_bgp_local` (Number) - Range: `1`-`255`
 - `ipv4_unicast_advertise_l2vpn_evpn` (Boolean) Advertise/export prefixes to l2vpn evpn table
 - `ipv4_unicast_aggregate_addresses` (Attributes List) Configure BGP aggregate entries (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_aggregate_addresses))
 - `ipv4_unicast_networks` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_networks))
@@ -85,6 +99,20 @@ Optional:
 - `ipv4_unicast_redistribute_static` (Boolean) Static routes
 - `ipv4_unicast_router_id_loopback` (Number) Loopback interface
   - Range: `0`-`2147483647`
+
+<a id="nestedatt--vrfs--admin_distances"></a>
+### Nested Schema for `vrfs.admin_distances`
+
+Required:
+
+- `distance` (Number) - Range: `1`-`255`
+- `source_ip` (String)
+- `wildcard` (String)
+
+Optional:
+
+- `acl` (String)
+
 
 <a id="nestedatt--vrfs--ipv4_unicast_aggregate_addresses"></a>
 ### Nested Schema for `vrfs.ipv4_unicast_aggregate_addresses`

--- a/examples/resources/iosxe_bgp_address_family_ipv4/resource.tf
+++ b/examples/resources/iosxe_bgp_address_family_ipv4/resource.tf
@@ -24,4 +24,14 @@ resource "iosxe_bgp_address_family_ipv4" "example" {
       backdoor  = true
     }
   ]
+  admin_distances = [
+    {
+      distance  = 200
+      source_ip = "10.1.1.1"
+      wildcard  = "0.0.0.0"
+    }
+  ]
+  distance_bgp_external = 20
+  distance_bgp_internal = 200
+  distance_bgp_local    = 200
 }

--- a/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
+++ b/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
@@ -29,6 +29,16 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
           backdoor  = true
         }
       ]
+      admin_distances = [
+        {
+          distance  = 200
+          source_ip = "10.1.1.1"
+          wildcard  = "0.0.0.0"
+        }
+      ]
+      distance_bgp_external = 20
+      distance_bgp_internal = 200
+      distance_bgp_local    = 200
     }
   ]
 }

--- a/gen/definitions/bgp_address_family_ipv4.yaml
+++ b/gen/definitions/bgp_address_family_ipv4.yaml
@@ -52,6 +52,34 @@ attributes:
         example: RM1
       - yang_name: backdoor
         example: true
+  - yang_name: ipv4-unicast/distance/adm-distance
+    tf_name: admin_distances
+    type: List
+    attributes:
+      - yang_name: distance
+        id: true
+        example: 200
+      - yang_name: srcip
+        tf_name: source_ip
+        id: true
+        example: 10.1.1.1
+      - yang_name: wildbits
+        tf_name: wildcard
+        id: true
+        example: 0.0.0.0
+      - yang_name: acl
+        example: 100
+        exclude_test: true
+  - yang_name: ipv4-unicast/distance/bgp/extern-as
+    tf_name: distance_bgp_external
+    example: 20
+  - yang_name: ipv4-unicast/distance/bgp/internal-as
+    tf_name: distance_bgp_internal
+    example: 200
+  - yang_name: ipv4-unicast/distance/bgp/local
+    tf_name: distance_bgp_local
+    example: 200
+
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-bgp:bgp=65000
     attributes:

--- a/gen/definitions/bgp_address_family_ipv4_vrf.yaml
+++ b/gen/definitions/bgp_address_family_ipv4_vrf.yaml
@@ -80,6 +80,34 @@ attributes:
             tf_name: evpn
             example: true
             exclude_test: true
+      - yang_name: ipv4-unicast/distance/adm-distance
+        tf_name: admin_distances
+        type: List
+        attributes:
+          - yang_name: distance
+            id: true
+            example: 200
+          - yang_name: srcip
+            tf_name: source_ip
+            id: true
+            example: 10.1.1.1
+          - yang_name: wildbits
+            tf_name: wildcard
+            id: true
+            example: 0.0.0.0
+          - yang_name: acl
+            example: 100
+            exclude_test: true
+      - yang_name: ipv4-unicast/distance/bgp/extern-as
+        tf_name: distance_bgp_external
+        example: 20
+      - yang_name: ipv4-unicast/distance/bgp/internal-as
+        tf_name: distance_bgp_internal
+        example: 200
+      - yang_name: ipv4-unicast/distance/bgp/local
+        tf_name: distance_bgp_local
+        example: 200
+
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1
     no_delete: true

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4.go
@@ -143,6 +143,42 @@ func (d *BGPAddressFamilyIPv4DataSource) Schema(ctx context.Context, req datasou
 					},
 				},
 			},
+			"admin_distances": schema.ListNestedAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"distance": schema.Int64Attribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+						"wildcard": schema.StringAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+						"acl": schema.StringAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"distance_bgp_external": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"distance_bgp_internal": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"distance_bgp_local": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_test.go
@@ -43,6 +43,12 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv4(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.network", "13.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.route_map", "RM1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.backdoor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "admin_distances.0.distance", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "admin_distances.0.source_ip", "10.1.1.1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "admin_distances.0.wildcard", "0.0.0.0"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "distance_bgp_external", "20"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "distance_bgp_internal", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4.test", "distance_bgp_local", "200"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -94,6 +100,14 @@ func testAccDataSourceIosxeBGPAddressFamilyIPv4Config() string {
 	config += `		route_map = "RM1"` + "\n"
 	config += `		backdoor = true` + "\n"
 	config += `	}]` + "\n"
+	config += `	admin_distances = [{` + "\n"
+	config += `		distance = 200` + "\n"
+	config += `		source_ip = "10.1.1.1"` + "\n"
+	config += `		wildcard = "0.0.0.0"` + "\n"
+	config += `	}]` + "\n"
+	config += `	distance_bgp_external = 20` + "\n"
+	config += `	distance_bgp_internal = 200` + "\n"
+	config += `	distance_bgp_local = 200` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf.go
@@ -168,6 +168,42 @@ func (d *BGPAddressFamilyIPv4VRFDataSource) Schema(ctx context.Context, req data
 								},
 							},
 						},
+						"admin_distances": schema.ListNestedAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"distance": schema.Int64Attribute{
+										MarkdownDescription: "",
+										Computed:            true,
+									},
+									"source_ip": schema.StringAttribute{
+										MarkdownDescription: "",
+										Computed:            true,
+									},
+									"wildcard": schema.StringAttribute{
+										MarkdownDescription: "",
+										Computed:            true,
+									},
+									"acl": schema.StringAttribute{
+										MarkdownDescription: "",
+										Computed:            true,
+									},
+								},
+							},
+						},
+						"distance_bgp_external": schema.Int64Attribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+						"distance_bgp_internal": schema.Int64Attribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
+						"distance_bgp_local": schema.Int64Attribute{
+							MarkdownDescription: "",
+							Computed:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -46,6 +46,12 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.network", "13.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.route_map", "RM1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.backdoor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.distance", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.source_ip", "10.1.1.1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.wildcard", "0.0.0.0"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_external", "20"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_internal", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_local", "200"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -123,6 +129,14 @@ func testAccDataSourceIosxeBGPAddressFamilyIPv4VRFConfig() string {
 	config += `			route_map = "RM1"` + "\n"
 	config += `			backdoor = true` + "\n"
 	config += `		}]` + "\n"
+	config += `		admin_distances = [{` + "\n"
+	config += `			distance = 200` + "\n"
+	config += `			source_ip = "10.1.1.1"` + "\n"
+	config += `			wildcard = "0.0.0.0"` + "\n"
+	config += `		}]` + "\n"
+	config += `		distance_bgp_external = 20` + "\n"
+	config += `		distance_bgp_internal = 200` + "\n"
+	config += `		distance_bgp_local = 200` + "\n"
 	config += `	}]` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/model_iosxe_bgp_address_family_ipv4.go
+++ b/internal/provider/model_iosxe_bgp_address_family_ipv4.go
@@ -49,6 +49,10 @@ type BGPAddressFamilyIPv4 struct {
 	Ipv4UnicastAggregateAddresses    []BGPAddressFamilyIPv4Ipv4UnicastAggregateAddresses `tfsdk:"ipv4_unicast_aggregate_addresses"`
 	Ipv4UnicastNetworksMask          []BGPAddressFamilyIPv4Ipv4UnicastNetworksMask       `tfsdk:"ipv4_unicast_networks_mask"`
 	Ipv4UnicastNetworks              []BGPAddressFamilyIPv4Ipv4UnicastNetworks           `tfsdk:"ipv4_unicast_networks"`
+	AdminDistances                   []BGPAddressFamilyIPv4AdminDistances                `tfsdk:"admin_distances"`
+	DistanceBgpExternal              types.Int64                                         `tfsdk:"distance_bgp_external"`
+	DistanceBgpInternal              types.Int64                                         `tfsdk:"distance_bgp_internal"`
+	DistanceBgpLocal                 types.Int64                                         `tfsdk:"distance_bgp_local"`
 }
 
 type BGPAddressFamilyIPv4Data struct {
@@ -61,6 +65,10 @@ type BGPAddressFamilyIPv4Data struct {
 	Ipv4UnicastAggregateAddresses    []BGPAddressFamilyIPv4Ipv4UnicastAggregateAddresses `tfsdk:"ipv4_unicast_aggregate_addresses"`
 	Ipv4UnicastNetworksMask          []BGPAddressFamilyIPv4Ipv4UnicastNetworksMask       `tfsdk:"ipv4_unicast_networks_mask"`
 	Ipv4UnicastNetworks              []BGPAddressFamilyIPv4Ipv4UnicastNetworks           `tfsdk:"ipv4_unicast_networks"`
+	AdminDistances                   []BGPAddressFamilyIPv4AdminDistances                `tfsdk:"admin_distances"`
+	DistanceBgpExternal              types.Int64                                         `tfsdk:"distance_bgp_external"`
+	DistanceBgpInternal              types.Int64                                         `tfsdk:"distance_bgp_internal"`
+	DistanceBgpLocal                 types.Int64                                         `tfsdk:"distance_bgp_local"`
 }
 type BGPAddressFamilyIPv4Ipv4UnicastAggregateAddresses struct {
 	Ipv4Address types.String `tfsdk:"ipv4_address"`
@@ -76,6 +84,12 @@ type BGPAddressFamilyIPv4Ipv4UnicastNetworks struct {
 	Network  types.String `tfsdk:"network"`
 	RouteMap types.String `tfsdk:"route_map"`
 	Backdoor types.Bool   `tfsdk:"backdoor"`
+}
+type BGPAddressFamilyIPv4AdminDistances struct {
+	Distance types.Int64  `tfsdk:"distance"`
+	SourceIp types.String `tfsdk:"source_ip"`
+	Wildcard types.String `tfsdk:"wildcard"`
+	Acl      types.String `tfsdk:"acl"`
 }
 
 // End of section. //template:end types
@@ -120,6 +134,15 @@ func (data BGPAddressFamilyIPv4) toBody(ctx context.Context) string {
 			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.redistribute.static", map[string]string{})
 		}
 	}
+	if !data.DistanceBgpExternal.IsNull() && !data.DistanceBgpExternal.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.bgp.extern-as", strconv.FormatInt(data.DistanceBgpExternal.ValueInt64(), 10))
+	}
+	if !data.DistanceBgpInternal.IsNull() && !data.DistanceBgpInternal.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.bgp.internal-as", strconv.FormatInt(data.DistanceBgpInternal.ValueInt64(), 10))
+	}
+	if !data.DistanceBgpLocal.IsNull() && !data.DistanceBgpLocal.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.bgp.local", strconv.FormatInt(data.DistanceBgpLocal.ValueInt64(), 10))
+	}
 	if len(data.Ipv4UnicastAggregateAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.aggregate-address", []interface{}{})
 		for index, item := range data.Ipv4UnicastAggregateAddresses {
@@ -163,6 +186,23 @@ func (data BGPAddressFamilyIPv4) toBody(ctx context.Context) string {
 				if item.Backdoor.ValueBool() {
 					body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.network.no-mask"+"."+strconv.Itoa(index)+"."+"backdoor", map[string]string{})
 				}
+			}
+		}
+	}
+	if len(data.AdminDistances) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.adm-distance", []interface{}{})
+		for index, item := range data.AdminDistances {
+			if !item.Distance.IsNull() && !item.Distance.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(index)+"."+"distance", strconv.FormatInt(item.Distance.ValueInt64(), 10))
+			}
+			if !item.SourceIp.IsNull() && !item.SourceIp.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(index)+"."+"srcip", item.SourceIp.ValueString())
+			}
+			if !item.Wildcard.IsNull() && !item.Wildcard.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(index)+"."+"wildbits", item.Wildcard.ValueString())
+			}
+			if !item.Acl.IsNull() && !item.Acl.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(index)+"."+"acl", item.Acl.ValueString())
 			}
 		}
 	}
@@ -326,6 +366,65 @@ func (data *BGPAddressFamilyIPv4) updateFromBody(ctx context.Context, res gjson.
 			data.Ipv4UnicastNetworks[i].Backdoor = types.BoolNull()
 		}
 	}
+	for i := range data.AdminDistances {
+		keys := [...]string{"distance", "srcip", "wildbits"}
+		keyValues := [...]string{strconv.FormatInt(data.AdminDistances[i].Distance.ValueInt64(), 10), data.AdminDistances[i].SourceIp.ValueString(), data.AdminDistances[i].Wildcard.ValueString()}
+
+		var r gjson.Result
+		res.Get(prefix + "ipv4-unicast.distance.adm-distance").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("distance"); value.Exists() && !data.AdminDistances[i].Distance.IsNull() {
+			data.AdminDistances[i].Distance = types.Int64Value(value.Int())
+		} else {
+			data.AdminDistances[i].Distance = types.Int64Null()
+		}
+		if value := r.Get("srcip"); value.Exists() && !data.AdminDistances[i].SourceIp.IsNull() {
+			data.AdminDistances[i].SourceIp = types.StringValue(value.String())
+		} else {
+			data.AdminDistances[i].SourceIp = types.StringNull()
+		}
+		if value := r.Get("wildbits"); value.Exists() && !data.AdminDistances[i].Wildcard.IsNull() {
+			data.AdminDistances[i].Wildcard = types.StringValue(value.String())
+		} else {
+			data.AdminDistances[i].Wildcard = types.StringNull()
+		}
+		if value := r.Get("acl"); value.Exists() && !data.AdminDistances[i].Acl.IsNull() {
+			data.AdminDistances[i].Acl = types.StringValue(value.String())
+		} else {
+			data.AdminDistances[i].Acl = types.StringNull()
+		}
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.extern-as"); value.Exists() && !data.DistanceBgpExternal.IsNull() {
+		data.DistanceBgpExternal = types.Int64Value(value.Int())
+	} else {
+		data.DistanceBgpExternal = types.Int64Null()
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.internal-as"); value.Exists() && !data.DistanceBgpInternal.IsNull() {
+		data.DistanceBgpInternal = types.Int64Value(value.Int())
+	} else {
+		data.DistanceBgpInternal = types.Int64Null()
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.local"); value.Exists() && !data.DistanceBgpLocal.IsNull() {
+		data.DistanceBgpLocal = types.Int64Value(value.Int())
+	} else {
+		data.DistanceBgpLocal = types.Int64Null()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -401,6 +500,35 @@ func (data *BGPAddressFamilyIPv4) fromBody(ctx context.Context, res gjson.Result
 			data.Ipv4UnicastNetworks = append(data.Ipv4UnicastNetworks, item)
 			return true
 		})
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.adm-distance"); value.Exists() {
+		data.AdminDistances = make([]BGPAddressFamilyIPv4AdminDistances, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := BGPAddressFamilyIPv4AdminDistances{}
+			if cValue := v.Get("distance"); cValue.Exists() {
+				item.Distance = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("srcip"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("wildbits"); cValue.Exists() {
+				item.Wildcard = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("acl"); cValue.Exists() {
+				item.Acl = types.StringValue(cValue.String())
+			}
+			data.AdminDistances = append(data.AdminDistances, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.extern-as"); value.Exists() {
+		data.DistanceBgpExternal = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.internal-as"); value.Exists() {
+		data.DistanceBgpInternal = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.local"); value.Exists() {
+		data.DistanceBgpLocal = types.Int64Value(value.Int())
 	}
 }
 
@@ -478,6 +606,35 @@ func (data *BGPAddressFamilyIPv4Data) fromBody(ctx context.Context, res gjson.Re
 			return true
 		})
 	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.adm-distance"); value.Exists() {
+		data.AdminDistances = make([]BGPAddressFamilyIPv4AdminDistances, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := BGPAddressFamilyIPv4AdminDistances{}
+			if cValue := v.Get("distance"); cValue.Exists() {
+				item.Distance = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("srcip"); cValue.Exists() {
+				item.SourceIp = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("wildbits"); cValue.Exists() {
+				item.Wildcard = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("acl"); cValue.Exists() {
+				item.Acl = types.StringValue(cValue.String())
+			}
+			data.AdminDistances = append(data.AdminDistances, item)
+			return true
+		})
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.extern-as"); value.Exists() {
+		data.DistanceBgpExternal = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.internal-as"); value.Exists() {
+		data.DistanceBgpInternal = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ipv4-unicast.distance.bgp.local"); value.Exists() {
+		data.DistanceBgpLocal = types.Int64Value(value.Int())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -486,6 +643,55 @@ func (data *BGPAddressFamilyIPv4Data) fromBody(ctx context.Context, res gjson.Re
 
 func (data *BGPAddressFamilyIPv4) getDeletedItems(ctx context.Context, state BGPAddressFamilyIPv4) []string {
 	deletedItems := make([]string, 0)
+	if !state.DistanceBgpLocal.IsNull() && data.DistanceBgpLocal.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/local", state.getPath()))
+	}
+	if !state.DistanceBgpInternal.IsNull() && data.DistanceBgpInternal.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/internal-as", state.getPath()))
+	}
+	if !state.DistanceBgpExternal.IsNull() && data.DistanceBgpExternal.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/extern-as", state.getPath()))
+	}
+	for i := range state.AdminDistances {
+		stateKeyValues := [...]string{strconv.FormatInt(state.AdminDistances[i].Distance.ValueInt64(), 10), state.AdminDistances[i].SourceIp.ValueString(), state.AdminDistances[i].Wildcard.ValueString()}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.AdminDistances[i].Distance.ValueInt64()).IsZero() {
+			emptyKeys = false
+		}
+		if !reflect.ValueOf(state.AdminDistances[i].SourceIp.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if !reflect.ValueOf(state.AdminDistances[i].Wildcard.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.AdminDistances {
+			found = true
+			if state.AdminDistances[i].Distance.ValueInt64() != data.AdminDistances[j].Distance.ValueInt64() {
+				found = false
+			}
+			if state.AdminDistances[i].SourceIp.ValueString() != data.AdminDistances[j].SourceIp.ValueString() {
+				found = false
+			}
+			if state.AdminDistances[i].Wildcard.ValueString() != data.AdminDistances[j].Wildcard.ValueString() {
+				found = false
+			}
+			if found {
+				if !state.AdminDistances[i].Acl.IsNull() && data.AdminDistances[j].Acl.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv4-unicast/distance/adm-distance=%v/acl", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv4-unicast/distance/adm-distance=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
+	}
 	for i := range state.Ipv4UnicastNetworks {
 		stateKeyValues := [...]string{state.Ipv4UnicastNetworks[i].Network.ValueString()}
 
@@ -632,6 +838,20 @@ func (data *BGPAddressFamilyIPv4) getEmptyLeafsDelete(ctx context.Context) []str
 
 func (data *BGPAddressFamilyIPv4) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.DistanceBgpLocal.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/local", data.getPath()))
+	}
+	if !data.DistanceBgpInternal.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/internal-as", data.getPath()))
+	}
+	if !data.DistanceBgpExternal.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv4-unicast/distance/bgp/extern-as", data.getPath()))
+	}
+	for i := range data.AdminDistances {
+		keyValues := [...]string{strconv.FormatInt(data.AdminDistances[i].Distance.ValueInt64(), 10), data.AdminDistances[i].SourceIp.ValueString(), data.AdminDistances[i].Wildcard.ValueString()}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv4-unicast/distance/adm-distance=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
 	for i := range data.Ipv4UnicastNetworks {
 		keyValues := [...]string{data.Ipv4UnicastNetworks[i].Network.ValueString()}
 

--- a/internal/provider/model_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/model_iosxe_bgp_address_family_ipv4_vrf.go
@@ -63,6 +63,10 @@ type BGPAddressFamilyIPv4VRFVrfs struct {
 	Ipv4UnicastRedistributeStatic    types.Bool                                                 `tfsdk:"ipv4_unicast_redistribute_static"`
 	Ipv4UnicastNetworksMask          []BGPAddressFamilyIPv4VRFVrfsIpv4UnicastNetworksMask       `tfsdk:"ipv4_unicast_networks_mask"`
 	Ipv4UnicastNetworks              []BGPAddressFamilyIPv4VRFVrfsIpv4UnicastNetworks           `tfsdk:"ipv4_unicast_networks"`
+	AdminDistances                   []BGPAddressFamilyIPv4VRFVrfsAdminDistances                `tfsdk:"admin_distances"`
+	DistanceBgpExternal              types.Int64                                                `tfsdk:"distance_bgp_external"`
+	DistanceBgpInternal              types.Int64                                                `tfsdk:"distance_bgp_internal"`
+	DistanceBgpLocal                 types.Int64                                                `tfsdk:"distance_bgp_local"`
 }
 type BGPAddressFamilyIPv4VRFVrfsIpv4UnicastAggregateAddresses struct {
 	Ipv4Address types.String `tfsdk:"ipv4_address"`
@@ -80,6 +84,12 @@ type BGPAddressFamilyIPv4VRFVrfsIpv4UnicastNetworks struct {
 	RouteMap types.String `tfsdk:"route_map"`
 	Backdoor types.Bool   `tfsdk:"backdoor"`
 	Evpn     types.Bool   `tfsdk:"evpn"`
+}
+type BGPAddressFamilyIPv4VRFVrfsAdminDistances struct {
+	Distance types.Int64  `tfsdk:"distance"`
+	SourceIp types.String `tfsdk:"source_ip"`
+	Wildcard types.String `tfsdk:"wildcard"`
+	Acl      types.String `tfsdk:"acl"`
 }
 
 // End of section. //template:end types
@@ -138,6 +148,15 @@ func (data BGPAddressFamilyIPv4VRF) toBody(ctx context.Context) string {
 					body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.redistribute-vrf.static", map[string]string{})
 				}
 			}
+			if !item.DistanceBgpExternal.IsNull() && !item.DistanceBgpExternal.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.bgp.extern-as", strconv.FormatInt(item.DistanceBgpExternal.ValueInt64(), 10))
+			}
+			if !item.DistanceBgpInternal.IsNull() && !item.DistanceBgpInternal.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.bgp.internal-as", strconv.FormatInt(item.DistanceBgpInternal.ValueInt64(), 10))
+			}
+			if !item.DistanceBgpLocal.IsNull() && !item.DistanceBgpLocal.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.bgp.local", strconv.FormatInt(item.DistanceBgpLocal.ValueInt64(), 10))
+			}
 			if len(item.Ipv4UnicastAggregateAddresses) > 0 {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.aggregate-address", []interface{}{})
 				for cindex, citem := range item.Ipv4UnicastAggregateAddresses {
@@ -191,6 +210,23 @@ func (data BGPAddressFamilyIPv4VRF) toBody(ctx context.Context) string {
 						if citem.Evpn.ValueBool() {
 							body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.network.no-mask"+"."+strconv.Itoa(cindex)+"."+"evpn", map[string]string{})
 						}
+					}
+				}
+			}
+			if len(item.AdminDistances) > 0 {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.adm-distance", []interface{}{})
+				for cindex, citem := range item.AdminDistances {
+					if !citem.Distance.IsNull() && !citem.Distance.IsUnknown() {
+						body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(cindex)+"."+"distance", strconv.FormatInt(citem.Distance.ValueInt64(), 10))
+					}
+					if !citem.SourceIp.IsNull() && !citem.SourceIp.IsUnknown() {
+						body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(cindex)+"."+"srcip", citem.SourceIp.ValueString())
+					}
+					if !citem.Wildcard.IsNull() && !citem.Wildcard.IsUnknown() {
+						body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(cindex)+"."+"wildbits", citem.Wildcard.ValueString())
+					}
+					if !citem.Acl.IsNull() && !citem.Acl.IsUnknown() {
+						body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.distance.adm-distance"+"."+strconv.Itoa(cindex)+"."+"acl", citem.Acl.ValueString())
 					}
 				}
 			}
@@ -416,6 +452,65 @@ func (data *BGPAddressFamilyIPv4VRF) updateFromBody(ctx context.Context, res gjs
 				data.Vrfs[i].Ipv4UnicastNetworks[ci].Evpn = types.BoolNull()
 			}
 		}
+		for ci := range data.Vrfs[i].AdminDistances {
+			keys := [...]string{"distance", "srcip", "wildbits"}
+			keyValues := [...]string{strconv.FormatInt(data.Vrfs[i].AdminDistances[ci].Distance.ValueInt64(), 10), data.Vrfs[i].AdminDistances[ci].SourceIp.ValueString(), data.Vrfs[i].AdminDistances[ci].Wildcard.ValueString()}
+
+			var cr gjson.Result
+			r.Get("ipv4-unicast.distance.adm-distance").ForEach(
+				func(_, v gjson.Result) bool {
+					found := false
+					for ik := range keys {
+						if v.Get(keys[ik]).String() == keyValues[ik] {
+							found = true
+							continue
+						}
+						found = false
+						break
+					}
+					if found {
+						cr = v
+						return false
+					}
+					return true
+				},
+			)
+			if value := cr.Get("distance"); value.Exists() && !data.Vrfs[i].AdminDistances[ci].Distance.IsNull() {
+				data.Vrfs[i].AdminDistances[ci].Distance = types.Int64Value(value.Int())
+			} else {
+				data.Vrfs[i].AdminDistances[ci].Distance = types.Int64Null()
+			}
+			if value := cr.Get("srcip"); value.Exists() && !data.Vrfs[i].AdminDistances[ci].SourceIp.IsNull() {
+				data.Vrfs[i].AdminDistances[ci].SourceIp = types.StringValue(value.String())
+			} else {
+				data.Vrfs[i].AdminDistances[ci].SourceIp = types.StringNull()
+			}
+			if value := cr.Get("wildbits"); value.Exists() && !data.Vrfs[i].AdminDistances[ci].Wildcard.IsNull() {
+				data.Vrfs[i].AdminDistances[ci].Wildcard = types.StringValue(value.String())
+			} else {
+				data.Vrfs[i].AdminDistances[ci].Wildcard = types.StringNull()
+			}
+			if value := cr.Get("acl"); value.Exists() && !data.Vrfs[i].AdminDistances[ci].Acl.IsNull() {
+				data.Vrfs[i].AdminDistances[ci].Acl = types.StringValue(value.String())
+			} else {
+				data.Vrfs[i].AdminDistances[ci].Acl = types.StringNull()
+			}
+		}
+		if value := r.Get("ipv4-unicast.distance.bgp.extern-as"); value.Exists() && !data.Vrfs[i].DistanceBgpExternal.IsNull() {
+			data.Vrfs[i].DistanceBgpExternal = types.Int64Value(value.Int())
+		} else {
+			data.Vrfs[i].DistanceBgpExternal = types.Int64Null()
+		}
+		if value := r.Get("ipv4-unicast.distance.bgp.internal-as"); value.Exists() && !data.Vrfs[i].DistanceBgpInternal.IsNull() {
+			data.Vrfs[i].DistanceBgpInternal = types.Int64Value(value.Int())
+		} else {
+			data.Vrfs[i].DistanceBgpInternal = types.Int64Null()
+		}
+		if value := r.Get("ipv4-unicast.distance.bgp.local"); value.Exists() && !data.Vrfs[i].DistanceBgpLocal.IsNull() {
+			data.Vrfs[i].DistanceBgpLocal = types.Int64Value(value.Int())
+		} else {
+			data.Vrfs[i].DistanceBgpLocal = types.Int64Null()
+		}
 	}
 }
 
@@ -517,6 +612,35 @@ func (data *BGPAddressFamilyIPv4VRF) fromBody(ctx context.Context, res gjson.Res
 					item.Ipv4UnicastNetworks = append(item.Ipv4UnicastNetworks, cItem)
 					return true
 				})
+			}
+			if cValue := v.Get("ipv4-unicast.distance.adm-distance"); cValue.Exists() {
+				item.AdminDistances = make([]BGPAddressFamilyIPv4VRFVrfsAdminDistances, 0)
+				cValue.ForEach(func(ck, cv gjson.Result) bool {
+					cItem := BGPAddressFamilyIPv4VRFVrfsAdminDistances{}
+					if ccValue := cv.Get("distance"); ccValue.Exists() {
+						cItem.Distance = types.Int64Value(ccValue.Int())
+					}
+					if ccValue := cv.Get("srcip"); ccValue.Exists() {
+						cItem.SourceIp = types.StringValue(ccValue.String())
+					}
+					if ccValue := cv.Get("wildbits"); ccValue.Exists() {
+						cItem.Wildcard = types.StringValue(ccValue.String())
+					}
+					if ccValue := cv.Get("acl"); ccValue.Exists() {
+						cItem.Acl = types.StringValue(ccValue.String())
+					}
+					item.AdminDistances = append(item.AdminDistances, cItem)
+					return true
+				})
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.extern-as"); cValue.Exists() {
+				item.DistanceBgpExternal = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.internal-as"); cValue.Exists() {
+				item.DistanceBgpInternal = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.local"); cValue.Exists() {
+				item.DistanceBgpLocal = types.Int64Value(cValue.Int())
 			}
 			data.Vrfs = append(data.Vrfs, item)
 			return true
@@ -623,6 +747,35 @@ func (data *BGPAddressFamilyIPv4VRFData) fromBody(ctx context.Context, res gjson
 					return true
 				})
 			}
+			if cValue := v.Get("ipv4-unicast.distance.adm-distance"); cValue.Exists() {
+				item.AdminDistances = make([]BGPAddressFamilyIPv4VRFVrfsAdminDistances, 0)
+				cValue.ForEach(func(ck, cv gjson.Result) bool {
+					cItem := BGPAddressFamilyIPv4VRFVrfsAdminDistances{}
+					if ccValue := cv.Get("distance"); ccValue.Exists() {
+						cItem.Distance = types.Int64Value(ccValue.Int())
+					}
+					if ccValue := cv.Get("srcip"); ccValue.Exists() {
+						cItem.SourceIp = types.StringValue(ccValue.String())
+					}
+					if ccValue := cv.Get("wildbits"); ccValue.Exists() {
+						cItem.Wildcard = types.StringValue(ccValue.String())
+					}
+					if ccValue := cv.Get("acl"); ccValue.Exists() {
+						cItem.Acl = types.StringValue(ccValue.String())
+					}
+					item.AdminDistances = append(item.AdminDistances, cItem)
+					return true
+				})
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.extern-as"); cValue.Exists() {
+				item.DistanceBgpExternal = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.internal-as"); cValue.Exists() {
+				item.DistanceBgpInternal = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("ipv4-unicast.distance.bgp.local"); cValue.Exists() {
+				item.DistanceBgpLocal = types.Int64Value(cValue.Int())
+			}
 			data.Vrfs = append(data.Vrfs, item)
 			return true
 		})
@@ -653,6 +806,55 @@ func (data *BGPAddressFamilyIPv4VRF) getDeletedItems(ctx context.Context, state 
 				found = false
 			}
 			if found {
+				if !state.Vrfs[i].DistanceBgpLocal.IsNull() && data.Vrfs[j].DistanceBgpLocal.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/distance/bgp/local", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.Vrfs[i].DistanceBgpInternal.IsNull() && data.Vrfs[j].DistanceBgpInternal.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/distance/bgp/internal-as", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.Vrfs[i].DistanceBgpExternal.IsNull() && data.Vrfs[j].DistanceBgpExternal.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/distance/bgp/extern-as", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				for ci := range state.Vrfs[i].AdminDistances {
+					cstateKeyValues := [...]string{strconv.FormatInt(state.Vrfs[i].AdminDistances[ci].Distance.ValueInt64(), 10), state.Vrfs[i].AdminDistances[ci].SourceIp.ValueString(), state.Vrfs[i].AdminDistances[ci].Wildcard.ValueString()}
+
+					cemptyKeys := true
+					if !reflect.ValueOf(state.Vrfs[i].AdminDistances[ci].Distance.ValueInt64()).IsZero() {
+						cemptyKeys = false
+					}
+					if !reflect.ValueOf(state.Vrfs[i].AdminDistances[ci].SourceIp.ValueString()).IsZero() {
+						cemptyKeys = false
+					}
+					if !reflect.ValueOf(state.Vrfs[i].AdminDistances[ci].Wildcard.ValueString()).IsZero() {
+						cemptyKeys = false
+					}
+					if cemptyKeys {
+						continue
+					}
+
+					found := false
+					for cj := range data.Vrfs[j].AdminDistances {
+						found = true
+						if state.Vrfs[i].AdminDistances[ci].Distance.ValueInt64() != data.Vrfs[j].AdminDistances[cj].Distance.ValueInt64() {
+							found = false
+						}
+						if state.Vrfs[i].AdminDistances[ci].SourceIp.ValueString() != data.Vrfs[j].AdminDistances[cj].SourceIp.ValueString() {
+							found = false
+						}
+						if state.Vrfs[i].AdminDistances[ci].Wildcard.ValueString() != data.Vrfs[j].AdminDistances[cj].Wildcard.ValueString() {
+							found = false
+						}
+						if found {
+							if !state.Vrfs[i].AdminDistances[ci].Acl.IsNull() && data.Vrfs[j].AdminDistances[cj].Acl.IsNull() {
+								deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/distance/adm-distance=%v/acl", state.getPath(), strings.Join(stateKeyValues[:], ","), strings.Join(cstateKeyValues[:], ",")))
+							}
+							break
+						}
+					}
+					if !found {
+						deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/distance/adm-distance=%v", state.getPath(), strings.Join(stateKeyValues[:], ","), strings.Join(cstateKeyValues[:], ",")))
+					}
+				}
 				for ci := range state.Vrfs[i].Ipv4UnicastNetworks {
 					cstateKeyValues := [...]string{state.Vrfs[i].Ipv4UnicastNetworks[ci].Network.ValueString()}
 

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -183,6 +184,60 @@ func (r *BGPAddressFamilyIPv4Resource) Schema(ctx context.Context, req resource.
 							Optional:            true,
 						},
 					},
+				},
+			},
+			"admin_distances": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"distance": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+							Required:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 255),
+							},
+						},
+						"source_ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"wildcard": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
+						"acl": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							Optional:            true,
+						},
+					},
+				},
+			},
+			"distance_bgp_external": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 255),
+				},
+			},
+			"distance_bgp_internal": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 255),
+				},
+			},
+			"distance_bgp_local": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 255),
 				},
 			},
 		},

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_test.go
@@ -46,6 +46,12 @@ func TestAccIosxeBGPAddressFamilyIPv4(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.network", "13.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.route_map", "RM1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "ipv4_unicast_networks.0.backdoor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "admin_distances.0.distance", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "admin_distances.0.source_ip", "10.1.1.1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "admin_distances.0.wildcard", "0.0.0.0"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "distance_bgp_external", "20"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "distance_bgp_internal", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4.test", "distance_bgp_local", "200"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -134,6 +140,14 @@ func testAccIosxeBGPAddressFamilyIPv4Config_all() string {
 	config += `		route_map = "RM1"` + "\n"
 	config += `		backdoor = true` + "\n"
 	config += `	}]` + "\n"
+	config += `	admin_distances = [{` + "\n"
+	config += `		distance = 200` + "\n"
+	config += `		source_ip = "10.1.1.1"` + "\n"
+	config += `		wildcard = "0.0.0.0"` + "\n"
+	config += `	}]` + "\n"
+	config += `	distance_bgp_external = 20` + "\n"
+	config += `	distance_bgp_internal = 200` + "\n"
+	config += `	distance_bgp_local = 200` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf.go
@@ -214,6 +214,60 @@ func (r *BGPAddressFamilyIPv4VRFResource) Schema(ctx context.Context, req resour
 								},
 							},
 						},
+						"admin_distances": schema.ListNestedAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							Optional:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"distance": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+										Required:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 255),
+										},
+									},
+									"source_ip": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("").String,
+										Required:            true,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+										},
+									},
+									"wildcard": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("").String,
+										Required:            true,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+										},
+									},
+									"acl": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("").String,
+										Optional:            true,
+									},
+								},
+							},
+						},
+						"distance_bgp_external": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 255),
+							},
+						},
+						"distance_bgp_internal": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 255),
+							},
+						},
+						"distance_bgp_local": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 255).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 255),
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -49,6 +49,12 @@ func TestAccIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.network", "13.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.route_map", "RM1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_networks.0.backdoor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.distance", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.source_ip", "10.1.1.1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.admin_distances.0.wildcard", "0.0.0.0"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_external", "20"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_internal", "200"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.distance_bgp_local", "200"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -160,6 +166,14 @@ func testAccIosxeBGPAddressFamilyIPv4VRFConfig_all() string {
 	config += `			route_map = "RM1"` + "\n"
 	config += `			backdoor = true` + "\n"
 	config += `		}]` + "\n"
+	config += `		admin_distances = [{` + "\n"
+	config += `			distance = 200` + "\n"
+	config += `			source_ip = "10.1.1.1"` + "\n"
+	config += `			wildcard = "0.0.0.0"` + "\n"
+	config += `		}]` + "\n"
+	config += `		distance_bgp_external = 20` + "\n"
+	config += `		distance_bgp_internal = 200` + "\n"
+	config += `		distance_bgp_local = 200` + "\n"
 	config += `	}]` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, iosxe_restconf.PreReq2, ]` + "\n"
 	config += `}` + "\n"

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -28,6 +28,7 @@ description: |-
 - Add `cdp_enable`, `cdp_tlv_app`, `cdp_tlv_location`, `cdp_tlv_server_location`, `ip_nat_inside`, and `ip_nat_outside` attributes to `iosxe_interface_ethernet` resource and data source
 - Add `negotiation_auto` attribute to `iosxe_interface_port_channel` resource and data source
 - Add `ip_hosts`, `ip_hosts_vrf`, `name`, `ips`, `vrf`, `hosts`, `subscriber_templating`, `call_home_contact_email`, `call_home_cisco_tac_1_profile_active`, `call_home_cisco_tac_1_destination_transport_method`, `ip_ftp_passive`, `tftp_source_interface_gigabit_ethernet`, `tftp_source_interface_loopback`, `version`, and `multilink_ppp_bundle_name` attributes to `iosxe_system` resource and data source
+- Add `admin_distances`, `distance_bgp_external`, `distance_bgp_internal`, `distance_bgp_local`, `distance`, `source_ip`, `wildcard`, and `acl` attributes to `iosxe_iosxe_bgp_address_family_ipv4` and `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
 
 ## 0.7.1
 


### PR DESCRIPTION
Add `admin_distances`, `distance_bgp_external`, `distance_bgp_internal`, `distance_bgp_local`, `distance`, `source_ip`, `wildcard`, and `acl` attributes to `iosxe_iosxe_bgp_address_family_ipv4` and `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source