### PR TITLE
Fix: Rename `update_source_loopback` to `update_source_interface_loopback` across documentation, resources, and tests

### DIFF
--- a/docs/data-sources/bgp_ipv4_unicast_vrf_neighbor.md
+++ b/docs/data-sources/bgp_ipv4_unicast_vrf_neighbor.md
@@ -72,7 +72,7 @@ data "iosxe_bgp_ipv4_unicast_vrf_neighbor" "example" {
 - `timers_keepalive_interval` (Number)
 - `timers_minimum_neighbor_hold` (Number)
 - `ttl_security_hops` (Number) IP hops
-- `update_source_loopback` (Number) Loopback interface
+- `update_source_interface_loopback` (Number) Loopback interface
 - `version` (Number) Set the BGP version to match a neighbor
 
 <a id="nestedatt--route_maps"></a>

--- a/docs/resources/bgp_ipv4_unicast_vrf_neighbor.md
+++ b/docs/resources/bgp_ipv4_unicast_vrf_neighbor.md
@@ -33,7 +33,7 @@ resource "iosxe_bgp_ipv4_unicast_vrf_neighbor" "example" {
   fall_over_bfd_check_control_plane_failure = true
   fall_over_bfd_strict_mode                 = true
   fall_over_maximum_metric_route_map        = "ROUTEMAP"
-  update_source_loopback                    = 100
+  update_source_interface_loopback          = 100
   activate                                  = true
   send_community                            = "both"
   route_reflector_client                    = false
@@ -108,7 +108,7 @@ resource "iosxe_bgp_ipv4_unicast_vrf_neighbor" "example" {
 - `timers_minimum_neighbor_hold` (Number) - Range: `0`-`65535`
 - `ttl_security_hops` (Number) IP hops
   - Range: `1`-`254`
-- `update_source_loopback` (Number) Loopback interface
+- `update_source_interface_loopback` (Number) Loopback interface
 - `version` (Number) Set the BGP version to match a neighbor
   - Range: `4`-`4`
 

--- a/examples/resources/iosxe_bgp_ipv4_unicast_vrf_neighbor/resource.tf
+++ b/examples/resources/iosxe_bgp_ipv4_unicast_vrf_neighbor/resource.tf
@@ -18,7 +18,7 @@ resource "iosxe_bgp_ipv4_unicast_vrf_neighbor" "example" {
   fall_over_bfd_check_control_plane_failure = true
   fall_over_bfd_strict_mode                 = true
   fall_over_maximum_metric_route_map        = "ROUTEMAP"
-  update_source_loopback                    = 100
+  update_source_interface_loopback          = 100
   activate                                  = true
   send_community                            = "both"
   route_reflector_client                    = false

--- a/gen/definitions/bgp_ipv4_unicast_vrf_neighbor.yaml
+++ b/gen/definitions/bgp_ipv4_unicast_vrf_neighbor.yaml
@@ -99,7 +99,7 @@ attributes:
     exclude_test: true
   - yang_name: update-source/interface/interface-choice/Loopback/Loopback
     xpath: update-source/interface/Loopback
-    tf_name: update_source_loopback
+    tf_name: update_source_interface_loopback
     type: Int64
     example: 100
   - yang_name: activate

--- a/internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
+++ b/internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
@@ -176,7 +176,7 @@ func (d *BGPIPv4UnicastVRFNeighborDataSource) Schema(ctx context.Context, req da
 				MarkdownDescription: "Accept either real AS or local AS from the ebgp peer",
 				Computed:            true,
 			},
-			"update_source_loopback": schema.Int64Attribute{
+			"update_source_interface_loopback": schema.Int64Attribute{
 				MarkdownDescription: "Loopback interface",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go
+++ b/internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go
@@ -46,7 +46,7 @@ func TestAccDataSourceIosxeBGPIPv4UnicastVRFNeighbor(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_bfd_check_control_plane_failure", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_bfd_strict_mode", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_maximum_metric_route_map", "ROUTEMAP"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "update_source_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "update_source_interface_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "activate", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "send_community", "both"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "route_reflector_client", "false"))
@@ -146,7 +146,7 @@ func testAccDataSourceIosxeBGPIPv4UnicastVRFNeighborConfig() string {
 	config += `	fall_over_bfd_check_control_plane_failure = true` + "\n"
 	config += `	fall_over_bfd_strict_mode = true` + "\n"
 	config += `	fall_over_maximum_metric_route_map = "ROUTEMAP"` + "\n"
-	config += `	update_source_loopback = 100` + "\n"
+	config += `	update_source_interface_loopback = 100` + "\n"
 	config += `	activate = true` + "\n"
 	config += `	send_community = "both"` + "\n"
 	config += `	route_reflector_client = false` + "\n"

--- a/internal/provider/model_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
+++ b/internal/provider/model_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
@@ -69,7 +69,7 @@ type BGPIPv4UnicastVRFNeighbor struct {
 	LocalAsNoPrepend                    types.Bool                           `tfsdk:"local_as_no_prepend"`
 	LocalAsReplaceAs                    types.Bool                           `tfsdk:"local_as_replace_as"`
 	LocalAsDualAs                       types.Bool                           `tfsdk:"local_as_dual_as"`
-	UpdateSourceLoopback                types.Int64                          `tfsdk:"update_source_loopback"`
+	UpdateSourceInterfaceLoopback       types.Int64                          `tfsdk:"update_source_interface_loopback"`
 	Activate                            types.Bool                           `tfsdk:"activate"`
 	SendCommunity                       types.String                         `tfsdk:"send_community"`
 	RouteReflectorClient                types.Bool                           `tfsdk:"route_reflector_client"`
@@ -115,7 +115,7 @@ type BGPIPv4UnicastVRFNeighborData struct {
 	LocalAsNoPrepend                    types.Bool                           `tfsdk:"local_as_no_prepend"`
 	LocalAsReplaceAs                    types.Bool                           `tfsdk:"local_as_replace_as"`
 	LocalAsDualAs                       types.Bool                           `tfsdk:"local_as_dual_as"`
-	UpdateSourceLoopback                types.Int64                          `tfsdk:"update_source_loopback"`
+	UpdateSourceInterfaceLoopback       types.Int64                          `tfsdk:"update_source_interface_loopback"`
 	Activate                            types.Bool                           `tfsdk:"activate"`
 	SendCommunity                       types.String                         `tfsdk:"send_community"`
 	RouteReflectorClient                types.Bool                           `tfsdk:"route_reflector_client"`
@@ -261,8 +261,8 @@ func (data BGPIPv4UnicastVRFNeighbor) toBody(ctx context.Context) string {
 			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"local-as.dual-as", map[string]string{})
 		}
 	}
-	if !data.UpdateSourceLoopback.IsNull() && !data.UpdateSourceLoopback.IsUnknown() {
-		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"update-source.interface.Loopback", strconv.FormatInt(data.UpdateSourceLoopback.ValueInt64(), 10))
+	if !data.UpdateSourceInterfaceLoopback.IsNull() && !data.UpdateSourceInterfaceLoopback.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"update-source.interface.Loopback", strconv.FormatInt(data.UpdateSourceInterfaceLoopback.ValueInt64(), 10))
 	}
 	if !data.Activate.IsNull() && !data.Activate.IsUnknown() {
 		if data.Activate.ValueBool() {
@@ -496,10 +496,10 @@ func (data *BGPIPv4UnicastVRFNeighbor) updateFromBody(ctx context.Context, res g
 	} else {
 		data.LocalAsDualAs = types.BoolNull()
 	}
-	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() && !data.UpdateSourceLoopback.IsNull() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() && !data.UpdateSourceInterfaceLoopback.IsNull() {
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	} else {
-		data.UpdateSourceLoopback = types.Int64Null()
+		data.UpdateSourceInterfaceLoopback = types.Int64Null()
 	}
 	if value := res.Get(prefix + "activate"); !data.Activate.IsNull() {
 		if value.Exists() {
@@ -729,7 +729,7 @@ func (data *BGPIPv4UnicastVRFNeighbor) fromBody(ctx context.Context, res gjson.R
 		data.LocalAsDualAs = types.BoolValue(false)
 	}
 	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "activate"); value.Exists() {
 		data.Activate = types.BoolValue(true)
@@ -901,7 +901,7 @@ func (data *BGPIPv4UnicastVRFNeighborData) fromBody(ctx context.Context, res gjs
 		data.LocalAsDualAs = types.BoolValue(false)
 	}
 	if value := res.Get(prefix + "update-source.interface.Loopback"); value.Exists() {
-		data.UpdateSourceLoopback = types.Int64Value(value.Int())
+		data.UpdateSourceInterfaceLoopback = types.Int64Value(value.Int())
 	}
 	if value := res.Get(prefix + "activate"); value.Exists() {
 		data.Activate = types.BoolValue(true)
@@ -1036,7 +1036,7 @@ func (data *BGPIPv4UnicastVRFNeighbor) getDeletedItems(ctx context.Context, stat
 	if !state.SendCommunity.IsNull() && data.SendCommunity.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/send-community/send-community-where", state.getPath()))
 	}
-	if !state.UpdateSourceLoopback.IsNull() && data.UpdateSourceLoopback.IsNull() {
+	if !state.UpdateSourceInterfaceLoopback.IsNull() && data.UpdateSourceInterfaceLoopback.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/update-source/interface/Loopback", state.getPath()))
 	}
 	if !state.LocalAsDualAs.IsNull() && data.LocalAsDualAs.IsNull() {
@@ -1221,7 +1221,7 @@ func (data *BGPIPv4UnicastVRFNeighbor) getDeletePaths(ctx context.Context) []str
 	if !data.SendCommunity.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/send-community/send-community-where", data.getPath()))
 	}
-	if !data.UpdateSourceLoopback.IsNull() {
+	if !data.UpdateSourceInterfaceLoopback.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/update-source/interface/Loopback", data.getPath()))
 	}
 	if !data.LocalAsDualAs.IsNull() {

--- a/internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
+++ b/internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
@@ -227,7 +227,7 @@ func (r *BGPIPv4UnicastVRFNeighborResource) Schema(ctx context.Context, req reso
 				MarkdownDescription: helpers.NewAttributeDescription("Accept either real AS or local AS from the ebgp peer").String,
 				Optional:            true,
 			},
-			"update_source_loopback": schema.Int64Attribute{
+			"update_source_interface_loopback": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Loopback interface").String,
 				Optional:            true,
 			},

--- a/internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go
+++ b/internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go
@@ -49,7 +49,7 @@ func TestAccIosxeBGPIPv4UnicastVRFNeighbor(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_bfd_check_control_plane_failure", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_bfd_strict_mode", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "fall_over_maximum_metric_route_map", "ROUTEMAP"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "update_source_loopback", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "update_source_interface_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "activate", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "send_community", "both"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_bgp_ipv4_unicast_vrf_neighbor.test", "route_reflector_client", "false"))
@@ -185,7 +185,7 @@ func testAccIosxeBGPIPv4UnicastVRFNeighborConfig_all() string {
 	config += `	fall_over_bfd_check_control_plane_failure = true` + "\n"
 	config += `	fall_over_bfd_strict_mode = true` + "\n"
 	config += `	fall_over_maximum_metric_route_map = "ROUTEMAP"` + "\n"
-	config += `	update_source_loopback = 100` + "\n"
+	config += `	update_source_interface_loopback = 100` + "\n"
 	config += `	activate = true` + "\n"
 	config += `	send_community = "both"` + "\n"
 	config += `	route_reflector_client = false` + "\n"


### PR DESCRIPTION
This change is to fix current CI failures and to maintain full and proper consistency with naming conventions across all relevant provider definitions, documentation, and tests where `update_source_loopback` was being referenced but should have been updated to reference `update_source_interface_loopback`.

Files Changed:
- docs/data-sources/bgp_ipv4_unicast_vrf_neighbor.md
- docs/resources/bgp_ipv4_unicast_vrf_neighbor.md
- examples/resources/iosxe_bgp_ipv4_unicast_vrf_neighbor/resource.tf
- gen/definitions/bgp_ipv4_unicast_vrf_neighbor.yaml
- internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
- internal/provider/data_source_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go
- internal/provider/model_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
- internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor.go
- internal/provider/resource_iosxe_bgp_ipv4_unicast_vrf_neighbor_test.go