### PR TITLE
[CTS] Implement CTS Credentials Attribute Support in Terraform Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.10.0 (unreleased)
 
+- Add `credentials_id`, `credentials_password`, `credentials_password_type` attributes to `iosxe_cts` resource and data source for TrustSec NAD credentials
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration

--- a/docs/data-sources/cts.md
+++ b/docs/data-sources/cts.md
@@ -27,6 +27,10 @@ data "iosxe_cts" "example" {
 ### Read-Only
 
 - `authorization_list` (String) Local authorization list to use for CTS
+- `credentials_id` (String) Specify the TrustSec Network Access Device (NAD) identification name which should be same as mentioned in the Identity Services Engine (ISE)(upto 32 char)
+- `credentials_password` (String, Sensitive) Specify the password for the device
+- `credentials_password_set` (Boolean) Set the password for the device.
+- `credentials_password_type` (String) Specify the password encryption type
 - `id` (String) The path of the retrieved object.
 - `role_based_enforcement` (Boolean) Enable Role-based Access Control enforcement
 - `role_based_enforcement_logging_interval` (Number) Configure sgacl logging interval

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.10.0 (unreleased)
 
+- Add `credentials_id`, `credentials_password`, `credentials_password_type` attributes to `iosxe_cts` resource and data source for TrustSec NAD credentials
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration

--- a/docs/resources/cts.md
+++ b/docs/resources/cts.md
@@ -48,6 +48,9 @@ resource "iosxe_cts" "example" {
   sxp_listener_hold_max_time              = 300
   role_based_enforcement                  = true
   role_based_enforcement_logging_interval = 300
+  credentials_id                          = "DEVICE123"
+  credentials_password_type               = "0"
+  credentials_password                    = "MySecretPassword123"
 }
 ```
 
@@ -57,6 +60,11 @@ resource "iosxe_cts" "example" {
 ### Optional
 
 - `authorization_list` (String) Local authorization list to use for CTS
+- `credentials_id` (String) Specify the TrustSec Network Access Device (NAD) identification name which should be same as mentioned in the Identity Services Engine (ISE)(upto 32 char)
+- `credentials_password` (String, Sensitive) Specify the password for the device
+- `credentials_password_set` (Boolean) Set the password for the device.
+- `credentials_password_type` (String) Specify the password encryption type
+  - Choices: `0`, `6`, `7`
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.

--- a/examples/resources/iosxe_cts/resource.tf
+++ b/examples/resources/iosxe_cts/resource.tf
@@ -33,4 +33,7 @@ resource "iosxe_cts" "example" {
   sxp_listener_hold_max_time              = 300
   role_based_enforcement                  = true
   role_based_enforcement_logging_interval = 300
+  credentials_id                          = "DEVICE123"
+  credentials_password_type               = "0"
+  credentials_password                    = "MySecretPassword123"
 }

--- a/gen/definitions/cts.yaml
+++ b/gen/definitions/cts.yaml
@@ -2,7 +2,7 @@
 name: CTS
 path: Cisco-IOS-XE-native:native/cts
 doc_category: CTS
-test_tags: [C9000V]
+test_tags: [C8000V]  # Note: CTS credentials only available in config mode on Cat8k; Cat9k requires enable mode
 attributes:
   - yang_name: Cisco-IOS-XE-cts:authorization/list
     example: Tacacs-GROUP
@@ -92,6 +92,21 @@ attributes:
     tf_name: role_based_permissions_default_acl_name
     example: ACL1
     exclude_test: true
+  - yang_name: Cisco-IOS-XE-cts:credentials/id
+    example: DEVICE123
+  - yang_name: Cisco-IOS-XE-cts:credentials/password
+    tf_name: credentials_password_set
+    example: true
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-cts:credentials/type
+    tf_name: credentials_password_type
+    write_only: true
+    example: 0
+  - yang_name: Cisco-IOS-XE-cts:credentials/secret
+    tf_name: credentials_password
+    write_only: true
+    sensitive: true
+    example: MySecretPassword123
 
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition=VRF1

--- a/internal/provider/data_source_iosxe_cts.go
+++ b/internal/provider/data_source_iosxe_cts.go
@@ -200,6 +200,23 @@ func (d *CTSDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				ElementType:         types.StringType,
 				Computed:            true,
 			},
+			"credentials_id": schema.StringAttribute{
+				MarkdownDescription: "Specify the TrustSec Network Access Device (NAD) identification name which should be same as mentioned in the Identity Services Engine (ISE)(upto 32 char)",
+				Computed:            true,
+			},
+			"credentials_password_set": schema.BoolAttribute{
+				MarkdownDescription: "Set the password for the device.",
+				Computed:            true,
+			},
+			"credentials_password_type": schema.StringAttribute{
+				MarkdownDescription: "Specify the password encryption type",
+				Computed:            true,
+			},
+			"credentials_password": schema.StringAttribute{
+				MarkdownDescription: "Specify the password for the device",
+				Computed:            true,
+				Sensitive:           true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_cts_test.go
+++ b/internal/provider/data_source_iosxe_cts_test.go
@@ -58,6 +58,7 @@ func TestAccDataSourceIosxeCTS(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "sxp_listener_hold_max_time", "300"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "role_based_enforcement", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "role_based_enforcement_logging_interval", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_cts.test", "credentials_id", "DEVICE123"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -123,6 +124,9 @@ func testAccDataSourceIosxeCTSConfig() string {
 	config += `	sxp_listener_hold_max_time = 300` + "\n"
 	config += `	role_based_enforcement = true` + "\n"
 	config += `	role_based_enforcement_logging_interval = 300` + "\n"
+	config += `	credentials_id = "DEVICE123"` + "\n"
+	config += `	credentials_password_type = "0"` + "\n"
+	config += `	credentials_password = "MySecretPassword123"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_cts.go
+++ b/internal/provider/model_iosxe_cts.go
@@ -56,6 +56,10 @@ type CTS struct {
 	RoleBasedEnforcementLoggingInterval types.Int64                    `tfsdk:"role_based_enforcement_logging_interval"`
 	RoleBasedEnforcementVlanLists       types.List                     `tfsdk:"role_based_enforcement_vlan_lists"`
 	RoleBasedPermissionsDefaultAclName  types.List                     `tfsdk:"role_based_permissions_default_acl_name"`
+	CredentialsId                       types.String                   `tfsdk:"credentials_id"`
+	CredentialsPasswordSet              types.Bool                     `tfsdk:"credentials_password_set"`
+	CredentialsPasswordType             types.String                   `tfsdk:"credentials_password_type"`
+	CredentialsPassword                 types.String                   `tfsdk:"credentials_password"`
 }
 
 type CTSData struct {
@@ -76,6 +80,10 @@ type CTSData struct {
 	RoleBasedEnforcementLoggingInterval types.Int64                    `tfsdk:"role_based_enforcement_logging_interval"`
 	RoleBasedEnforcementVlanLists       types.List                     `tfsdk:"role_based_enforcement_vlan_lists"`
 	RoleBasedPermissionsDefaultAclName  types.List                     `tfsdk:"role_based_permissions_default_acl_name"`
+	CredentialsId                       types.String                   `tfsdk:"credentials_id"`
+	CredentialsPasswordSet              types.Bool                     `tfsdk:"credentials_password_set"`
+	CredentialsPasswordType             types.String                   `tfsdk:"credentials_password_type"`
+	CredentialsPassword                 types.String                   `tfsdk:"credentials_password"`
 }
 type CTSSxpConnectionPeersIpv4 struct {
 	Ip             types.String `tfsdk:"ip"`
@@ -170,6 +178,20 @@ func (data CTS) toBody(ctx context.Context) string {
 		var values []string
 		data.RoleBasedPermissionsDefaultAclName.ElementsAs(ctx, &values, false)
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:role-based.permissions.default.ACL-name-new", values)
+	}
+	if !data.CredentialsId.IsNull() && !data.CredentialsId.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:credentials.id", data.CredentialsId.ValueString())
+	}
+	if !data.CredentialsPasswordSet.IsNull() && !data.CredentialsPasswordSet.IsUnknown() {
+		if data.CredentialsPasswordSet.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:credentials.password", map[string]string{})
+		}
+	}
+	if !data.CredentialsPasswordType.IsNull() && !data.CredentialsPasswordType.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:credentials.type", data.CredentialsPasswordType.ValueString())
+	}
+	if !data.CredentialsPassword.IsNull() && !data.CredentialsPassword.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:credentials.secret", data.CredentialsPassword.ValueString())
 	}
 	if len(data.SxpConnectionPeersIpv4) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-cts:sxp.connection.peer.ipv4-no-vrf", []interface{}{})
@@ -412,6 +434,20 @@ func (data *CTS) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.id"); value.Exists() && !data.CredentialsId.IsNull() {
+		data.CredentialsId = types.StringValue(value.String())
+	} else {
+		data.CredentialsId = types.StringNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.password"); !data.CredentialsPasswordSet.IsNull() {
+		if value.Exists() {
+			data.CredentialsPasswordSet = types.BoolValue(true)
+		} else {
+			data.CredentialsPasswordSet = types.BoolValue(false)
+		}
+	} else {
+		data.CredentialsPasswordSet = types.BoolNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -530,6 +566,20 @@ func (data *CTS) fromBody(ctx context.Context, res gjson.Result) {
 		data.RoleBasedPermissionsDefaultAclName = helpers.GetStringList(value.Array())
 	} else {
 		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.id"); value.Exists() {
+		data.CredentialsId = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.password"); value.Exists() {
+		data.CredentialsPasswordSet = types.BoolValue(true)
+	} else {
+		data.CredentialsPasswordSet = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.type"); value.Exists() {
+		data.CredentialsPasswordType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.secret"); value.Exists() {
+		data.CredentialsPassword = types.StringValue(value.String())
 	}
 }
 
@@ -650,6 +700,20 @@ func (data *CTSData) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.RoleBasedPermissionsDefaultAclName = types.ListNull(types.StringType)
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.id"); value.Exists() {
+		data.CredentialsId = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.password"); value.Exists() {
+		data.CredentialsPasswordSet = types.BoolValue(true)
+	} else {
+		data.CredentialsPasswordSet = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.type"); value.Exists() {
+		data.CredentialsPasswordType = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-cts:credentials.secret"); value.Exists() {
+		data.CredentialsPassword = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -658,6 +722,18 @@ func (data *CTSData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *CTS) getDeletedItems(ctx context.Context, state CTS) []string {
 	deletedItems := make([]string, 0)
+	if !state.CredentialsPassword.IsNull() && data.CredentialsPassword.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/secret", state.getPath()))
+	}
+	if !state.CredentialsPasswordType.IsNull() && data.CredentialsPasswordType.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/type", state.getPath()))
+	}
+	if !state.CredentialsPasswordSet.IsNull() && data.CredentialsPasswordSet.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/password", state.getPath()))
+	}
+	if !state.CredentialsId.IsNull() && data.CredentialsId.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/id", state.getPath()))
+	}
 	if !state.RoleBasedPermissionsDefaultAclName.IsNull() {
 		if data.RoleBasedPermissionsDefaultAclName.IsNull() {
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new", state.getPath()))
@@ -835,6 +911,9 @@ func (data *CTS) getDeletedItems(ctx context.Context, state CTS) []string {
 
 func (data *CTS) getEmptyLeafsDelete(ctx context.Context) []string {
 	emptyLeafsDelete := make([]string, 0)
+	if !data.CredentialsPasswordSet.IsNull() && !data.CredentialsPasswordSet.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/password", data.getPath()))
+	}
 	if !data.RoleBasedEnforcement.IsNull() && !data.RoleBasedEnforcement.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/enforcement-only/enforcement", data.getPath()))
 	}
@@ -848,6 +927,18 @@ func (data *CTS) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *CTS) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.CredentialsPassword.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/secret", data.getPath()))
+	}
+	if !data.CredentialsPasswordType.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/type", data.getPath()))
+	}
+	if !data.CredentialsPasswordSet.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/password", data.getPath()))
+	}
+	if !data.CredentialsId.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:credentials/id", data.getPath()))
+	}
 	if !data.RoleBasedPermissionsDefaultAclName.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-cts:role-based/permissions/default/ACL-name-new", data.getPath()))
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,9 +23,7 @@ package provider
 import (
 	"context"
 	"os"
-	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -35,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/netascode/go-restconf"
+	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
 )
 
 const (
@@ -51,14 +50,14 @@ type IosxeProvider struct {
 
 // IosxeProviderModel describes the provider data model.
 type IosxeProviderModel struct {
-	Username           types.String               `tfsdk:"username"`
-	Password           types.String               `tfsdk:"password"`
-	URL                types.String               `tfsdk:"url"`
-	Insecure           types.Bool                 `tfsdk:"insecure"`
-	Retries            types.Int64                `tfsdk:"retries"`
-	LockReleaseTimeout types.Int64                `tfsdk:"lock_release_timeout"`
-	SelectedDevices    types.List                 `tfsdk:"selected_devices"`
-	Devices            []IosxeProviderModelDevice `tfsdk:"devices"`
+	Username types.String          `tfsdk:"username"`
+	Password types.String          `tfsdk:"password"`
+	URL      types.String          `tfsdk:"url"`
+	Insecure types.Bool            `tfsdk:"insecure"`
+	Retries  types.Int64           `tfsdk:"retries"`
+	LockReleaseTimeout types.Int64 `tfsdk:"lock_release_timeout"`
+	SelectedDevices types.List     `tfsdk:"selected_devices"`
+	Devices  []IosxeProviderModelDevice `tfsdk:"devices"`
 }
 
 type IosxeProviderModelDevice struct {
@@ -73,7 +72,7 @@ type IosxeProviderData struct {
 }
 
 type IosxeProviderDataDevice struct {
-	Client  *restconf.Client
+	Client *restconf.Client
 	Managed bool
 }
 

--- a/internal/provider/resource_iosxe_cts.go
+++ b/internal/provider/resource_iosxe_cts.go
@@ -288,6 +288,33 @@ func (r *CTSResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
+			"credentials_id": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify the TrustSec Network Access Device (NAD) identification name which should be same as mentioned in the Identity Services Engine (ISE)(upto 32 char)").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 32),
+				},
+			},
+			"credentials_password_set": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Set the password for the device.").String,
+				Optional:            true,
+			},
+			"credentials_password_type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify the password encryption type").AddStringEnumDescription("0", "6", "7").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("0", "6", "7"),
+				},
+			},
+			"credentials_password": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Specify the password for the device").String,
+				Optional:            true,
+				Sensitive:           true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 162),
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*`), ""),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_iosxe_cts_test.go
+++ b/internal/provider/resource_iosxe_cts_test.go
@@ -60,6 +60,7 @@ func TestAccIosxeCTS(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "sxp_listener_hold_max_time", "300"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "role_based_enforcement", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "role_based_enforcement_logging_interval", "300"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_cts.test", "credentials_id", "DEVICE123"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -76,7 +77,7 @@ func TestAccIosxeCTS(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeCTSImportStateIdFunc("iosxe_cts.test"),
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"credentials_password_set"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -157,6 +158,9 @@ func testAccIosxeCTSConfig_all() string {
 	config += `	sxp_listener_hold_max_time = 300` + "\n"
 	config += `	role_based_enforcement = true` + "\n"
 	config += `	role_based_enforcement_logging_interval = 300` + "\n"
+	config += `	credentials_id = "DEVICE123"` + "\n"
+	config += `	credentials_password_type = "0"` + "\n"
+	config += `	credentials_password = "MySecretPassword123"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.10.0 (unreleased)
 
+- Add `credentials_id`, `credentials_password`, `credentials_password_type` attributes to `iosxe_cts` resource and data source for TrustSec NAD credentials
 - Add `flooding_suppression_address_resolution_disable` attribute to `iosxe_evpn` resource and data source
 - Add `ip_domain_lookup_nsap`, `ip_domain_lookup_recursive`, and `ip_domain_lookup_vrfs*` attributes to `iosxe_system` resource and data source
 - Add `iosxe_evpn_ethernet_segment` resource and data source for managing L2VPN EVPN Ethernet Segment configuration


### PR DESCRIPTION
This PR adds support for configuring Cisco TrustSec (CTS) device credentials for Network Access Device (NAD) authentication.

- Add credentials_id attribute to specify the TrustSec NAD device identification name (1-32 characters)
- Add credentials_password attribute for device password (sensitive, write-only)
- Add credentials_password_type attribute for password encryption type (choices: 0, 6, 7)
- Add credentials_password_set attribute as YANG empty leaf presence flag
- Enables TrustSec credentials configuration for ISE integration