### PR TITLE
[AAA]  Implement RADIUS-Server Attribute Support in Terraform Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.10.0 (unreleased)
 
+- BREAKING CHANGE: Remove `access_request_include` attribute from `iosxe_radius_server` resource and data source (use `send_attributes` with `include-in-access-req` instead)
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration

--- a/docs/data-sources/radius_server.md
+++ b/docs/data-sources/radius_server.md
@@ -37,7 +37,6 @@ data "iosxe_radius_server" "example" {
 
 Read-Only:
 
-- `access_request_include` (Boolean) Include attribute
 - `attribute_31_parameters` (Attributes List) (see [below for nested schema](#nestedatt--attributes--attribute_31_parameters))
 - `number` (String)
 - `send_attributes` (List of String)

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.10.0 (unreleased)
 
+- BREAKING CHANGE: Remove `access_request_include` attribute from `iosxe_radius_server` resource and data source (use `send_attributes` with `include-in-access-req` instead)
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration

--- a/docs/resources/radius_server.md
+++ b/docs/resources/radius_server.md
@@ -59,7 +59,6 @@ Required:
 
 Optional:
 
-- `access_request_include` (Boolean) Include attribute
 - `attribute_31_parameters` (Attributes List) (see [below for nested schema](#nestedatt--attributes--attribute_31_parameters))
 - `send_attributes` (List of String)
 

--- a/gen/definitions/radius_server.yaml
+++ b/gen/definitions/radius_server.yaml
@@ -11,9 +11,6 @@ attributes:
       - yang_name: number
         id: true
         example: 31
-      - yang_name: access-request/include
-        example: true
-        exclude_test: true
       - yang_name: attri31/attri31-list
         tf_name: attribute_31_parameters
         type: List

--- a/internal/provider/data_source_iosxe_radius_server.go
+++ b/internal/provider/data_source_iosxe_radius_server.go
@@ -76,10 +76,6 @@ func (d *RadiusServerDataSource) Schema(ctx context.Context, req datasource.Sche
 							MarkdownDescription: "",
 							Computed:            true,
 						},
-						"access_request_include": schema.BoolAttribute{
-							MarkdownDescription: "Include attribute",
-							Computed:            true,
-						},
 						"attribute_31_parameters": schema.ListNestedAttribute{
 							MarkdownDescription: "",
 							Computed:            true,

--- a/internal/provider/model_iosxe_radius_server.go
+++ b/internal/provider/model_iosxe_radius_server.go
@@ -56,7 +56,6 @@ type RadiusServerData struct {
 }
 type RadiusServerAttributes struct {
 	Number                types.String                                  `tfsdk:"number"`
-	AccessRequestInclude  types.Bool                                    `tfsdk:"access_request_include"`
 	Attribute31Parameters []RadiusServerAttributesAttribute31Parameters `tfsdk:"attribute_31_parameters"`
 	SendAttributes        types.List                                    `tfsdk:"send_attributes"`
 }
@@ -111,11 +110,6 @@ func (data RadiusServer) toBody(ctx context.Context) string {
 		for index, item := range data.Attributes {
 			if !item.Number.IsNull() && !item.Number.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-aaa:attribute"+"."+strconv.Itoa(index)+"."+"number", item.Number.ValueString())
-			}
-			if !item.AccessRequestInclude.IsNull() && !item.AccessRequestInclude.IsUnknown() {
-				if item.AccessRequestInclude.ValueBool() {
-					body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-aaa:attribute"+"."+strconv.Itoa(index)+"."+"access-request.include", map[string]string{})
-				}
 			}
 			if !item.SendAttributes.IsNull() && !item.SendAttributes.IsUnknown() {
 				var values []string
@@ -187,15 +181,6 @@ func (data *RadiusServer) updateFromBody(ctx context.Context, res gjson.Result) 
 			data.Attributes[i].Number = types.StringValue(value.String())
 		} else {
 			data.Attributes[i].Number = types.StringNull()
-		}
-		if value := r.Get("access-request.include"); !data.Attributes[i].AccessRequestInclude.IsNull() {
-			if value.Exists() {
-				data.Attributes[i].AccessRequestInclude = types.BoolValue(true)
-			} else {
-				data.Attributes[i].AccessRequestInclude = types.BoolValue(false)
-			}
-		} else {
-			data.Attributes[i].AccessRequestInclude = types.BoolNull()
 		}
 		for ci := range data.Attributes[i].Attribute31Parameters {
 			keys := [...]string{"calling-station-id"}
@@ -293,11 +278,6 @@ func (data *RadiusServer) fromBody(ctx context.Context, res gjson.Result) {
 			if cValue := v.Get("number"); cValue.Exists() {
 				item.Number = types.StringValue(cValue.String())
 			}
-			if cValue := v.Get("access-request.include"); cValue.Exists() {
-				item.AccessRequestInclude = types.BoolValue(true)
-			} else {
-				item.AccessRequestInclude = types.BoolValue(false)
-			}
 			if cValue := v.Get("attri31.attri31-list"); cValue.Exists() {
 				item.Attribute31Parameters = make([]RadiusServerAttributesAttribute31Parameters, 0)
 				cValue.ForEach(func(ck, cv gjson.Result) bool {
@@ -360,11 +340,6 @@ func (data *RadiusServerData) fromBody(ctx context.Context, res gjson.Result) {
 			item := RadiusServerAttributes{}
 			if cValue := v.Get("number"); cValue.Exists() {
 				item.Number = types.StringValue(cValue.String())
-			}
-			if cValue := v.Get("access-request.include"); cValue.Exists() {
-				item.AccessRequestInclude = types.BoolValue(true)
-			} else {
-				item.AccessRequestInclude = types.BoolValue(false)
 			}
 			if cValue := v.Get("attri31.attri31-list"); cValue.Exists() {
 				item.Attribute31Parameters = make([]RadiusServerAttributesAttribute31Parameters, 0)
@@ -504,9 +479,6 @@ func (data *RadiusServer) getDeletedItems(ctx context.Context, state RadiusServe
 						deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:attribute=%v/attri31/attri31-list=%v", state.getPath(), strings.Join(stateKeyValues[:], ","), strings.Join(cstateKeyValues[:], ",")))
 					}
 				}
-				if !state.Attributes[i].AccessRequestInclude.IsNull() && data.Attributes[j].AccessRequestInclude.IsNull() {
-					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:attribute=%v/access-request/include", state.getPath(), strings.Join(stateKeyValues[:], ",")))
-				}
 				break
 			}
 		}
@@ -536,9 +508,6 @@ func (data *RadiusServer) getEmptyLeafsDelete(ctx context.Context) []string {
 			if !data.Attributes[i].Attribute31Parameters[ci].IdSendNasPortDetail.IsNull() && !data.Attributes[i].Attribute31Parameters[ci].IdSendNasPortDetail.ValueBool() {
 				emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:attribute=%v/attri31/attri31-list=%v/id-send/nas-port-detail", data.getPath(), strings.Join(keyValues[:], ","), strings.Join(ckeyValues[:], ",")))
 			}
-		}
-		if !data.Attributes[i].AccessRequestInclude.IsNull() && !data.Attributes[i].AccessRequestInclude.ValueBool() {
-			emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:attribute=%v/access-request/include", data.getPath(), strings.Join(keyValues[:], ",")))
 		}
 	}
 

--- a/internal/provider/resource_iosxe_radius_server.go
+++ b/internal/provider/resource_iosxe_radius_server.go
@@ -87,10 +87,6 @@ func (r *RadiusServerResource) Schema(ctx context.Context, req resource.SchemaRe
 							MarkdownDescription: helpers.NewAttributeDescription("").String,
 							Required:            true,
 						},
-						"access_request_include": schema.BoolAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Include attribute").String,
-							Optional:            true,
-						},
 						"attribute_31_parameters": schema.ListNestedAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("").String,
 							Optional:            true,

--- a/internal/provider/resource_iosxe_radius_server_test.go
+++ b/internal/provider/resource_iosxe_radius_server_test.go
@@ -57,7 +57,7 @@ func TestAccIosxeRadiusServer(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeRadiusServerImportStateIdFunc("iosxe_radius_server.test"),
-				ImportStateVerifyIgnore: []string{"attributes.0.access_request_include", "attributes.0.attribute_31_parameters.0.id_send_nas_port_detail", "attributes.0.attribute_31_parameters.0.id_send_mac_only"},
+				ImportStateVerifyIgnore: []string{"attributes.0.attribute_31_parameters.0.id_send_nas_port_detail", "attributes.0.attribute_31_parameters.0.id_send_mac_only"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.10.0 (unreleased)
 
+- BREAKING CHANGE: Remove `access_request_include` attribute from `iosxe_radius_server` resource and data source (use `send_attributes` with `include-in-access-req` instead)
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration


### PR DESCRIPTION
This PR adds support for RADIUS-server attributes to be implemented consistently across different attributes.

## Changes
- Remove access_request_include boolean attribute from radius-server attribute 25 resource
- Users should use send_attributes with 'include-in-access-req' instead to implement radius-server attribute 25
- This standardizes on the generic send_attributes approach for all RADIUS attributes
- BREAKING CHANGE: Existing configurations using access_request_include must migrate to send_attributes