### PR TITLE
Fix BGP router-id test failures by excluding IP-based router-id from tests

### DIFF
--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -18,7 +18,6 @@ resource "iosxe_bgp" "example" {
   default_ipv4_unicast = false
   log_neighbor_changes = true
   router_id_loopback   = 100
-  router_id_ip         = "172.16.255.1"
 }
 ```
 

--- a/docs/resources/bgp_address_family_ipv4_vrf.md
+++ b/docs/resources/bgp_address_family_ipv4_vrf.md
@@ -22,7 +22,6 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
       ipv4_unicast_advertise_l2vpn_evpn   = true
       ipv4_unicast_redistribute_connected = true
       ipv4_unicast_router_id_loopback     = 101
-      ipv4_unicast_router_id_ip           = "10.1.1.1"
       ipv4_unicast_aggregate_addresses = [
         {
           ipv4_address = "50.0.0.0"

--- a/examples/resources/iosxe_bgp/resource.tf
+++ b/examples/resources/iosxe_bgp/resource.tf
@@ -3,5 +3,4 @@ resource "iosxe_bgp" "example" {
   default_ipv4_unicast = false
   log_neighbor_changes = true
   router_id_loopback   = 100
-  router_id_ip         = "172.16.255.1"
 }

--- a/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
+++ b/examples/resources/iosxe_bgp_address_family_ipv4_vrf/resource.tf
@@ -7,7 +7,6 @@ resource "iosxe_bgp_address_family_ipv4_vrf" "example" {
       ipv4_unicast_advertise_l2vpn_evpn   = true
       ipv4_unicast_redistribute_connected = true
       ipv4_unicast_router_id_loopback     = 101
-      ipv4_unicast_router_id_ip           = "10.1.1.1"
       ipv4_unicast_aggregate_addresses = [
         {
           ipv4_address = "50.0.0.0"

--- a/gen/definitions/bgp.yaml
+++ b/gen/definitions/bgp.yaml
@@ -20,6 +20,7 @@ attributes:
     xpath: bgp/router-id/ip-id
     tf_name: router_id_ip
     example: 172.16.255.1
+    exclude_test: true
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/interface/Loopback=100
     attributes:

--- a/gen/definitions/bgp_address_family_ipv4_vrf.yaml
+++ b/gen/definitions/bgp_address_family_ipv4_vrf.yaml
@@ -30,6 +30,7 @@ attributes:
         xpath: ipv4-unicast/bgp/router-id/ip-id
         tf_name: ipv4_unicast_router_id_ip
         example: 10.1.1.1
+        exclude_test: true
       - yang_name: ipv4-unicast/aggregate-address
         tf_name: ipv4_unicast_aggregate_addresses
         type: List

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -36,7 +36,6 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_advertise_l2vpn_evpn", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_connected", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_loopback", "101"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_ip", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_address", "50.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_mask", "255.255.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_static", "true"))
@@ -114,7 +113,6 @@ func testAccDataSourceIosxeBGPAddressFamilyIPv4VRFConfig() string {
 	config += `		ipv4_unicast_advertise_l2vpn_evpn = true` + "\n"
 	config += `		ipv4_unicast_redistribute_connected = true` + "\n"
 	config += `		ipv4_unicast_router_id_loopback = 101` + "\n"
-	config += `		ipv4_unicast_router_id_ip = "10.1.1.1"` + "\n"
 	config += `		ipv4_unicast_aggregate_addresses = [{` + "\n"
 	config += `			ipv4_address = "50.0.0.0"` + "\n"
 	config += `			ipv4_mask = "255.255.0.0"` + "\n"

--- a/internal/provider/data_source_iosxe_bgp_test.go
+++ b/internal/provider/data_source_iosxe_bgp_test.go
@@ -35,7 +35,6 @@ func TestAccDataSourceIosxeBGP(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "default_ipv4_unicast", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "log_neighbor_changes", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "router_id_loopback", "100"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp.test", "router_id_ip", "172.16.255.1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -74,7 +73,6 @@ func testAccDataSourceIosxeBGPConfig() string {
 	config += `	default_ipv4_unicast = false` + "\n"
 	config += `	log_neighbor_changes = true` + "\n"
 	config += `	router_id_loopback = 100` + "\n"
-	config += `	router_id_ip = "172.16.255.1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv4_vrf_test.go
@@ -39,7 +39,6 @@ func TestAccIosxeBGPAddressFamilyIPv4VRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_advertise_l2vpn_evpn", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_connected", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_loopback", "101"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_router_id_ip", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_address", "50.0.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_aggregate_addresses.0.ipv4_mask", "255.255.0.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_address_family_ipv4_vrf.test", "vrfs.0.ipv4_unicast_redistribute_static", "true"))
@@ -151,7 +150,6 @@ func testAccIosxeBGPAddressFamilyIPv4VRFConfig_all() string {
 	config += `		ipv4_unicast_advertise_l2vpn_evpn = true` + "\n"
 	config += `		ipv4_unicast_redistribute_connected = true` + "\n"
 	config += `		ipv4_unicast_router_id_loopback = 101` + "\n"
-	config += `		ipv4_unicast_router_id_ip = "10.1.1.1"` + "\n"
 	config += `		ipv4_unicast_aggregate_addresses = [{` + "\n"
 	config += `			ipv4_address = "50.0.0.0"` + "\n"
 	config += `			ipv4_mask = "255.255.0.0"` + "\n"

--- a/internal/provider/resource_iosxe_bgp_test.go
+++ b/internal/provider/resource_iosxe_bgp_test.go
@@ -38,7 +38,6 @@ func TestAccIosxeBGP(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "default_ipv4_unicast", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "log_neighbor_changes", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "router_id_loopback", "100"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp.test", "router_id_ip", "172.16.255.1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -112,7 +111,6 @@ func testAccIosxeBGPConfig_all() string {
 	config += `	default_ipv4_unicast = false` + "\n"
 	config += `	log_neighbor_changes = true` + "\n"
 	config += `	router_id_loopback = 100` + "\n"
-	config += `	router_id_ip = "172.16.255.1"` + "\n"
 	config += `	depends_on = [iosxe_restconf.PreReq0, ]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
  ### Changes
  Added `exclude_test: true` to IP-based router-id attributes in BGP resource
  definitions to prevent test failures caused by YANG choice mutual exclusivity.

  **Modified files:**
  - `gen/definitions/bgp.yaml` - excluded `router_id_ip` from tests
  - `gen/definitions/bgp_address_family_ipv4_vrf.yaml` - excluded
  `ipv4_unicast_router_id_ip` from tests

  ### Reasoning
  The BGP YANG model defines router-id as a mutually exclusive choice between:
  - Interface-based (Loopback) - **best practice, kept in tests**
  - IP-based - excluded from tests

  When both attributes were tested simultaneously, the device only accepted the last
  configured value due to YANG choice enforcement, causing state drift and test
  assertion failures.

  ### Testing
  Tests now only validate `router_id_loopback` and `ipv4_unicast_router_id_loopback`
  (best practice configuration using stable Loopback interface identifiers), while the
  provider still supports both configuration methods for customer use.

  Fixes #343