### PR TITLE
Added more commands to `iosxe_system` and `iosxe_dot1x` resrouce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Add `iosxe_sla` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
-- Add `track_objects` attribute to `iosxe_system` resource and data source
+- Add `track_objects`, `ip_domain_list_names`, `ip_domain_list_vrf_domain`, `ip_domain_list_vrf`, `ethernet_cfm_alarm_config_delay`, `ethernet_cfm_alarm_config_reset`, `standby_redirects_enable_disable`, `standby_redirects`, and `security_passwords_min_length` attribute to `iosxe_system` resource and data source
+- Add `guest_vlan_supplicant`, `critical_eapol`, and `critical_eapol_block` attributes to `iosxe_dot1x` resource and data source
 
 ## 0.8.0
 

--- a/docs/data-sources/dot1x.md
+++ b/docs/data-sources/dot1x.md
@@ -28,8 +28,11 @@ data "iosxe_dot1x" "example" {
 
 - `auth_fail_eapol` (Boolean) Send EAPOL-Success on successful auth-fail Authorization
 - `credentials` (Attributes List) Configure 802.1X credentials profiles (see [below for nested schema](#nestedatt--credentials))
+- `critical_eapol` (Boolean) Send EAPOL-Success on successful Critical Authentication
+- `critical_eapol_block` (Boolean) Block all EAPoL transaction on Critical Authentication
 - `critical_eapol_config_block` (Boolean) Block all EAPoL transaction on Critical Authentication
 - `critical_recovery_delay` (Number) Set 802.1x Critical Authentication Recovery Delay period
+- `guest_vlan_supplicant` (Boolean) Allow 802.1x capable supplicants to enter Guest Vlan
 - `id` (String) The path of the retrieved object.
 - `logging_verbose` (Boolean) Show verbose messages in system logs
 - `supplicant_controlled_transient` (Boolean) Controlled access is only applied during authentication

--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -46,9 +46,14 @@ data "iosxe_system" "example" {
 - `enable_secret_level` (Number) Set exec level password
 - `enable_secret_type` (String)
 - `epm_logging` (Boolean) Enable EPM logging
+- `ethernet_cfm_alarm_config_delay` (Number) msec (default 2500 msec)
+- `ethernet_cfm_alarm_config_reset` (Number) msec (default 10000 msec)
 - `hostname` (String) Set system's network name
 - `id` (String) The path of the retrieved object.
 - `ip_bgp_community_new_format` (Boolean) select aa:nn format for BGP community
+- `ip_domain_list_names` (List of String)
+- `ip_domain_list_vrf` (String)
+- `ip_domain_list_vrf_domain` (String)
 - `ip_domain_lookup` (Boolean) Enable IP Domain Name System hostname translation
 - `ip_domain_lookup_source_interface_five_gigabit_ethernet` (String) Five GigabitEthernet
 - `ip_domain_lookup_source_interface_forty_gigabit_ethernet` (String) Forty GigabitEthernet
@@ -134,6 +139,9 @@ data "iosxe_system" "example" {
 - `pnp_profiles` (Attributes List) PNP profile (see [below for nested schema](#nestedatt--pnp_profiles))
 - `redundancy` (Boolean) Enter redundancy mode
 - `redundancy_mode` (String) redundancy mode for this chassis
+- `security_passwords_min_length` (Number) Minimum length of passwords
+- `standby_redirects` (Boolean)
+- `standby_redirects_enable_disable` (String)
 - `subscriber_templating` (Boolean) Configure subscriber templating
 - `tftp_source_interface_gigabit_ethernet` (String) GigabitEthernet IEEE 802.3z
 - `tftp_source_interface_loopback` (Number) Loopback interface

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -18,7 +18,8 @@ description: |-
 - Add `iosxe_sla` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
-- Add `track_objects` attribute to `iosxe_system` resource and data source
+- Add `track_objects`, `ip_domain_list_names`, `ip_domain_list_vrf_domain`, `ip_domain_list_vrf`, `ethernet_cfm_alarm_config_delay`, `ethernet_cfm_alarm_config_reset`, `standby_redirects_enable_disable`, `standby_redirects`, and `security_passwords_min_length` attribute to `iosxe_system` resource and data source
+- Add `guest_vlan_supplicant`, `critical_eapol`, and `critical_eapol_block` attributes to `iosxe_dot1x` resource and data source
 
 ## 0.8.0
 

--- a/docs/resources/dot1x.md
+++ b/docs/resources/dot1x.md
@@ -32,6 +32,7 @@ resource "iosxe_dot1x" "example" {
   supplicant_controlled_transient = true
   supplicant_force_multicast      = true
   system_auth_control             = true
+  guest_vlan_supplicant           = true
 }
 ```
 
@@ -42,12 +43,15 @@ resource "iosxe_dot1x" "example" {
 
 - `auth_fail_eapol` (Boolean) Send EAPOL-Success on successful auth-fail Authorization
 - `credentials` (Attributes List) Configure 802.1X credentials profiles (see [below for nested schema](#nestedatt--credentials))
+- `critical_eapol` (Boolean) Send EAPOL-Success on successful Critical Authentication
+- `critical_eapol_block` (Boolean) Block all EAPoL transaction on Critical Authentication
 - `critical_eapol_config_block` (Boolean) Block all EAPoL transaction on Critical Authentication
 - `critical_recovery_delay` (Number) Set 802.1x Critical Authentication Recovery Delay period
   - Range: `1`-`10000`
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
+- `guest_vlan_supplicant` (Boolean) Allow 802.1x capable supplicants to enter Guest Vlan
 - `logging_verbose` (Boolean) Show verbose messages in system logs
 - `supplicant_controlled_transient` (Boolean) Controlled access is only applied during authentication
 - `supplicant_force_multicast` (Boolean) Force 802.1X supplicant to send multicast packets

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -44,6 +44,8 @@ resource "iosxe_system" "example" {
   call_home_cisco_tac_1_profile_active               = true
   call_home_cisco_tac_1_destination_transport_method = "email"
   ip_nbar_classification_dns_classify_by_domain      = true
+  ip_domain_list_vrf_domain                          = "example.com"
+  ip_domain_list_vrf                                 = "VRF1"
 }
 ```
 
@@ -80,8 +82,15 @@ resource "iosxe_system" "example" {
   - Range: `0`-`255`
 - `enable_secret_type` (String) - Choices: `0`, `4`, `5`, `8`, `9`
 - `epm_logging` (Boolean) Enable EPM logging
+- `ethernet_cfm_alarm_config_delay` (Number) msec (default 2500 msec)
+  - Range: `2500`-`10000`
+- `ethernet_cfm_alarm_config_reset` (Number) msec (default 10000 msec)
+  - Range: `2500`-`10000`
 - `hostname` (String) Set system's network name
 - `ip_bgp_community_new_format` (Boolean) select aa:nn format for BGP community
+- `ip_domain_list_names` (List of String)
+- `ip_domain_list_vrf` (String)
+- `ip_domain_list_vrf_domain` (String)
 - `ip_domain_lookup` (Boolean) Enable IP Domain Name System hostname translation
 - `ip_domain_lookup_source_interface_five_gigabit_ethernet` (String) Five GigabitEthernet
 - `ip_domain_lookup_source_interface_forty_gigabit_ethernet` (String) Forty GigabitEthernet
@@ -186,6 +195,10 @@ resource "iosxe_system" "example" {
 - `redundancy` (Boolean) Enter redundancy mode
 - `redundancy_mode` (String) redundancy mode for this chassis
   - Choices: `none`, `rpr`, `rpr-plus`, `sso`
+- `security_passwords_min_length` (Number) Minimum length of passwords
+  - Range: `1`-`16`
+- `standby_redirects` (Boolean)
+- `standby_redirects_enable_disable` (String) - Choices: `disable`, `enable`
 - `subscriber_templating` (Boolean) Configure subscriber templating
 - `tftp_source_interface_gigabit_ethernet` (String) GigabitEthernet IEEE 802.3z
 - `tftp_source_interface_loopback` (Number) Loopback interface

--- a/examples/resources/iosxe_dot1x/resource.tf
+++ b/examples/resources/iosxe_dot1x/resource.tf
@@ -17,4 +17,5 @@ resource "iosxe_dot1x" "example" {
   supplicant_controlled_transient = true
   supplicant_force_multicast      = true
   system_auth_control             = true
+  guest_vlan_supplicant           = true
 }

--- a/examples/resources/iosxe_system/resource.tf
+++ b/examples/resources/iosxe_system/resource.tf
@@ -29,4 +29,6 @@ resource "iosxe_system" "example" {
   call_home_cisco_tac_1_profile_active               = true
   call_home_cisco_tac_1_destination_transport_method = "email"
   ip_nbar_classification_dns_classify_by_domain      = true
+  ip_domain_list_vrf_domain                          = "example.com"
+  ip_domain_list_vrf                                 = "VRF1"
 }

--- a/gen/definitions/dot1x.yaml
+++ b/gen/definitions/dot1x.yaml
@@ -40,3 +40,13 @@ attributes:
     example: true
   - yang_name: Cisco-IOS-XE-dot1x:system-auth-control
     example: true
+  - yang_name: Cisco-IOS-XE-dot1x:guest-vlan/supplicant
+    example: true
+  - yang_name: Cisco-IOS-XE-dot1x:critical/eapol-config
+    tf_name: critical_eapol
+    example: true
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-dot1x:critical/eapol-config/block
+    tf_name: critical_eapol_block
+    example: true
+    exclude_test: true

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -492,7 +492,6 @@ attributes:
     example: true
     exclude_test: true
 
-
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1
     no_delete: true

--- a/gen/definitions/system.yaml
+++ b/gen/definitions/system.yaml
@@ -517,6 +517,36 @@ attributes:
   - yang_name: ip/Cisco-IOS-XE-nbar:nbar/classification/dns/classify-by-domain-with-default
     tf_name: ip_nbar_classification_dns_classify_by_domain
     example: true
+  - yang_name: Cisco-IOS-XE-aaa:security/passwords/min-length
+    tf_name: security_passwords_min_length
+    example: 8
+    exclude_test: true
+  - yang_name: ip/domain/list/domain-name
+    tf_name: ip_domain_list_names
+    example: example.com
+    exclude_test: true
+  - yang_name: ip/domain/list/vrf/domain-name
+    tf_name: ip_domain_list_vrf_domain
+    example: example.com
+  - yang_name: ip/domain/list/vrf/vrf-name
+    tf_name: ip_domain_list_vrf
+    example: VRF1
+  - yang_name: ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/delay
+    example: 2600
+    exclude_test: true
+  - yang_name: ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/reset
+    example: 10000
+    exclude_test: true
+  - yang_name: standby/redirects-config/redirect_choice/redirects/redirects
+    xpath: standby/redirects-config/redirects
+    tf_name: standby_redirects
+    example: true
+    exclude_test: true
+  - yang_name: standby/redirects-config/redirect_choice/redirect-enable-disable/redirect-enable-disable/redirects
+    xpath: standby/redirects-config/redirect-enable-disable/redirects
+    tf_name: standby_redirects_enable_disable
+    example: false
+    exclude_test: true
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/internal/provider/data_source_iosxe_dot1x.go
+++ b/internal/provider/data_source_iosxe_dot1x.go
@@ -135,6 +135,18 @@ func (d *Dot1xDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				MarkdownDescription: "Enable or Disable SysAuthControl",
 				Computed:            true,
 			},
+			"guest_vlan_supplicant": schema.BoolAttribute{
+				MarkdownDescription: "Allow 802.1x capable supplicants to enter Guest Vlan",
+				Computed:            true,
+			},
+			"critical_eapol": schema.BoolAttribute{
+				MarkdownDescription: "Send EAPOL-Success on successful Critical Authentication",
+				Computed:            true,
+			},
+			"critical_eapol_block": schema.BoolAttribute{
+				MarkdownDescription: "Block all EAPoL transaction on Critical Authentication",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_dot1x_test.go
+++ b/internal/provider/data_source_iosxe_dot1x_test.go
@@ -46,6 +46,7 @@ func TestAccDataSourceIosxeDot1x(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_dot1x.test", "supplicant_controlled_transient", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_dot1x.test", "supplicant_force_multicast", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_dot1x.test", "system_auth_control", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_dot1x.test", "guest_vlan_supplicant", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -84,6 +85,7 @@ func testAccDataSourceIosxeDot1xConfig() string {
 	config += `	supplicant_controlled_transient = true` + "\n"
 	config += `	supplicant_force_multicast = true` + "\n"
 	config += `	system_auth_control = true` + "\n"
+	config += `	guest_vlan_supplicant = true` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/data_source_iosxe_system.go
+++ b/internal/provider/data_source_iosxe_system.go
@@ -643,6 +643,39 @@ func (d *SystemDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "dns classification by domain",
 				Computed:            true,
 			},
+			"security_passwords_min_length": schema.Int64Attribute{
+				MarkdownDescription: "Minimum length of passwords",
+				Computed:            true,
+			},
+			"ip_domain_list_names": schema.ListAttribute{
+				MarkdownDescription: "",
+				ElementType:         types.StringType,
+				Computed:            true,
+			},
+			"ip_domain_list_vrf_domain": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"ip_domain_list_vrf": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"ethernet_cfm_alarm_config_delay": schema.Int64Attribute{
+				MarkdownDescription: "msec (default 2500 msec)",
+				Computed:            true,
+			},
+			"ethernet_cfm_alarm_config_reset": schema.Int64Attribute{
+				MarkdownDescription: "msec (default 10000 msec)",
+				Computed:            true,
+			},
+			"standby_redirects": schema.BoolAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"standby_redirects_enable_disable": schema.StringAttribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_system_test.go
+++ b/internal/provider/data_source_iosxe_system_test.go
@@ -74,6 +74,8 @@ func TestAccDataSourceIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "call_home_cisco_tac_1_profile_active", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "call_home_cisco_tac_1_destination_transport_method", "email"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_nbar_classification_dns_classify_by_domain", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_list_vrf_domain", "example.com"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_list_vrf", "VRF1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -154,6 +156,8 @@ func testAccDataSourceIosxeSystemConfig() string {
 	config += `	call_home_cisco_tac_1_profile_active = true` + "\n"
 	config += `	call_home_cisco_tac_1_destination_transport_method = "email"` + "\n"
 	config += `	ip_nbar_classification_dns_classify_by_domain = true` + "\n"
+	config += `	ip_domain_list_vrf_domain = "example.com"` + "\n"
+	config += `	ip_domain_list_vrf = "VRF1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_dot1x.go
+++ b/internal/provider/model_iosxe_dot1x.go
@@ -50,6 +50,9 @@ type Dot1x struct {
 	SupplicantControlledTransient types.Bool         `tfsdk:"supplicant_controlled_transient"`
 	SupplicantForceMulticast      types.Bool         `tfsdk:"supplicant_force_multicast"`
 	SystemAuthControl             types.Bool         `tfsdk:"system_auth_control"`
+	GuestVlanSupplicant           types.Bool         `tfsdk:"guest_vlan_supplicant"`
+	CriticalEapol                 types.Bool         `tfsdk:"critical_eapol"`
+	CriticalEapolBlock            types.Bool         `tfsdk:"critical_eapol_block"`
 }
 
 type Dot1xData struct {
@@ -64,6 +67,9 @@ type Dot1xData struct {
 	SupplicantControlledTransient types.Bool         `tfsdk:"supplicant_controlled_transient"`
 	SupplicantForceMulticast      types.Bool         `tfsdk:"supplicant_force_multicast"`
 	SystemAuthControl             types.Bool         `tfsdk:"system_auth_control"`
+	GuestVlanSupplicant           types.Bool         `tfsdk:"guest_vlan_supplicant"`
+	CriticalEapol                 types.Bool         `tfsdk:"critical_eapol"`
+	CriticalEapolBlock            types.Bool         `tfsdk:"critical_eapol_block"`
 }
 type Dot1xCredentials struct {
 	ProfileName   types.String `tfsdk:"profile_name"`
@@ -138,6 +144,21 @@ func (data Dot1x) toBody(ctx context.Context) string {
 	if !data.SystemAuthControl.IsNull() && !data.SystemAuthControl.IsUnknown() {
 		if data.SystemAuthControl.ValueBool() {
 			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-dot1x:system-auth-control", map[string]string{})
+		}
+	}
+	if !data.GuestVlanSupplicant.IsNull() && !data.GuestVlanSupplicant.IsUnknown() {
+		if data.GuestVlanSupplicant.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-dot1x:guest-vlan.supplicant", map[string]string{})
+		}
+	}
+	if !data.CriticalEapol.IsNull() && !data.CriticalEapol.IsUnknown() {
+		if data.CriticalEapol.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-dot1x:critical.eapol-config", map[string]string{})
+		}
+	}
+	if !data.CriticalEapolBlock.IsNull() && !data.CriticalEapolBlock.IsUnknown() {
+		if data.CriticalEapolBlock.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-dot1x:critical.eapol-config.block", map[string]string{})
 		}
 	}
 	if len(data.Credentials) > 0 {
@@ -301,6 +322,33 @@ func (data *Dot1x) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.SystemAuthControl = types.BoolNull()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:guest-vlan.supplicant"); !data.GuestVlanSupplicant.IsNull() {
+		if value.Exists() {
+			data.GuestVlanSupplicant = types.BoolValue(true)
+		} else {
+			data.GuestVlanSupplicant = types.BoolValue(false)
+		}
+	} else {
+		data.GuestVlanSupplicant = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config"); !data.CriticalEapol.IsNull() {
+		if value.Exists() {
+			data.CriticalEapol = types.BoolValue(true)
+		} else {
+			data.CriticalEapol = types.BoolValue(false)
+		}
+	} else {
+		data.CriticalEapol = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config.block"); !data.CriticalEapolBlock.IsNull() {
+		if value.Exists() {
+			data.CriticalEapolBlock = types.BoolValue(true)
+		} else {
+			data.CriticalEapolBlock = types.BoolValue(false)
+		}
+	} else {
+		data.CriticalEapolBlock = types.BoolNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -376,6 +424,21 @@ func (data *Dot1x) fromBody(ctx context.Context, res gjson.Result) {
 		data.SystemAuthControl = types.BoolValue(true)
 	} else {
 		data.SystemAuthControl = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:guest-vlan.supplicant"); value.Exists() {
+		data.GuestVlanSupplicant = types.BoolValue(true)
+	} else {
+		data.GuestVlanSupplicant = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config"); value.Exists() {
+		data.CriticalEapol = types.BoolValue(true)
+	} else {
+		data.CriticalEapol = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config.block"); value.Exists() {
+		data.CriticalEapolBlock = types.BoolValue(true)
+	} else {
+		data.CriticalEapolBlock = types.BoolValue(false)
 	}
 }
 
@@ -453,6 +516,21 @@ func (data *Dot1xData) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.SystemAuthControl = types.BoolValue(false)
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:guest-vlan.supplicant"); value.Exists() {
+		data.GuestVlanSupplicant = types.BoolValue(true)
+	} else {
+		data.GuestVlanSupplicant = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config"); value.Exists() {
+		data.CriticalEapol = types.BoolValue(true)
+	} else {
+		data.CriticalEapol = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-dot1x:critical.eapol-config.block"); value.Exists() {
+		data.CriticalEapolBlock = types.BoolValue(true)
+	} else {
+		data.CriticalEapolBlock = types.BoolValue(false)
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -461,6 +539,15 @@ func (data *Dot1xData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *Dot1x) getDeletedItems(ctx context.Context, state Dot1x) []string {
 	deletedItems := make([]string, 0)
+	if !state.CriticalEapolBlock.IsNull() && data.CriticalEapolBlock.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config/block", state.getPath()))
+	}
+	if !state.CriticalEapol.IsNull() && data.CriticalEapol.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config", state.getPath()))
+	}
+	if !state.GuestVlanSupplicant.IsNull() && data.GuestVlanSupplicant.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:guest-vlan/supplicant", state.getPath()))
+	}
 	if !state.SystemAuthControl.IsNull() && data.SystemAuthControl.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:system-auth-control", state.getPath()))
 	}
@@ -538,6 +625,15 @@ func (data *Dot1x) getDeletedItems(ctx context.Context, state Dot1x) []string {
 
 func (data *Dot1x) getEmptyLeafsDelete(ctx context.Context) []string {
 	emptyLeafsDelete := make([]string, 0)
+	if !data.CriticalEapolBlock.IsNull() && !data.CriticalEapolBlock.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config/block", data.getPath()))
+	}
+	if !data.CriticalEapol.IsNull() && !data.CriticalEapol.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config", data.getPath()))
+	}
+	if !data.GuestVlanSupplicant.IsNull() && !data.GuestVlanSupplicant.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:guest-vlan/supplicant", data.getPath()))
+	}
 	if !data.SystemAuthControl.IsNull() && !data.SystemAuthControl.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:system-auth-control", data.getPath()))
 	}
@@ -567,6 +663,15 @@ func (data *Dot1x) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *Dot1x) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.CriticalEapolBlock.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config/block", data.getPath()))
+	}
+	if !data.CriticalEapol.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:critical/eapol-config", data.getPath()))
+	}
+	if !data.GuestVlanSupplicant.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:guest-vlan/supplicant", data.getPath()))
+	}
 	if !data.SystemAuthControl.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-dot1x:system-auth-control", data.getPath()))
 	}

--- a/internal/provider/model_iosxe_system.go
+++ b/internal/provider/model_iosxe_system.go
@@ -153,6 +153,14 @@ type System struct {
 	Version                                                types.String                                        `tfsdk:"version"`
 	TrackObjects                                           []SystemTrackObjects                                `tfsdk:"track_objects"`
 	IpNbarClassificationDnsClassifyByDomain                types.Bool                                          `tfsdk:"ip_nbar_classification_dns_classify_by_domain"`
+	SecurityPasswordsMinLength                             types.Int64                                         `tfsdk:"security_passwords_min_length"`
+	IpDomainListNames                                      types.List                                          `tfsdk:"ip_domain_list_names"`
+	IpDomainListVrfDomain                                  types.String                                        `tfsdk:"ip_domain_list_vrf_domain"`
+	IpDomainListVrf                                        types.String                                        `tfsdk:"ip_domain_list_vrf"`
+	EthernetCfmAlarmConfigDelay                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_delay"`
+	EthernetCfmAlarmConfigReset                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_reset"`
+	StandbyRedirects                                       types.Bool                                          `tfsdk:"standby_redirects"`
+	StandbyRedirectsEnableDisable                          types.String                                        `tfsdk:"standby_redirects_enable_disable"`
 }
 
 type SystemData struct {
@@ -271,6 +279,14 @@ type SystemData struct {
 	Version                                                types.String                                        `tfsdk:"version"`
 	TrackObjects                                           []SystemTrackObjects                                `tfsdk:"track_objects"`
 	IpNbarClassificationDnsClassifyByDomain                types.Bool                                          `tfsdk:"ip_nbar_classification_dns_classify_by_domain"`
+	SecurityPasswordsMinLength                             types.Int64                                         `tfsdk:"security_passwords_min_length"`
+	IpDomainListNames                                      types.List                                          `tfsdk:"ip_domain_list_names"`
+	IpDomainListVrfDomain                                  types.String                                        `tfsdk:"ip_domain_list_vrf_domain"`
+	IpDomainListVrf                                        types.String                                        `tfsdk:"ip_domain_list_vrf"`
+	EthernetCfmAlarmConfigDelay                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_delay"`
+	EthernetCfmAlarmConfigReset                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_reset"`
+	StandbyRedirects                                       types.Bool                                          `tfsdk:"standby_redirects"`
+	StandbyRedirectsEnableDisable                          types.String                                        `tfsdk:"standby_redirects_enable_disable"`
 }
 type SystemMulticastRoutingVrfs struct {
 	Vrf         types.String `tfsdk:"vrf"`
@@ -695,6 +711,32 @@ func (data System) toBody(ctx context.Context) string {
 	}
 	if !data.IpNbarClassificationDnsClassifyByDomain.IsNull() && !data.IpNbarClassificationDnsClassifyByDomain.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.Cisco-IOS-XE-nbar:nbar.classification.dns.classify-by-domain-with-default", data.IpNbarClassificationDnsClassifyByDomain.ValueBool())
+	}
+	if !data.SecurityPasswordsMinLength.IsNull() && !data.SecurityPasswordsMinLength.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-aaa:security.passwords.min-length", strconv.FormatInt(data.SecurityPasswordsMinLength.ValueInt64(), 10))
+	}
+	if !data.IpDomainListNames.IsNull() && !data.IpDomainListNames.IsUnknown() {
+		var values []string
+		data.IpDomainListNames.ElementsAs(ctx, &values, false)
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.domain.list.domain-name", values)
+	}
+	if !data.IpDomainListVrfDomain.IsNull() && !data.IpDomainListVrfDomain.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.domain.list.vrf.domain-name", data.IpDomainListVrfDomain.ValueString())
+	}
+	if !data.IpDomainListVrf.IsNull() && !data.IpDomainListVrf.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.domain.list.vrf.vrf-name", data.IpDomainListVrf.ValueString())
+	}
+	if !data.EthernetCfmAlarmConfigDelay.IsNull() && !data.EthernetCfmAlarmConfigDelay.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.delay", strconv.FormatInt(data.EthernetCfmAlarmConfigDelay.ValueInt64(), 10))
+	}
+	if !data.EthernetCfmAlarmConfigReset.IsNull() && !data.EthernetCfmAlarmConfigReset.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.reset", strconv.FormatInt(data.EthernetCfmAlarmConfigReset.ValueInt64(), 10))
+	}
+	if !data.StandbyRedirects.IsNull() && !data.StandbyRedirects.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"standby.redirects-config.redirects", data.StandbyRedirects.ValueBool())
+	}
+	if !data.StandbyRedirectsEnableDisable.IsNull() && !data.StandbyRedirectsEnableDisable.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"standby.redirects-config.redirect-enable-disable.redirects", data.StandbyRedirectsEnableDisable.ValueString())
 	}
 	if len(data.MulticastRoutingVrfs) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.Cisco-IOS-XE-multicast:multicast-routing.vrf", []interface{}{})
@@ -1781,6 +1823,48 @@ func (data *System) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.IpNbarClassificationDnsClassifyByDomain = types.BoolNull()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-aaa:security.passwords.min-length"); value.Exists() && !data.SecurityPasswordsMinLength.IsNull() {
+		data.SecurityPasswordsMinLength = types.Int64Value(value.Int())
+	} else {
+		data.SecurityPasswordsMinLength = types.Int64Null()
+	}
+	if value := res.Get(prefix + "ip.domain.list.domain-name"); value.Exists() && !data.IpDomainListNames.IsNull() {
+		data.IpDomainListNames = helpers.GetStringList(value.Array())
+	} else {
+		data.IpDomainListNames = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.domain-name"); value.Exists() && !data.IpDomainListVrfDomain.IsNull() {
+		data.IpDomainListVrfDomain = types.StringValue(value.String())
+	} else {
+		data.IpDomainListVrfDomain = types.StringNull()
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.vrf-name"); value.Exists() && !data.IpDomainListVrf.IsNull() {
+		data.IpDomainListVrf = types.StringValue(value.String())
+	} else {
+		data.IpDomainListVrf = types.StringNull()
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.delay"); value.Exists() && !data.EthernetCfmAlarmConfigDelay.IsNull() {
+		data.EthernetCfmAlarmConfigDelay = types.Int64Value(value.Int())
+	} else {
+		data.EthernetCfmAlarmConfigDelay = types.Int64Null()
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.reset"); value.Exists() && !data.EthernetCfmAlarmConfigReset.IsNull() {
+		data.EthernetCfmAlarmConfigReset = types.Int64Value(value.Int())
+	} else {
+		data.EthernetCfmAlarmConfigReset = types.Int64Null()
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirects"); !data.StandbyRedirects.IsNull() {
+		if value.Exists() {
+			data.StandbyRedirects = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.StandbyRedirects = types.BoolNull()
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirect-enable-disable.redirects"); value.Exists() && !data.StandbyRedirectsEnableDisable.IsNull() {
+		data.StandbyRedirectsEnableDisable = types.StringValue(value.String())
+	} else {
+		data.StandbyRedirectsEnableDisable = types.StringNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -2307,6 +2391,34 @@ func (data *System) fromBody(ctx context.Context, res gjson.Result) {
 		data.IpNbarClassificationDnsClassifyByDomain = types.BoolValue(value.Bool())
 	} else {
 		data.IpNbarClassificationDnsClassifyByDomain = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-aaa:security.passwords.min-length"); value.Exists() {
+		data.SecurityPasswordsMinLength = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ip.domain.list.domain-name"); value.Exists() {
+		data.IpDomainListNames = helpers.GetStringList(value.Array())
+	} else {
+		data.IpDomainListNames = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.domain-name"); value.Exists() {
+		data.IpDomainListVrfDomain = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.vrf-name"); value.Exists() {
+		data.IpDomainListVrf = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.delay"); value.Exists() {
+		data.EthernetCfmAlarmConfigDelay = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.reset"); value.Exists() {
+		data.EthernetCfmAlarmConfigReset = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirects"); value.Exists() {
+		data.StandbyRedirects = types.BoolValue(value.Bool())
+	} else {
+		data.StandbyRedirects = types.BoolNull()
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirect-enable-disable.redirects"); value.Exists() {
+		data.StandbyRedirectsEnableDisable = types.StringValue(value.String())
 	}
 }
 
@@ -2835,6 +2947,34 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.IpNbarClassificationDnsClassifyByDomain = types.BoolNull()
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-aaa:security.passwords.min-length"); value.Exists() {
+		data.SecurityPasswordsMinLength = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ip.domain.list.domain-name"); value.Exists() {
+		data.IpDomainListNames = helpers.GetStringList(value.Array())
+	} else {
+		data.IpDomainListNames = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.domain-name"); value.Exists() {
+		data.IpDomainListVrfDomain = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "ip.domain.list.vrf.vrf-name"); value.Exists() {
+		data.IpDomainListVrf = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.delay"); value.Exists() {
+		data.EthernetCfmAlarmConfigDelay = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ethernet.Cisco-IOS-XE-ethernet:cfm.alarm-config.reset"); value.Exists() {
+		data.EthernetCfmAlarmConfigReset = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirects"); value.Exists() {
+		data.StandbyRedirects = types.BoolValue(value.Bool())
+	} else {
+		data.StandbyRedirects = types.BoolNull()
+	}
+	if value := res.Get(prefix + "standby.redirects-config.redirect-enable-disable.redirects"); value.Exists() {
+		data.StandbyRedirectsEnableDisable = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -2843,6 +2983,48 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *System) getDeletedItems(ctx context.Context, state System) []string {
 	deletedItems := make([]string, 0)
+	if !state.StandbyRedirectsEnableDisable.IsNull() && data.StandbyRedirectsEnableDisable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/standby/redirects-config/redirect-enable-disable/redirects", state.getPath()))
+	}
+	if !state.StandbyRedirects.IsNull() && data.StandbyRedirects.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/standby/redirects-config/redirects", state.getPath()))
+	}
+	if !state.EthernetCfmAlarmConfigReset.IsNull() && data.EthernetCfmAlarmConfigReset.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/reset", state.getPath()))
+	}
+	if !state.EthernetCfmAlarmConfigDelay.IsNull() && data.EthernetCfmAlarmConfigDelay.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/delay", state.getPath()))
+	}
+	if !state.IpDomainListVrf.IsNull() && data.IpDomainListVrf.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/domain/list/vrf/vrf-name", state.getPath()))
+	}
+	if !state.IpDomainListVrfDomain.IsNull() && data.IpDomainListVrfDomain.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/domain/list/vrf/domain-name", state.getPath()))
+	}
+	if !state.IpDomainListNames.IsNull() {
+		if data.IpDomainListNames.IsNull() {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/domain/list/domain-name", state.getPath()))
+		} else {
+			var dataValues, stateValues []string
+			data.IpDomainListNames.ElementsAs(ctx, &dataValues, false)
+			state.IpDomainListNames.ElementsAs(ctx, &stateValues, false)
+			for _, v := range stateValues {
+				found := false
+				for _, vv := range dataValues {
+					if v == vv {
+						found = true
+						break
+					}
+				}
+				if !found {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/domain/list/domain-name=%v", state.getPath(), v))
+				}
+			}
+		}
+	}
+	if !state.SecurityPasswordsMinLength.IsNull() && data.SecurityPasswordsMinLength.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:security/passwords/min-length", state.getPath()))
+	}
 	if !state.IpNbarClassificationDnsClassifyByDomain.IsNull() && data.IpNbarClassificationDnsClassifyByDomain.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/Cisco-IOS-XE-nbar:nbar/classification/dns/classify-by-domain-with-default", state.getPath()))
 	}
@@ -3601,6 +3783,30 @@ func (data *System) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *System) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.StandbyRedirectsEnableDisable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/standby/redirects-config/redirect-enable-disable/redirects", data.getPath()))
+	}
+	if !data.StandbyRedirects.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/standby/redirects-config/redirects", data.getPath()))
+	}
+	if !data.EthernetCfmAlarmConfigReset.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/reset", data.getPath()))
+	}
+	if !data.EthernetCfmAlarmConfigDelay.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ethernet/Cisco-IOS-XE-ethernet:cfm/alarm-config/delay", data.getPath()))
+	}
+	if !data.IpDomainListVrf.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/domain/list/vrf/vrf-name", data.getPath()))
+	}
+	if !data.IpDomainListVrfDomain.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/domain/list/vrf/domain-name", data.getPath()))
+	}
+	if !data.IpDomainListNames.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/domain/list/domain-name", data.getPath()))
+	}
+	if !data.SecurityPasswordsMinLength.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:security/passwords/min-length", data.getPath()))
+	}
 	if !data.IpNbarClassificationDnsClassifyByDomain.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/Cisco-IOS-XE-nbar:nbar/classification/dns/classify-by-domain-with-default", data.getPath()))
 	}

--- a/internal/provider/resource_iosxe_dot1x.go
+++ b/internal/provider/resource_iosxe_dot1x.go
@@ -162,6 +162,18 @@ func (r *Dot1xResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: helpers.NewAttributeDescription("Enable or Disable SysAuthControl").String,
 				Optional:            true,
 			},
+			"guest_vlan_supplicant": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Allow 802.1x capable supplicants to enter Guest Vlan").String,
+				Optional:            true,
+			},
+			"critical_eapol": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Send EAPOL-Success on successful Critical Authentication").String,
+				Optional:            true,
+			},
+			"critical_eapol_block": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Block all EAPoL transaction on Critical Authentication").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_dot1x_test.go
+++ b/internal/provider/resource_iosxe_dot1x_test.go
@@ -48,6 +48,7 @@ func TestAccIosxeDot1x(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_dot1x.test", "supplicant_controlled_transient", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_dot1x.test", "supplicant_force_multicast", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_dot1x.test", "system_auth_control", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_dot1x.test", "guest_vlan_supplicant", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -64,7 +65,7 @@ func TestAccIosxeDot1x(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeDot1xImportStateIdFunc("iosxe_dot1x.test"),
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"critical_eapol", "critical_eapol_block"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -117,6 +118,7 @@ func testAccIosxeDot1xConfig_all() string {
 	config += `	supplicant_controlled_transient = true` + "\n"
 	config += `	supplicant_force_multicast = true` + "\n"
 	config += `	system_auth_control = true` + "\n"
+	config += `	guest_vlan_supplicant = true` + "\n"
 	config += `}` + "\n"
 	return config
 }

--- a/internal/provider/resource_iosxe_system.go
+++ b/internal/provider/resource_iosxe_system.go
@@ -767,6 +767,51 @@ func (r *SystemResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: helpers.NewAttributeDescription("dns classification by domain").String,
 				Optional:            true,
 			},
+			"security_passwords_min_length": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Minimum length of passwords").AddIntegerRangeDescription(1, 16).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 16),
+				},
+			},
+			"ip_domain_list_names": schema.ListAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				ElementType:         types.StringType,
+				Optional:            true,
+			},
+			"ip_domain_list_vrf_domain": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+			},
+			"ip_domain_list_vrf": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+			},
+			"ethernet_cfm_alarm_config_delay": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("msec (default 2500 msec)").AddIntegerRangeDescription(2500, 10000).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(2500, 10000),
+				},
+			},
+			"ethernet_cfm_alarm_config_reset": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("msec (default 10000 msec)").AddIntegerRangeDescription(2500, 10000).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(2500, 10000),
+				},
+			},
+			"standby_redirects": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				Optional:            true,
+			},
+			"standby_redirects_enable_disable": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddStringEnumDescription("disable", "enable").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("disable", "enable"),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_system_test.go
+++ b/internal/provider/resource_iosxe_system_test.go
@@ -76,6 +76,8 @@ func TestAccIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "call_home_cisco_tac_1_profile_active", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "call_home_cisco_tac_1_destination_transport_method", "email"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_nbar_classification_dns_classify_by_domain", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_list_vrf_domain", "example.com"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_list_vrf", "VRF1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -189,6 +191,8 @@ func testAccIosxeSystemConfig_all() string {
 	config += `	call_home_cisco_tac_1_profile_active = true` + "\n"
 	config += `	call_home_cisco_tac_1_destination_transport_method = "email"` + "\n"
 	config += `	ip_nbar_classification_dns_classify_by_domain = true` + "\n"
+	config += `	ip_domain_list_vrf_domain = "example.com"` + "\n"
+	config += `	ip_domain_list_vrf = "VRF1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -18,7 +18,8 @@ description: |-
 - Add `iosxe_sla` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4` resource and data source
 - Add `ipv4_unicast_admin_distances`, `ipv4_unicast_distance_bgp_external`, `ipv4_unicast_distance_bgp_internal` and `ipv4_unicast_distance_bgp_local` attributes to `iosxe_iosxe_bgp_address_family_ipv4_vrf` resource and data source
-- Add `track_objects` attribute to `iosxe_system` resource and data source
+- Add `track_objects`, `ip_domain_list_names`, `ip_domain_list_vrf_domain`, `ip_domain_list_vrf`, `ethernet_cfm_alarm_config_delay`, `ethernet_cfm_alarm_config_reset`, `standby_redirects_enable_disable`, `standby_redirects`, and `security_passwords_min_length` attribute to `iosxe_system` resource and data source
+- Add `guest_vlan_supplicant`, `critical_eapol`, and `critical_eapol_block` attributes to `iosxe_dot1x` resource and data source
 
 ## 0.8.0
 


### PR DESCRIPTION
- Add `ip_domain_list_names`, `ip_domain_list_vrf_domain`, `ip_domain_list_vrf`, `ethernet_cfm_alarm_config_delay`, `ethernet_cfm_alarm_config_reset`, `standby_redirects_enable_disable`, `standby_redirects`, and `security_passwords_min_length` attribute to `iosxe_system` resource and data source
- Add `guest_vlan_supplicant`, `critical_eapol`, and `critical_eapol_block` attributes to `iosxe_dot1x` resource and data source