### PR TITLE
feat(interface_vlan): add static MAC address support for VLAN SVIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `passive_interface_disable_*` attributes to `iosxe_ospf` and `iosxe_ospf_vrf` resources and data sources
 - Fix issue with destroying `iosxe_interface_ethernet` resources
 - Change route target attributes of `iosxe_vrf` from type "List" to "Set"
+- Add `mac_address` attribute to `iosxe_interface_vlan` resource and data source
 
 ## 0.9.0
 

--- a/docs/data-sources/interface_vlan.md
+++ b/docs/data-sources/interface_vlan.md
@@ -60,6 +60,7 @@ data "iosxe_interface_vlan" "example" {
 - `ipv6_mtu` (Number) Set IPv6 Maximum Transmission Unit
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
+- `mac_address` (String) Manually set interface MAC address
 - `shutdown` (Boolean) Shutdown the selected interface
 - `unnumbered` (String) Enable IP processing without an explicit address
 - `vrf_forwarding` (String) Configure forwarding table

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -12,6 +12,7 @@ description: |-
 - Add `passive_interface_disable_*` attributes to `iosxe_ospf` and `iosxe_ospf_vrf` resources and data sources
 - Fix issue with destroying `iosxe_interface_ethernet` resources
 - Change route target attributes of `iosxe_vrf` from type "List" to "Set"
+- Add `mac_address` attribute to `iosxe_interface_vlan` resource and data source
 
 ## 0.9.0
 

--- a/docs/resources/interface_vlan.md
+++ b/docs/resources/interface_vlan.md
@@ -56,6 +56,7 @@ resource "iosxe_interface_vlan" "example" {
     }
   ]
   load_interval = 30
+  mac_address   = "0000.dead.beef"
 }
 ```
 
@@ -103,6 +104,7 @@ resource "iosxe_interface_vlan" "example" {
 - `ipv6_nd_ra_suppress_all` (Boolean) Suppress all IPv6 RA
 - `load_interval` (Number) Specify interval for load calculation for an interface
   - Range: `30`-`600`
+- `mac_address` (String) Manually set interface MAC address
 - `shutdown` (Boolean) Shutdown the selected interface
 - `unnumbered` (String) Enable IP processing without an explicit address
 - `vrf_forwarding` (String) Configure forwarding table

--- a/examples/resources/iosxe_interface_vlan/resource.tf
+++ b/examples/resources/iosxe_interface_vlan/resource.tf
@@ -41,4 +41,5 @@ resource "iosxe_interface_vlan" "example" {
     }
   ]
   load_interval = 30
+  mac_address   = "0000.dead.beef"
 }

--- a/gen/definitions/interface_vlan.yaml
+++ b/gen/definitions/interface_vlan.yaml
@@ -140,3 +140,5 @@ test_prerequisites:
         value: VRF1
       - name: address-family/ipv4
         value: ""
+      - name: address-family/ipv6
+        value: ""

--- a/gen/definitions/interface_vlan.yaml
+++ b/gen/definitions/interface_vlan.yaml
@@ -131,6 +131,8 @@ attributes:
         example: true
   - yang_name: load-interval
     example: 30
+  - yang_name: mac-address
+    example: 0000.dead.beef
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/internal/provider/data_source_iosxe_interface_vlan.go
+++ b/internal/provider/data_source_iosxe_interface_vlan.go
@@ -235,6 +235,10 @@ func (d *InterfaceVLANDataSource) Schema(ctx context.Context, req datasource.Sch
 				MarkdownDescription: "Specify interval for load calculation for an interface",
 				Computed:            true,
 			},
+			"mac_address": schema.StringAttribute{
+				MarkdownDescription: "Manually set interface MAC address",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_vlan_test.go
+++ b/internal/provider/data_source_iosxe_interface_vlan_test.go
@@ -65,6 +65,7 @@ func TestAccDataSourceIosxeInterfaceVLAN(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "ipv6_addresses.0.prefix", "2006:DB8::/32"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "ipv6_addresses.0.eui_64", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vlan.test", "mac_address", "0000.dead.beef"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -136,6 +137,7 @@ func testAccDataSourceIosxeInterfaceVLANConfig() string {
 	config += `		eui_64 = true` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
+	config += `	mac_address = "0000.dead.beef"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_iosxe_interface_vlan_test.go
+++ b/internal/provider/data_source_iosxe_interface_vlan_test.go
@@ -87,6 +87,7 @@ resource "iosxe_restconf" "PreReq0" {
 	attributes = {
 		"name" = "VRF1"
 		"address-family/ipv4" = ""
+		"address-family/ipv6" = ""
 	}
 }
 

--- a/internal/provider/model_iosxe_interface_vlan.go
+++ b/internal/provider/model_iosxe_interface_vlan.go
@@ -74,6 +74,7 @@ type InterfaceVLAN struct {
 	Ipv6LinkLocalAddresses       []InterfaceVLANIpv6LinkLocalAddresses `tfsdk:"ipv6_link_local_addresses"`
 	Ipv6Addresses                []InterfaceVLANIpv6Addresses          `tfsdk:"ipv6_addresses"`
 	LoadInterval                 types.Int64                           `tfsdk:"load_interval"`
+	MacAddress                   types.String                          `tfsdk:"mac_address"`
 }
 
 type InterfaceVLANData struct {
@@ -111,6 +112,7 @@ type InterfaceVLANData struct {
 	Ipv6LinkLocalAddresses       []InterfaceVLANIpv6LinkLocalAddresses `tfsdk:"ipv6_link_local_addresses"`
 	Ipv6Addresses                []InterfaceVLANIpv6Addresses          `tfsdk:"ipv6_addresses"`
 	LoadInterval                 types.Int64                           `tfsdk:"load_interval"`
+	MacAddress                   types.String                          `tfsdk:"mac_address"`
 }
 type InterfaceVLANHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -255,6 +257,9 @@ func (data InterfaceVLAN) toBody(ctx context.Context) string {
 	}
 	if !data.LoadInterval.IsNull() && !data.LoadInterval.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"load-interval", strconv.FormatInt(data.LoadInterval.ValueInt64(), 10))
+	}
+	if !data.MacAddress.IsNull() && !data.MacAddress.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"mac-address", data.MacAddress.ValueString())
 	}
 	if len(data.HelperAddresses) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.helper-address", []interface{}{})
@@ -614,6 +619,11 @@ func (data *InterfaceVLAN) updateFromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.LoadInterval = types.Int64Null()
 	}
+	if value := res.Get(prefix + "mac-address"); value.Exists() && !data.MacAddress.IsNull() {
+		data.MacAddress = types.StringValue(value.String())
+	} else {
+		data.MacAddress = types.StringNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -785,6 +795,9 @@ func (data *InterfaceVLAN) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "mac-address"); value.Exists() {
+		data.MacAddress = types.StringValue(value.String())
 	}
 }
 
@@ -958,6 +971,9 @@ func (data *InterfaceVLANData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "load-interval"); value.Exists() {
 		data.LoadInterval = types.Int64Value(value.Int())
 	}
+	if value := res.Get(prefix + "mac-address"); value.Exists() {
+		data.MacAddress = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -966,6 +982,9 @@ func (data *InterfaceVLANData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *InterfaceVLAN) getDeletedItems(ctx context.Context, state InterfaceVLAN) []string {
 	deletedItems := make([]string, 0)
+	if !state.MacAddress.IsNull() && data.MacAddress.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/mac-address", state.getPath()))
+	}
 	if !state.LoadInterval.IsNull() && data.LoadInterval.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/load-interval", state.getPath()))
 	}
@@ -1199,6 +1218,9 @@ func (data *InterfaceVLAN) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *InterfaceVLAN) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.MacAddress.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/mac-address", data.getPath()))
+	}
 	if !data.LoadInterval.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/load-interval", data.getPath()))
 	}

--- a/internal/provider/resource_iosxe_interface_vlan.go
+++ b/internal/provider/resource_iosxe_interface_vlan.go
@@ -298,6 +298,10 @@ func (r *InterfaceVLANResource) Schema(ctx context.Context, req resource.SchemaR
 					int64validator.Between(30, 600),
 				},
 			},
+			"mac_address": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Manually set interface MAC address").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_interface_vlan_test.go
+++ b/internal/provider/resource_iosxe_interface_vlan_test.go
@@ -68,6 +68,7 @@ func TestAccIosxeInterfaceVLAN(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "ipv6_addresses.0.prefix", "2006:DB8::/32"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "ipv6_addresses.0.eui_64", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "load_interval", "30"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vlan.test", "mac_address", "0000.dead.beef"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -174,6 +175,7 @@ func testAccIosxeInterfaceVLANConfig_all() string {
 	config += `		eui_64 = true` + "\n"
 	config += `	}]` + "\n"
 	config += `	load_interval = 30` + "\n"
+	config += `	mac_address = "0000.dead.beef"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_vlan_test.go
+++ b/internal/provider/resource_iosxe_interface_vlan_test.go
@@ -114,6 +114,7 @@ resource "iosxe_restconf" "PreReq0" {
 	attributes = {
 		"name" = "VRF1"
 		"address-family/ipv4" = ""
+		"address-family/ipv6" = ""
 	}
 }
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -12,6 +12,7 @@ description: |-
 - Add `passive_interface_disable_*` attributes to `iosxe_ospf` and `iosxe_ospf_vrf` resources and data sources
 - Fix issue with destroying `iosxe_interface_ethernet` resources
 - Change route target attributes of `iosxe_vrf` from type "List" to "Set"
+- Add `mac_address` attribute to `iosxe_interface_vlan` resource and data source
 
 ## 0.9.0
 


### PR DESCRIPTION
This PR adds support for static MAC addresses on VLAN SVIs through a new `mac_address` attribute in the `iosxe_interface_vlan` resource provider.

An additional change was made to the prerequisites for the tests for VLAN SVIs. When I executed these tests against a relatively fresh Catalyst 9000v instance, they failed prior to me making any changes to the codebase. These failures persisted until I added the IPv6 address family to the VRF's definition (which makes logical sense, since the tests add IPv6 configuration to the VLAN SVI that is associated with the VRF created by the tests as a prerequisite). If desired, I can split this fix into a separate PR, then stack this PR on top of that one - just let me know!