### PR TITLE
[BGP] Add Direct IP Router-ID Support for Global and VRF Contexts

### DIFF
--- a/docs/data-sources/bgp.md
+++ b/docs/data-sources/bgp.md
@@ -34,4 +34,5 @@ data "iosxe_bgp" "example" {
 - `default_ipv4_unicast` (Boolean) Activate ipv4-unicast for a peer by default
 - `id` (String) The path of the retrieved object.
 - `log_neighbor_changes` (Boolean) Log neighbor up/down and reset reason
+- `router_id_ip` (String) Manually configured router identifier
 - `router_id_loopback` (Number) Loopback interface

--- a/docs/data-sources/bgp_address_family_ipv4_vrf.md
+++ b/docs/data-sources/bgp_address_family_ipv4_vrf.md
@@ -51,6 +51,7 @@ Read-Only:
 - `ipv4_unicast_networks_mask` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_networks_mask))
 - `ipv4_unicast_redistribute_connected` (Boolean) Connected
 - `ipv4_unicast_redistribute_static` (Boolean) Static routes
+- `ipv4_unicast_router_id_ip` (String) Manually configured router identifier
 - `ipv4_unicast_router_id_loopback` (Number) Loopback interface
 - `name` (String)
 

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -18,6 +18,7 @@ resource "iosxe_bgp" "example" {
   default_ipv4_unicast = false
   log_neighbor_changes = true
   router_id_loopback   = 100
+  router_id_ip         = "172.16.255.1"
 }
 ```
 
@@ -35,6 +36,7 @@ resource "iosxe_bgp" "example" {
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
 - `log_neighbor_changes` (Boolean) Log neighbor up/down and reset reason
+- `router_id_ip` (String) Manually configured router identifier
 - `router_id_loopback` (Number) Loopback interface
   - Range: `0`-`2147483647`
 

--- a/docs/resources/bgp_address_family_ipv4_vrf.md
+++ b/docs/resources/bgp_address_family_ipv4_vrf.md
@@ -22,6 +22,7 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
       ipv4_unicast_advertise_l2vpn_evpn   = true
       ipv4_unicast_redistribute_connected = true
       ipv4_unicast_router_id_loopback     = 101
+      ipv4_unicast_router_id_ip           = "10.1.1.1"
       ipv4_unicast_aggregate_addresses = [
         {
           ipv4_address = "50.0.0.0"
@@ -97,6 +98,7 @@ Optional:
 - `ipv4_unicast_networks_mask` (Attributes List) Specify a network to announce via BGP (see [below for nested schema](#nestedatt--vrfs--ipv4_unicast_networks_mask))
 - `ipv4_unicast_redistribute_connected` (Boolean) Connected
 - `ipv4_unicast_redistribute_static` (Boolean) Static routes
+- `ipv4_unicast_router_id_ip` (String) Manually configured router identifier
 - `ipv4_unicast_router_id_loopback` (Number) Loopback interface
   - Range: `0`-`2147483647`
 

--- a/examples/resources/iosxe_bgp/resource.tf
+++ b/examples/resources/iosxe_bgp/resource.tf
@@ -3,4 +3,5 @@ resource "iosxe_bgp" "example" {
   default_ipv4_unicast = false
   log_neighbor_changes = true
   router_id_loopback   = 100
+  router_id_ip         = "172.16.255.1"
 }

--- a/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
+++ b/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
@@ -7,6 +7,7 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
       ipv4_unicast_advertise_l2vpn_evpn   = true
       ipv4_unicast_redistribute_connected = true
       ipv4_unicast_router_id_loopback     = 101
+      ipv4_unicast_router_id_ip           = "10.1.1.1"
       ipv4_unicast_aggregate_addresses = [
         {
           ipv4_address = "50.0.0.0"

--- a/gen/definitions/bgp.yaml
+++ b/gen/definitions/bgp.yaml
@@ -16,6 +16,10 @@ attributes:
     xpath: bgp/router-id/interface/Loopback
     tf_name: router_id_loopback
     example: 100
+  - yang_name: bgp/router-id/id-choice/ip-id/ip-id
+    xpath: bgp/router-id/ip-id
+    tf_name: router_id_ip
+    example: 172.16.255.1
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/interface/Loopback=100
     attributes:

--- a/gen/definitions/bgp_address_family_ipv4_vrf.yaml
+++ b/gen/definitions/bgp_address_family_ipv4_vrf.yaml
@@ -26,6 +26,10 @@ attributes:
         xpath: ipv4-unicast/bgp/router-id/interface/Loopback
         tf_name: ipv4_unicast_router_id_loopback
         example: 101
+      - yang_name: ipv4-unicast/bgp/router-id/id-choice/ip-id/ip-id
+        xpath: ipv4-unicast/bgp/router-id/ip-id
+        tf_name: ipv4_unicast_router_id_ip
+        example: 10.1.1.1
       - yang_name: ipv4-unicast/aggregate-address
         tf_name: ipv4_unicast_aggregate_addresses
         type: List

--- a/internal/provider/data_source_iosxe_bgp.go
+++ b/internal/provider/data_source_iosxe_bgp.go
@@ -83,6 +83,10 @@ func (d *BGPDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "Loopback interface",
 				Computed:            true,
 			},
+			"router_id_ip": schema.StringAttribute{
+				MarkdownDescription: "Manually configured router identifier",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf.go
@@ -96,6 +96,10 @@ func (d *BGPAddressFamilyIPv4VRFDataSource) Schema(ctx context.Context, req data
 							MarkdownDescription: "Loopback interface",
 							Computed:            true,
 						},
+						"ipv4_unicast_router_id_ip": schema.StringAttribute{
+							MarkdownDescription: "Manually configured router identifier",
+							Computed:            true,
+						},
 						"ipv4_unicast_aggregate_addresses": schema.ListNestedAttribute{
 							MarkdownDescription: "Configure BGP aggregate entries",
 							Computed:            true,

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -36,6 +36,7 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_advertise_l2vpn_evpn", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_connected", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_loopback", "101"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_ip", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_address", "50.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_mask", "255.255.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_static", "true"))
@@ -113,6 +114,7 @@ func testAccDataSourceIosxeBGPAddressFamilyIPv4VRFConfig() string {
 	config += `		ipv4_unicast_advertise_l2vpn_evpn = true` + "\n"
 	config += `		ipv4_unicast_redistribute_connected = true` + "\n"
 	config += `		ipv4_unicast_router_id_loopback = 101` + "\n"
+	config += `		ipv4_unicast_router_id_ip = "10.1.1.1"` + "\n"
 	config += `		ipv4_unicast_aggregate_addresses = [{` + "\n"
 	config += `			ipv4_address = "50.0.0.0"` + "\n"
 	config += `			ipv4_mask = "255.255.0.0"` + "\n"

--- a/internal/provider/data_source_iosxe_bgp_test.go
+++ b/internal/provider/data_source_iosxe_bgp_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceIosxeBGP(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "default_ipv4_unicast", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "log_neighbor_changes", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "router_id_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "router_id_ip", "172.16.255.1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -73,6 +74,7 @@ func testAccDataSourceIosxeBGPConfig() string {
 	config += `	default_ipv4_unicast = false` + "\n"
 	config += `	log_neighbor_changes = true` + "\n"
 	config += `	router_id_loopback = 100` + "\n"
+	config += `	router_id_ip = "172.16.255.1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_bgp.go
+++ b/internal/provider/model_iosxe_bgp.go
@@ -44,6 +44,7 @@ type BGP struct {
 	DefaultIpv4Unicast types.Bool   `tfsdk:"default_ipv4_unicast"`
 	LogNeighborChanges types.Bool   `tfsdk:"log_neighbor_changes"`
 	RouterIdLoopback   types.Int64  `tfsdk:"router_id_loopback"`
+	RouterIdIp         types.String `tfsdk:"router_id_ip"`
 }
 
 type BGPData struct {
@@ -53,6 +54,7 @@ type BGPData struct {
 	DefaultIpv4Unicast types.Bool   `tfsdk:"default_ipv4_unicast"`
 	LogNeighborChanges types.Bool   `tfsdk:"log_neighbor_changes"`
 	RouterIdLoopback   types.Int64  `tfsdk:"router_id_loopback"`
+	RouterIdIp         types.String `tfsdk:"router_id_ip"`
 }
 
 // End of section. //template:end types
@@ -96,6 +98,9 @@ func (data BGP) toBody(ctx context.Context) string {
 	if !data.RouterIdLoopback.IsNull() && !data.RouterIdLoopback.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"bgp.router-id.interface.Loopback", strconv.FormatInt(data.RouterIdLoopback.ValueInt64(), 10))
 	}
+	if !data.RouterIdIp.IsNull() && !data.RouterIdIp.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"bgp.router-id.ip-id", data.RouterIdIp.ValueString())
+	}
 	return body
 }
 
@@ -132,6 +137,11 @@ func (data *BGP) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.RouterIdLoopback = types.Int64Null()
 	}
+	if value := res.Get(prefix + "bgp.router-id.ip-id"); value.Exists() && !data.RouterIdIp.IsNull() {
+		data.RouterIdIp = types.StringValue(value.String())
+	} else {
+		data.RouterIdIp = types.StringNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -155,6 +165,9 @@ func (data *BGP) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "bgp.router-id.interface.Loopback"); value.Exists() {
 		data.RouterIdLoopback = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "bgp.router-id.ip-id"); value.Exists() {
+		data.RouterIdIp = types.StringValue(value.String())
 	}
 }
 
@@ -180,6 +193,9 @@ func (data *BGPData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "bgp.router-id.interface.Loopback"); value.Exists() {
 		data.RouterIdLoopback = types.Int64Value(value.Int())
 	}
+	if value := res.Get(prefix + "bgp.router-id.ip-id"); value.Exists() {
+		data.RouterIdIp = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -188,6 +204,9 @@ func (data *BGPData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *BGP) getDeletedItems(ctx context.Context, state BGP) []string {
 	deletedItems := make([]string, 0)
+	if !state.RouterIdIp.IsNull() && data.RouterIdIp.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/bgp/router-id/ip-id", state.getPath()))
+	}
 	if !state.RouterIdLoopback.IsNull() && data.RouterIdLoopback.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/bgp/router-id/interface/Loopback", state.getPath()))
 	}
@@ -217,6 +236,9 @@ func (data *BGP) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *BGP) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.RouterIdIp.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/bgp/router-id/ip-id", data.getPath()))
+	}
 	if !data.RouterIdLoopback.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/bgp/router-id/interface/Loopback", data.getPath()))
 	}

--- a/internal/provider/model_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/model_iosxe_bgp_address_family_ipv4_vrf.go
@@ -59,6 +59,7 @@ type BGPAddressFamilyIPv4VRFVrfs struct {
 	Ipv4UnicastAdvertiseL2vpnEvpn    types.Bool                                                 `tfsdk:"ipv4_unicast_advertise_l2vpn_evpn"`
 	Ipv4UnicastRedistributeConnected types.Bool                                                 `tfsdk:"ipv4_unicast_redistribute_connected"`
 	Ipv4UnicastRouterIdLoopback      types.Int64                                                `tfsdk:"ipv4_unicast_router_id_loopback"`
+	Ipv4UnicastRouterIdIp            types.String                                               `tfsdk:"ipv4_unicast_router_id_ip"`
 	Ipv4UnicastAggregateAddresses    []BGPAddressFamilyIPv4VRFVrfsIpv4UnicastAggregateAddresses `tfsdk:"ipv4_unicast_aggregate_addresses"`
 	Ipv4UnicastRedistributeStatic    types.Bool                                                 `tfsdk:"ipv4_unicast_redistribute_static"`
 	Ipv4UnicastNetworksMask          []BGPAddressFamilyIPv4VRFVrfsIpv4UnicastNetworksMask       `tfsdk:"ipv4_unicast_networks_mask"`
@@ -142,6 +143,9 @@ func (data BGPAddressFamilyIPv4VRF) toBody(ctx context.Context) string {
 			}
 			if !item.Ipv4UnicastRouterIdLoopback.IsNull() && !item.Ipv4UnicastRouterIdLoopback.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.bgp.router-id.interface.Loopback", strconv.FormatInt(item.Ipv4UnicastRouterIdLoopback.ValueInt64(), 10))
+			}
+			if !item.Ipv4UnicastRouterIdIp.IsNull() && !item.Ipv4UnicastRouterIdIp.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"vrf"+"."+strconv.Itoa(index)+"."+"ipv4-unicast.bgp.router-id.ip-id", item.Ipv4UnicastRouterIdIp.ValueString())
 			}
 			if !item.Ipv4UnicastRedistributeStatic.IsNull() && !item.Ipv4UnicastRedistributeStatic.IsUnknown() {
 				if item.Ipv4UnicastRedistributeStatic.ValueBool() {
@@ -299,6 +303,11 @@ func (data *BGPAddressFamilyIPv4VRF) updateFromBody(ctx context.Context, res gjs
 			data.Vrfs[i].Ipv4UnicastRouterIdLoopback = types.Int64Value(value.Int())
 		} else {
 			data.Vrfs[i].Ipv4UnicastRouterIdLoopback = types.Int64Null()
+		}
+		if value := r.Get("ipv4-unicast.bgp.router-id.ip-id"); value.Exists() && !data.Vrfs[i].Ipv4UnicastRouterIdIp.IsNull() {
+			data.Vrfs[i].Ipv4UnicastRouterIdIp = types.StringValue(value.String())
+		} else {
+			data.Vrfs[i].Ipv4UnicastRouterIdIp = types.StringNull()
 		}
 		for ci := range data.Vrfs[i].Ipv4UnicastAggregateAddresses {
 			keys := [...]string{"ipv4-address", "ipv4-mask"}
@@ -543,6 +552,9 @@ func (data *BGPAddressFamilyIPv4VRF) fromBody(ctx context.Context, res gjson.Res
 			if cValue := v.Get("ipv4-unicast.bgp.router-id.interface.Loopback"); cValue.Exists() {
 				item.Ipv4UnicastRouterIdLoopback = types.Int64Value(cValue.Int())
 			}
+			if cValue := v.Get("ipv4-unicast.bgp.router-id.ip-id"); cValue.Exists() {
+				item.Ipv4UnicastRouterIdIp = types.StringValue(cValue.String())
+			}
 			if cValue := v.Get("ipv4-unicast.aggregate-address"); cValue.Exists() {
 				item.Ipv4UnicastAggregateAddresses = make([]BGPAddressFamilyIPv4VRFVrfsIpv4UnicastAggregateAddresses, 0)
 				cValue.ForEach(func(ck, cv gjson.Result) bool {
@@ -676,6 +688,9 @@ func (data *BGPAddressFamilyIPv4VRFData) fromBody(ctx context.Context, res gjson
 			}
 			if cValue := v.Get("ipv4-unicast.bgp.router-id.interface.Loopback"); cValue.Exists() {
 				item.Ipv4UnicastRouterIdLoopback = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("ipv4-unicast.bgp.router-id.ip-id"); cValue.Exists() {
+				item.Ipv4UnicastRouterIdIp = types.StringValue(cValue.String())
 			}
 			if cValue := v.Get("ipv4-unicast.aggregate-address"); cValue.Exists() {
 				item.Ipv4UnicastAggregateAddresses = make([]BGPAddressFamilyIPv4VRFVrfsIpv4UnicastAggregateAddresses, 0)
@@ -962,6 +977,9 @@ func (data *BGPAddressFamilyIPv4VRF) getDeletedItems(ctx context.Context, state 
 					if !found {
 						deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/aggregate-address=%v", state.getPath(), strings.Join(stateKeyValues[:], ","), strings.Join(cstateKeyValues[:], ",")))
 					}
+				}
+				if !state.Vrfs[i].Ipv4UnicastRouterIdIp.IsNull() && data.Vrfs[j].Ipv4UnicastRouterIdIp.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/bgp/router-id/ip-id", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 				}
 				if !state.Vrfs[i].Ipv4UnicastRouterIdLoopback.IsNull() && data.Vrfs[j].Ipv4UnicastRouterIdLoopback.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrf=%v/ipv4-unicast/bgp/router-id/interface/Loopback", state.getPath(), strings.Join(stateKeyValues[:], ",")))

--- a/internal/provider/resource_iosxe_bgp.go
+++ b/internal/provider/resource_iosxe_bgp.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
@@ -105,6 +106,13 @@ func (r *BGPResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 2147483647),
+				},
+			},
+			"router_id_ip": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Manually configured router identifier").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
 				},
 			},
 		},

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf.go
@@ -127,6 +127,13 @@ func (r *BGPAddressFamilyIPv4VRFResource) Schema(ctx context.Context, req resour
 								int64validator.Between(0, 2147483647),
 							},
 						},
+						"ipv4_unicast_router_id_ip": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Manually configured router identifier").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?`), ""),
+							},
+						},
 						"ipv4_unicast_aggregate_addresses": schema.ListNestedAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Configure BGP aggregate entries").String,
 							Optional:            true,

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -39,6 +39,7 @@ func TestAccIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_advertise_l2vpn_evpn", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_connected", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_loopback", "101"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_ip", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_address", "50.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_mask", "255.255.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_static", "true"))
@@ -150,6 +151,7 @@ func testAccIosxeBGPAddressFamilyIPv4VRFConfig_all() string {
 	config += `		ipv4_unicast_advertise_l2vpn_evpn = true` + "\n"
 	config += `		ipv4_unicast_redistribute_connected = true` + "\n"
 	config += `		ipv4_unicast_router_id_loopback = 101` + "\n"
+	config += `		ipv4_unicast_router_id_ip = "10.1.1.1"` + "\n"
 	config += `		ipv4_unicast_aggregate_addresses = [{` + "\n"
 	config += `			ipv4_address = "50.0.0.0"` + "\n"
 	config += `			ipv4_mask = "255.255.0.0"` + "\n"

--- a/internal/provider/resource_iosxe_bgp_test.go
+++ b/internal/provider/resource_iosxe_bgp_test.go
@@ -38,6 +38,7 @@ func TestAccIosxeBGP(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "default_ipv4_unicast", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "log_neighbor_changes", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "router_id_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "router_id_ip", "172.16.255.1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -111,6 +112,7 @@ func testAccIosxeBGPConfig_all() string {
 	config += `	default_ipv4_unicast = false` + "\n"
 	config += `	log_neighbor_changes = true` + "\n"
 	config += `	router_id_loopback = 100` + "\n"
+	config += `	router_id_ip = "172.16.255.1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
---

## Related Issue(s)

Fixes #443

## Proposed Changes

This PR implements support for configuring BGP router-ID using direct IP addresses for both global and VRF-specific contexts.

Previously, the provider only supported `router_id_loopback` (interface-based configuration). This PR adds `router_id_ip` attributes to enable direct IP address configuration, providing network engineers with more flexibility.

### Changes Made:

**YANG Definition Updates (Manual):**
- `gen/definitions/bgp.yaml` - Added `router_id_ip` attribute
- `gen/definitions/bgp_address_family_ipv4_vrf.yaml` - Added `ipv4_unicast_router_id_ip` attribute

**Auto-Generated Code Updates (via `make gen`):**
- Provider resources and data sources for both global and VRF BGP
- Documentation (Markdown files)
- Examples (Terraform configurations)
- Test files

### YANG Paths:
- **Global BGP**: `/native/router/ios-bgp:bgp/ios-bgp:bgp/ios-bgp:router-id/ip-id`
- **VRF BGP**: `/native/router/ios-bgp:bgp/address-family/with-vrf/ipv4/vrf/ipv4-unicast/bgp/router-id/ip-id`

### Configuration Examples:

**Global BGP Router-ID:**
```hcl
resource "iosxe_bgp" "example" {
  asn                  = "65000"
  default_ipv4_unicast = false
  log_neighbor_changes = true
  router_id_ip         = "172.16.255.1"  # NEW
}
```

**VRF BGP Router-ID:**
```hcl
resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
  asn     = "65000"
  af_name = "unicast"
  vrfs = [
    {
      name                      = "VRF_A"
      ipv4_unicast_router_id_ip = "10.1.1.1"  # NEW
      ipv4_unicast_advertise_l2vpn_evpn = false
    }
  ]
}
```

## Robot Test(s)

### Test Environment:
- **Device**: Cisco CSR1000v
- **IOS-XE Version**: 17.x
- **IP Address**: 10.81.239.54
- **Protocol**: RESTCONF (HTTPS)

### Test Results:

**Scenario 1: Global BGP Router-ID**
```bash
$ terraform plan
Plan: 1 to add, 0 to change, 0 to destroy.

$ terraform apply -auto-approve
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Device verification:**
```
router bgp 65001
 bgp router-id 172.16.255.1  ✓ VERIFIED
```

**Scenario 2: VRF BGP Router-ID**
```bash
$ terraform plan
Plan: 1 to add, 0 to change, 0 to destroy.

$ terraform apply -auto-approve
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Device verification:**
```
router bgp 65001
 address-family ipv4 vrf TEST_VRF
  bgp router-id 10.1.1.1  ✓ VERIFIED
```

### Test Artifacts:
- Provider builds successfully with Go 1.24.4
- Terraform plan succeeds
- Terraform apply succeeds
- Configuration verified on device via CLI
- Configuration verified via RESTCONF API
- Both global and VRF scenarios tested and validated

## Cisco IOS-XE Version

**Developed Against**: IOS-XE 17.x (CSR1000v)  
**YANG Module**: Cisco-IOS-XE-bgp (revision 2024-07-01)

## External Repo Link

This PR is part of a coordinated enhancement across three repositories:
1. **terraform-provider-iosxe** (Issue #443) - **THIS PR**
2. **nac-iosxe** (Issue #444) - Schema updates (to be submitted)
3. **terraform-iosxe-nac-iosxe** (Issue #445) - Module updates (to be submitted)

Master Epic: #446 - BGP Router-ID Direct IP Configuration Support

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly (auto-generated via `make gen`)
- [ ] Robot test(s) included or updated for data model updates or additions
  - *Note: Robot tests will be included in nac-iosxe PR #444*
- [x] If applicable, external repo link, e.g. Ansible Collection, provided
- [ ] Assigned the proper reviewers

## Additional Notes

### Build Process:
```bash
# Code generation
make gen

# Verification
go version  # Go 1.24.4
Provider builds successfully (18 files changed, 87 insertions)
```

### Backwards Compatibility:
✓ This change is **fully backwards compatible**. The existing `router_id_loopback` attribute continues to work. Network engineers can choose either method:
- **Method 1 (existing)**: Interface-based via `router_id_loopback`
- **Method 2 (new)**: Direct IP via `router_id_ip`

### Configuration Methods:

| Method | Provider Attribute | Cisco CLI Result |
|--------|-------------------|------------------|
| **Interface-Based** (existing) | `router_id_loopback = 100` | `bgp router-id interface Loopback100` |
| **Direct IP** (new) | `router_id_ip = "172.16.255.1"` | `bgp router-id 172.16.255.1` |

Both methods are valid Cisco configurations following best practices.