### PR TITLE
Add version tag to logging_count attribute for IOS-XE 17.15+

### DIFF
--- a/docs/resources/logging.md
+++ b/docs/resources/logging.md
@@ -135,7 +135,6 @@ resource "iosxe_logging" "example" {
       ]
     }
   ]
-  logging_count       = true
   persistent_url      = "flash:/local_logging"
   persistent_size     = 1000000
   persistent_filesize = 500000

--- a/examples/resources/iosxe_logging/resource.tf
+++ b/examples/resources/iosxe_logging/resource.tf
@@ -120,7 +120,6 @@ resource "iosxe_logging" "example" {
       ]
     }
   ]
-  logging_count       = true
   persistent_url      = "flash:/local_logging"
   persistent_size     = 1000000
   persistent_filesize = 500000

--- a/gen/definitions/logging.yaml
+++ b/gen/definitions/logging.yaml
@@ -237,6 +237,7 @@ attributes:
   - yang_name: count
     tf_name: logging_count
     example: true
+    test_tags: [IOSXE1715]
   - yang_name: persistent/url
     example: flash:/local_logging
   - yang_name: persistent/size

--- a/internal/provider/data_source_iosxe_logging_test.go
+++ b/internal/provider/data_source_iosxe_logging_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -69,7 +70,9 @@ func TestAccDataSourceIosxeLogging(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_udp_ports.0.port_number", "10000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_tcp_ports.0.port_number", "10001"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_tls_ports.0.port_number", "10002"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "logging_count", "true"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "logging_count", "true"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_url", "flash:/local_logging"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_size", "1000000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_filesize", "500000"))
@@ -196,7 +199,9 @@ func testAccDataSourceIosxeLoggingConfig() string {
 	config += `			port_number = 10002` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
-	config += `	logging_count = true` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `	logging_count = true` + "\n"
+	}
 	config += `	persistent_url = "flash:/local_logging"` + "\n"
 	config += `	persistent_size = 1000000` + "\n"
 	config += `	persistent_filesize = 500000` + "\n"

--- a/internal/provider/resource_iosxe_logging_test.go
+++ b/internal/provider/resource_iosxe_logging_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -71,7 +72,9 @@ func TestAccIosxeLogging(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_udp_ports.0.port_number", "10000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_tcp_ports.0.port_number", "10001"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "ipv6_vrf_hosts_transport.0.transport_tls_ports.0.port_number", "10002"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "logging_count", "true"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "logging_count", "true"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_url", "flash:/local_logging"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_size", "1000000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_filesize", "500000"))
@@ -92,7 +95,7 @@ func TestAccIosxeLogging(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeLoggingImportStateIdFunc("iosxe_logging.test"),
-				ImportStateVerifyIgnore: []string{"persistent_immediate", "persistent_notify", "persistent_protected"},
+				ImportStateVerifyIgnore: []string{"logging_count", "persistent_immediate", "persistent_notify", "persistent_protected"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -231,7 +234,9 @@ func testAccIosxeLoggingConfig_all() string {
 	config += `			port_number = 10002` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
-	config += `	logging_count = true` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `	logging_count = true` + "\n"
+	}
 	config += `	persistent_url = "flash:/local_logging"` + "\n"
 	config += `	persistent_size = 1000000` + "\n"
 	config += `	persistent_filesize = 500000` + "\n"


### PR DESCRIPTION
  ## Problem

  The `TestAccDataSourceIosxeLogging` test is failing on IOS-XE 17.12 devices in CI when testing
  the `logging_count` attribute.

  ## Root Cause

  The `logging count` CLI command exists in IOS-XE 17.12, but YANG model support for this feature was not
  added until IOS-XE 17.15:
  - **17.12 YANG:** Module version 4.4.0 (revision 2023-03-01) - no `count` element
  - **17.15 YANG:** Module version 4.5.0 (revision 2024-03-01) - added "Logging on and logging count model"

  ## Solution

  Add `test_tags: [IOSXE1715]` to the `logging_count` attribute in the definition file. This will cause tests
   to skip this attribute on devices running earlier versions while keeping it available for 17.15+ devices.

  ## Testing

  - CI tests on 17.12 devices will skip `logging_count` validation
  - CI tests on 17.15+ devices (when `IOSXE1715` env var is set) will include `logging_count` validation
  - Provider functionality unchanged - users on 17.15+ can still configure this attribute
  
 ##   Introduced In

  Commit: eebfc47fdb386c045e6bf3861e434b5d8a2ba6fb
  PR: #334 
  Author: @tech-of-all-trades
  Date: Nov 4, 2025