### PR TITLE
Implemented Protocol Purge Support in Terraform Provider

### DIFF
--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -101,6 +101,7 @@ data "iosxe_system" "example" {
 - `ip_radius_source_interface_vlan` (Number) Iosxr Vlans
 - `ip_radius_source_interface_vrf` (String) VPN Routing/Forwarding parameters
 - `ip_routing` (Boolean) Enable or disable IP routing
+- `ip_routing_protocol_purge_interface` (Boolean) Perform IP routing protocol routes purge on link failures
 - `ip_scp_server_enable` (Boolean) Enable server side of SCP
 - `ip_source_route` (Boolean) Process packets with source routing header options
 - `ip_ssh_authentication_retries` (Number) Specify number of authentication retries

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,10 +7,6 @@ description: |-
 
 # Changelog
 
-## 0.10.0
-
-- Add `ip_routing_protocol_purge_interface` attrribute to `system` resource and data sources
-
 ## 0.10.0 (unreleased)
 
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -48,6 +48,7 @@ resource "iosxe_system" "example" {
   ip_multicast_route_limit                           = 200000
   ip_domain_list_vrf_domain                          = "example.com"
   ip_domain_list_vrf                                 = "VRF1"
+  ip_routing_protocol_purge_interface                = true
 }
 ```
 
@@ -148,6 +149,7 @@ resource "iosxe_system" "example" {
   - Range: `0`-`65535`
 - `ip_radius_source_interface_vrf` (String) VPN Routing/Forwarding parameters
 - `ip_routing` (Boolean) Enable or disable IP routing
+- `ip_routing_protocol_purge_interface` (Boolean) Perform IP routing protocol routes purge on link failures
 - `ip_scp_server_enable` (Boolean) Enable server side of SCP
 - `ip_source_route` (Boolean) Process packets with source routing header options
 - `ip_ssh_authentication_retries` (Number) Specify number of authentication retries

--- a/examples/resources/iosxe_system/resource.tf
+++ b/examples/resources/iosxe_system/resource.tf
@@ -33,4 +33,5 @@ resource "iosxe_system" "example" {
   ip_multicast_route_limit                           = 200000
   ip_domain_list_vrf_domain                          = "example.com"
   ip_domain_list_vrf                                 = "VRF1"
+  ip_routing_protocol_purge_interface                = true
 }

--- a/internal/provider/data_source_iosxe_system.go
+++ b/internal/provider/data_source_iosxe_system.go
@@ -709,6 +709,10 @@ func (d *SystemDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "",
 				Computed:            true,
 			},
+			"ip_routing_protocol_purge_interface": schema.BoolAttribute{
+				MarkdownDescription: "Perform IP routing protocol routes purge on link failures",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_system_test.go
+++ b/internal/provider/data_source_iosxe_system_test.go
@@ -78,6 +78,7 @@ func TestAccDataSourceIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_multicast_route_limit", "200000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_list_vrf_domain", "example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_list_vrf", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_routing_protocol_purge_interface", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -162,6 +163,7 @@ func testAccDataSourceIosxeSystemConfig() string {
 	config += `	ip_multicast_route_limit = 200000` + "\n"
 	config += `	ip_domain_list_vrf_domain = "example.com"` + "\n"
 	config += `	ip_domain_list_vrf = "VRF1"` + "\n"
+	config += `	ip_routing_protocol_purge_interface = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_system.go
+++ b/internal/provider/model_iosxe_system.go
@@ -169,6 +169,7 @@ type System struct {
 	EthernetCfmAlarmConfigReset                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_reset"`
 	StandbyRedirects                                       types.Bool                                          `tfsdk:"standby_redirects"`
 	StandbyRedirectsEnableDisable                          types.String                                        `tfsdk:"standby_redirects_enable_disable"`
+	IpRoutingProtocolPurgeInterface                        types.Bool                                          `tfsdk:"ip_routing_protocol_purge_interface"`
 }
 
 type SystemData struct {
@@ -303,6 +304,7 @@ type SystemData struct {
 	EthernetCfmAlarmConfigReset                            types.Int64                                         `tfsdk:"ethernet_cfm_alarm_config_reset"`
 	StandbyRedirects                                       types.Bool                                          `tfsdk:"standby_redirects"`
 	StandbyRedirectsEnableDisable                          types.String                                        `tfsdk:"standby_redirects_enable_disable"`
+	IpRoutingProtocolPurgeInterface                        types.Bool                                          `tfsdk:"ip_routing_protocol_purge_interface"`
 }
 type SystemMulticastRoutingVrfs struct {
 	Vrf         types.String `tfsdk:"vrf"`
@@ -777,6 +779,9 @@ func (data System) toBody(ctx context.Context) string {
 	}
 	if !data.StandbyRedirectsEnableDisable.IsNull() && !data.StandbyRedirectsEnableDisable.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"standby.redirects-config.redirect-enable-disable.redirects", data.StandbyRedirectsEnableDisable.ValueString())
+	}
+	if !data.IpRoutingProtocolPurgeInterface.IsNull() && !data.IpRoutingProtocolPurgeInterface.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.routing-new.routing.protocol.purge.interface", data.IpRoutingProtocolPurgeInterface.ValueBool())
 	}
 	if len(data.MulticastRoutingVrfs) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.Cisco-IOS-XE-multicast:multicast-routing.vrf", []interface{}{})
@@ -1940,6 +1945,13 @@ func (data *System) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.StandbyRedirectsEnableDisable = types.StringNull()
 	}
+	if value := res.Get(prefix + "ip.routing-new.routing.protocol.purge.interface"); !data.IpRoutingProtocolPurgeInterface.IsNull() {
+		if value.Exists() {
+			data.IpRoutingProtocolPurgeInterface = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.IpRoutingProtocolPurgeInterface = types.BoolNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -2521,6 +2533,11 @@ func (data *System) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "standby.redirects-config.redirect-enable-disable.redirects"); value.Exists() {
 		data.StandbyRedirectsEnableDisable = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "ip.routing-new.routing.protocol.purge.interface"); value.Exists() {
+		data.IpRoutingProtocolPurgeInterface = types.BoolValue(value.Bool())
+	} else {
+		data.IpRoutingProtocolPurgeInterface = types.BoolNull()
 	}
 }
 
@@ -3104,6 +3121,11 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "standby.redirects-config.redirect-enable-disable.redirects"); value.Exists() {
 		data.StandbyRedirectsEnableDisable = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "ip.routing-new.routing.protocol.purge.interface"); value.Exists() {
+		data.IpRoutingProtocolPurgeInterface = types.BoolValue(value.Bool())
+	} else {
+		data.IpRoutingProtocolPurgeInterface = types.BoolNull()
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -3112,6 +3134,9 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *System) getDeletedItems(ctx context.Context, state System) []string {
 	deletedItems := make([]string, 0)
+	if !state.IpRoutingProtocolPurgeInterface.IsNull() && data.IpRoutingProtocolPurgeInterface.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/routing-new/routing/protocol/purge/interface", state.getPath()))
+	}
 	if !state.StandbyRedirectsEnableDisable.IsNull() && data.StandbyRedirectsEnableDisable.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/standby/redirects-config/redirect-enable-disable/redirects", state.getPath()))
 	}
@@ -3936,6 +3961,9 @@ func (data *System) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *System) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.IpRoutingProtocolPurgeInterface.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/routing-new/routing/protocol/purge/interface", data.getPath()))
+	}
 	if !data.StandbyRedirectsEnableDisable.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/standby/redirects-config/redirect-enable-disable/redirects", data.getPath()))
 	}

--- a/internal/provider/resource_iosxe_system.go
+++ b/internal/provider/resource_iosxe_system.go
@@ -851,6 +851,10 @@ func (r *SystemResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					stringvalidator.OneOf("disable", "enable"),
 				},
 			},
+			"ip_routing_protocol_purge_interface": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Perform IP routing protocol routes purge on link failures").String,
+				Optional:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_system_test.go
+++ b/internal/provider/resource_iosxe_system_test.go
@@ -80,6 +80,7 @@ func TestAccIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_multicast_route_limit", "200000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_list_vrf_domain", "example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_list_vrf", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_routing_protocol_purge_interface", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -197,6 +198,7 @@ func testAccIosxeSystemConfig_all() string {
 	config += `	ip_multicast_route_limit = 200000` + "\n"
 	config += `	ip_domain_list_vrf_domain = "example.com"` + "\n"
 	config += `	ip_domain_list_vrf = "VRF1"` + "\n"
+	config += `	ip_routing_protocol_purge_interface = true` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
**Related Issue(s)**

#495
(https://wwwin-github.cisco.com/netascode/nac-iosxe/issues/495)

**Proposed Changes**
This PR adds support for controlling IP routing protocol purge behavior. This controls whether routing protocols automatically purge routes when an interface goes down.

**Changes Made:**

### Schema Validation Updates:

- schemas/schema.yaml - Added up the yang path for routing purge protocol in system.yaml file.

### Documentation Updates:

-  Updated the chanelog.md. 

**Files Changed:**

gen/definitions/system.yaml 
docs/guides/changelog.md 
Total: 2 files changed, 7 insertions(+)

**Cisco IOS-XE Version**

Validated Against: Cisco IOS XE Software, Version 17.15.03 - C9KV

**External Repo Link**

https://github.com/CiscoDevNet/terraform-provider-iosxe