### PR TITLE
fix(tests): EVPN Ethernet Segment tests fail due to incorrect MAC address format in YAML definition

### DIFF
--- a/docs/resources/evpn_ethernet_segment.md
+++ b/docs/resources/evpn_ethernet_segment.md
@@ -20,9 +20,8 @@ resource "iosxe_evpn_ethernet_segment" "example" {
   redundancy_single_active = true
   identifier_types = [
     {
-      type       = 0
-      hex_string = "0001.0000.0000.0000.000A"
-      system_mac = "00:11:22:33:44:55"
+      type       = 3
+      system_mac = "0011.2233.4455"
     }
   ]
 }

--- a/examples/resources/iosxe_evpn_ethernet_segment/resource.tf
+++ b/examples/resources/iosxe_evpn_ethernet_segment/resource.tf
@@ -5,9 +5,8 @@ resource "iosxe_evpn_ethernet_segment" "example" {
   redundancy_single_active = true
   identifier_types = [
     {
-      type       = 0
-      hex_string = "0001.0000.0000.0000.000A"
-      system_mac = "00:11:22:33:44:55"
+      type       = 3
+      system_mac = "0011.2233.4455"
     }
   ]
 }

--- a/gen/definitions/evpn_ethernet_segment.yaml
+++ b/gen/definitions/evpn_ethernet_segment.yaml
@@ -27,11 +27,12 @@ attributes:
       - yang_name: identifier-type
         tf_name: type
         id: true
-        example: 0
+        example: 3
       - yang_name: esi-type-choice/hex-string/hex-string
         xpath: hex-string
         tf_name: hex_string
-        example: 0001.0000.0000.0000.000A
+        example: 00.00.00.00.00.00.01.01.01
+        exclude_test: true
       - yang_name: esi-type-choice/system-mac/system-mac
         xpath: system-mac
-        example: 00:11:22:33:44:55
+        example: 0011.2233.4455

--- a/internal/provider/data_source_iosxe_evpn_ethernet_segment_test.go
+++ b/internal/provider/data_source_iosxe_evpn_ethernet_segment_test.go
@@ -39,9 +39,8 @@ func TestAccDataSourceIosxeEVPNEthernetSegment(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "df_election_wait_time", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "redundancy_all_active", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "redundancy_single_active", "true"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "identifier_types.0.type", "0"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "identifier_types.0.hex_string", "0001.0000.0000.0000.000A"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "identifier_types.0.system_mac", "00:11:22:33:44:55"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "identifier_types.0.type", "3"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_evpn_ethernet_segment.test", "identifier_types.0.system_mac", "0011.2233.4455"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -69,9 +68,8 @@ func testAccDataSourceIosxeEVPNEthernetSegmentConfig() string {
 	config += `	redundancy_all_active = false` + "\n"
 	config += `	redundancy_single_active = true` + "\n"
 	config += `	identifier_types = [{` + "\n"
-	config += `		type = 0` + "\n"
-	config += `		hex_string = "0001.0000.0000.0000.000A"` + "\n"
-	config += `		system_mac = "00:11:22:33:44:55"` + "\n"
+	config += `		type = 3` + "\n"
+	config += `		system_mac = "0011.2233.4455"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/resource_iosxe_evpn_ethernet_segment_test.go
+++ b/internal/provider/resource_iosxe_evpn_ethernet_segment_test.go
@@ -42,9 +42,8 @@ func TestAccIosxeEVPNEthernetSegment(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "df_election_wait_time", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "redundancy_all_active", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "redundancy_single_active", "true"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "identifier_types.0.type", "0"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "identifier_types.0.hex_string", "0001.0000.0000.0000.000A"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "identifier_types.0.system_mac", "00:11:22:33:44:55"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "identifier_types.0.type", "3"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_evpn_ethernet_segment.test", "identifier_types.0.system_mac", "0011.2233.4455"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -106,9 +105,8 @@ func testAccIosxeEVPNEthernetSegmentConfig_all() string {
 	config += `	redundancy_all_active = false` + "\n"
 	config += `	redundancy_single_active = true` + "\n"
 	config += `	identifier_types = [{` + "\n"
-	config += `		type = 0` + "\n"
-	config += `		hex_string = "0001.0000.0000.0000.000A"` + "\n"
-	config += `		system_mac = "00:11:22:33:44:55"` + "\n"
+	config += `		type = 3` + "\n"
+	config += `		system_mac = "0011.2233.4455"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
Closes #347.

This PR modifies the definition files for EVPN Ethernet Segments such that identifiers have properly-formatted examples compliant with the format that IOS-XE accepts.

Can confirm that acceptance tests now pass locally:

```
➜  terraform-provider-iosxe git:(fix/evpn-ethernet-segment-tests) ✗ go test -v ./... -run TestAccDataSourceIosxeEVPNEthernetSegment
?   	github.com/CiscoDevNet/terraform-provider-iosxe	[no test files]
=== RUN   TestAccDataSourceIosxeEVPNEthernetSegment
--- PASS: TestAccDataSourceIosxeEVPNEthernetSegment (50.81s)
PASS
ok  	github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider	51.314s
?   	github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers	[no test files]
```

As a side note - the data model schema generally allows users to provide MAC addresses in multiple different formats. Without some kind of normalization logic that translates the user-provided format into the YANG-required format, we will inevitably run into issues where the user-provided format is incompatible with the YANG-required format. However, forcing specific attributes of the data model to have specific formats does not create a great user experience.

In my opinion, there should be utility functions in the provider to perform this normalization logic (as doing this in the module via HCL might get messy). If the team agrees, I can submit a PR that introduces an example of what this normalization logic might look like.