### PR TITLE
fix(bgp neighbor): Update 'update_source_loopback' property to match TF naming conventions

### DIFF
--- a/docs/data-sources/bgp_neighbor.md
+++ b/docs/data-sources/bgp_neighbor.md
@@ -62,5 +62,5 @@ data "iosxe_bgp_neighbor" "example" {
 - `timers_keepalive_interval` (Number)
 - `timers_minimum_neighbor_hold` (Number)
 - `ttl_security_hops` (Number) IP hops
-- `update_source_loopback` (Number) Loopback interface
+- `update_source_interface_loopback` (Number) Loopback interface
 - `version` (Number) Set the BGP version to match a neighbor

--- a/docs/resources/bgp_neighbor.md
+++ b/docs/resources/bgp_neighbor.md
@@ -35,7 +35,7 @@ resource "iosxe_bgp_neighbor" "example" {
   timers_keepalive_interval                 = 655
   timers_holdtime                           = 866
   timers_minimum_neighbor_hold              = 222
-  update_source_loopback                    = 100
+  update_source_interface_loopback          = 100
 }
 ```
 
@@ -82,7 +82,7 @@ resource "iosxe_bgp_neighbor" "example" {
 - `timers_minimum_neighbor_hold` (Number) - Range: `0`-`65535`
 - `ttl_security_hops` (Number) IP hops
   - Range: `1`-`254`
-- `update_source_loopback` (Number) Loopback interface
+- `update_source_interface_loopback` (Number) Loopback interface
 - `version` (Number) Set the BGP version to match a neighbor
   - Range: `4`-`4`
 

--- a/examples/resources/iosxe_bgp_neighbor/resource.tf
+++ b/examples/resources/iosxe_bgp_neighbor/resource.tf
@@ -20,5 +20,5 @@ resource "iosxe_bgp_neighbor" "example" {
   timers_keepalive_interval                 = 655
   timers_holdtime                           = 866
   timers_minimum_neighbor_hold              = 222
-  update_source_loopback                    = 100
+  update_source_interface_loopback          = 100
 }

--- a/gen/definitions/bgp_neighbor.yaml
+++ b/gen/definitions/bgp_neighbor.yaml
@@ -90,7 +90,7 @@ attributes:
     exclude_test: true
   - yang_name: update-source/interface/interface-choice/Loopback/Loopback
     xpath: update-source/interface/Loopback
-    tf_name: update_source_loopback
+    tf_name: update_source_interface_loopback
     type: Int64
     example: 100
   - yang_name: ebgp-multihop

--- a/internal/provider/data_source_iosxe_bgp_neighbor.go
+++ b/internal/provider/data_source_iosxe_bgp_neighbor.go
@@ -180,7 +180,7 @@ func (d *BGPNeighborDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "IP hops",
 				Computed:            true,
 			},
-			"update_source_loopback": schema.Int64Attribute{
+			"update_source_interface_loopback": schema.Int64Attribute{
 				MarkdownDescription: "Loopback interface",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_iosxe_bgp_neighbor_test.go
+++ b/internal/provider/data_source_iosxe_bgp_neighbor_test.go
@@ -49,7 +49,7 @@ func TestAccDataSourceIosxeBGPNeighbor(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_neighbor.test", "timers_keepalive_interval", "655"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_neighbor.test", "timers_holdtime", "866"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_neighbor.test", "timers_minimum_neighbor_hold", "222"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_neighbor.test", "update_source_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_neighbor.test", "update_source_interface_loopback", "100"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -110,7 +110,7 @@ func testAccDataSourceIosxeBGPNeighborConfig() string {
 	config += `	timers_keepalive_interval = 655` + "\n"
 	config += `	timers_holdtime = 866` + "\n"
 	config += `	timers_minimum_neighbor_hold = 222` + "\n"
-	config += `	update_source_loopback = 100` + "\n"
+	config += `	update_source_interface_loopback = 100` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_bgp_neighbor.go
+++ b/internal/provider/model_iosxe_bgp_neighbor.go
@@ -68,7 +68,7 @@ type BGPNeighbor struct {
 	TimersHoldtime                      types.Int64  `tfsdk:"timers_holdtime"`
 	TimersMinimumNeighborHold           types.Int64  `tfsdk:"timers_minimum_neighbor_hold"`
 	TtlSecurityHops                     types.Int64  `tfsdk:"ttl_security_hops"`
-	UpdateSourceLoopback                types.Int64  `tfsdk:"update_source_loopback"`
+	UpdateSourceInterfaceLoopback       types.Int64  `tfsdk:"update_source_interface_loopback"`
 	EbgpMultihop                        types.Bool   `tfsdk:"ebgp_multihop"`
 	EbgpMultihopMaxHop                  types.Int64  `tfsdk:"ebgp_multihop_max_hop"`
 	InheritPeerSession                  types.String `tfsdk:"inherit_peer_session"`
@@ -105,7 +105,7 @@ type BGPNeighborData struct {
 	TimersHoldtime                      types.Int64  `tfsdk:"timers_holdtime"`
 	TimersMinimumNeighborHold           types.Int64  `tfsdk:"timers_minimum_neighbor_hold"`
 	TtlSecurityHops                     types.Int64  `tfsdk:"ttl_security_hops"`
-	UpdateSourceLoopback                types.Int64  `tfsdk:"update_source_loopback"`
+	UpdateSourceInterfaceLoopback       types.Int64  `tfsdk:"update_source_interface_loopback"`
 	EbgpMultihop                        types.Bool   `tfsdk:"ebgp_multihop"`
 	EbgpMultihopMaxHop                  types.Int64  `tfsdk:"ebgp_multihop_max_hop"`
 	InheritPeerSession                  types.String `tfsdk:"inherit_peer_session"`
@@ -245,8 +245,8 @@ func (data BGPNeighbor) toBody(ctx context.Context) string {
 	if !data.TtlSecurityHops.IsNull() && !data.TtlSecurityHops.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ttl-security.hops", strconv.FormatInt(data.TtlSecurityHops.ValueInt64(), 10))
 	}
-	if !data.UpdateSourceLoopback.IsNull() && !data.UpdateSourceLoopback.IsUnknown() {
-		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"update-source.interface.Loopback", strconv.FormatInt(data.UpdateSourceLoopback.ValueInt64(), 10))
+	if !data.UpdateSourceInterfaceLoopback.IsNull() && !data.UpdateSourceInterfaceLoopback.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"update-source.interface.Loopback", strconv.FormatInt(data.UpdateSourceInterfaceLoopback.ValueInt64(), 10))
 	}
 	if !data.EbgpMultihop.IsNull() && !data.EbgpMultihop.IsUnknown() {
 		if data.EbgpMultihop.ValueBool() {
@@ -444,10 +444,10 @@ func (data *BGPNeighbor) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.TtlSecurityHops = types.Int64Null()
 	}
-	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() && !data.UpdateSourceLoopback.IsNull() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() && !data.UpdateSourceInterfaceLoopback.IsNull() {
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	} else {
-		data.UpdateSourceLoopback = types.Int64Null()
+		data.UpdateSourceInterfaceLoopback = types.Int64Null()
 	}
 	if value := res.Get(prefix + "ebgp-multihop"); !data.EbgpMultihop.IsNull() {
 		if value.Exists() {
@@ -582,7 +582,7 @@ func (data *BGPNeighbor) fromBody(ctx context.Context, res gjson.Result) {
 		data.TtlSecurityHops = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "ebgp-multihop"); value.Exists() {
 		data.EbgpMultihop = types.BoolValue(true)
@@ -709,7 +709,7 @@ func (data *BGPNeighborData) fromBody(ctx context.Context, res gjson.Result) {
 		data.TtlSecurityHops = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "ebgp-multihop"); value.Exists() {
 		data.EbgpMultihop = types.BoolValue(true)
@@ -739,7 +739,7 @@ func (data *BGPNeighbor) getDeletedItems(ctx context.Context, state BGPNeighbor)
 	if !state.EbgpMultihop.IsNull() && data.EbgpMultihop.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ebgp-multihop", state.getPath()))
 	}
-	if !state.UpdateSourceLoopback.IsNull() && data.UpdateSourceLoopback.IsNull() {
+	if !state.UpdateSourceInterfaceLoopback.IsNull() && data.UpdateSourceInterfaceLoopback.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/update-source/interface/Loopback", state.getPath()))
 	}
 	if !state.TtlSecurityHops.IsNull() && data.TtlSecurityHops.IsNull() {
@@ -885,7 +885,7 @@ func (data *BGPNeighbor) getDeletePaths(ctx context.Context) []string {
 	if !data.EbgpMultihop.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ebgp-multihop", data.getPath()))
 	}
-	if !data.UpdateSourceLoopback.IsNull() {
+	if !data.UpdateSourceInterfaceLoopback.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/update-source/interface/Loopback", data.getPath()))
 	}
 	if !data.TtlSecurityHops.IsNull() {

--- a/internal/provider/resource_iosxe_bgp_neighbor.go
+++ b/internal/provider/resource_iosxe_bgp_neighbor.go
@@ -227,7 +227,7 @@ func (r *BGPNeighborResource) Schema(ctx context.Context, req resource.SchemaReq
 					int64validator.Between(1, 254),
 				},
 			},
-			"update_source_loopback": schema.Int64Attribute{
+			"update_source_interface_loopback": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Loopback interface").String,
 				Optional:            true,
 			},

--- a/internal/provider/resource_iosxe_bgp_neighbor_test.go
+++ b/internal/provider/resource_iosxe_bgp_neighbor_test.go
@@ -52,7 +52,7 @@ func TestAccIosxeBGPNeighbor(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_neighbor.test", "timers_keepalive_interval", "655"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_neighbor.test", "timers_holdtime", "866"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_neighbor.test", "timers_minimum_neighbor_hold", "222"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_neighbor.test", "update_source_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_neighbor.test", "update_source_interface_loopback", "100"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -147,7 +147,7 @@ func testAccIosxeBGPNeighborConfig_all() string {
 	config += `	timers_keepalive_interval = 655` + "\n"
 	config += `	timers_holdtime = 866` + "\n"
 	config += `	timers_minimum_neighbor_hold = 222` + "\n"
-	config += `	update_source_loopback = 100` + "\n"
+	config += `	update_source_interface_loopback = 100` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, iosxe_restconf.PreReq1, ]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
### This PR updates the "`tf_name`" parameter for the BGP neighbor **update source interface** attribute to better align with Terraform naming conventions. 

This change makes the attribute name more consistent with the underlying YANG path (`update-source/interface/Loopback`) while adhering to expected TF naming conventions, clearly indicating that it references an interface (specifically a Loopback interface).

---

**Changes:**
- Renamed `update_source_loopback` to `update_source_interface_loopback` in the BGP Neighbor definition.
- Updated all documentation, examples, and codebase for consistency and clarity.

`gen/definitions/bgp_neighbor.yaml` (Lines 91-93)
```yaml
- yang_name: update-source/interface/interface-choice/Loopback/Loopback
  xpath: update-source/interface/Loopback
  tf_name: update_source_interface_loopback  # NEW NAME
```

```yaml
- yang_name: update-source/interface/interface-choice/Loopback/Loopback
  xpath: update-source/interface/Loopback
  tf_name: update_source_loopback  # OLD NAME
```