### PR TITLE
[OSPF] Implement Advanced OSPF Support in Terraform Provider 

### DIFF
--- a/docs/data-sources/interface_ospf.md
+++ b/docs/data-sources/interface_ospf.md
@@ -39,6 +39,7 @@ data "iosxe_interface_ospf" "example" {
 - `id` (String) The path of the retrieved object.
 - `message_digest_keys` (Attributes List) Message digest authentication password (key) (see [below for nested schema](#nestedatt--message_digest_keys))
 - `mtu_ignore` (Boolean) Ignores the MTU in DBD packets
+- `multi_area_ids` (Attributes List) Set the OSPF multi-area ID (see [below for nested schema](#nestedatt--multi_area_ids))
 - `network_type_broadcast` (Boolean) Specify OSPF broadcast multi-access network
 - `network_type_non_broadcast` (Boolean) Specify OSPF NBMA network
 - `network_type_point_to_multipoint` (Boolean) Specify OSPF point-to-multipoint network
@@ -55,6 +56,14 @@ Read-Only:
 - `id` (Number) Key ID
 - `md5_auth_key` (String, Sensitive) The OSPF password (key) (only the first 16 characters are used)
 - `md5_auth_type` (Number) Encryption type (0 for not yet encrypted, 7 for proprietary)
+
+
+<a id="nestedatt--multi_area_ids"></a>
+### Nested Schema for `multi_area_ids`
+
+Read-Only:
+
+- `area_id` (String) OSPF multi-area ID
 
 
 <a id="nestedatt--process_ids"></a>

--- a/docs/data-sources/ospf.md
+++ b/docs/data-sources/ospf.md
@@ -39,11 +39,24 @@ data "iosxe_ospf" "example" {
 - `default_metric` (Number) Set metric of redistributed routes
 - `distance` (Number) Administrative distance
 - `domain_tag` (Number) OSPF domain-tag
+- `fast_reroute_per_prefix_enable_prefix_priority` (String) Priority of prefixes to be protected
 - `id` (String) The path of the retrieved object.
+- `log_adjacency_changes` (Boolean) Log changes in adjacency state
+- `log_adjacency_changes_detail` (Boolean) Log all state changes
+- `max_metric_router_lsa` (Boolean) Maximum metric in self-originated router-LSAs
+- `max_metric_router_lsa_external_lsa_metric` (Number)
+- `max_metric_router_lsa_include_stub` (Boolean) Set maximum metric for stub links in router-LSAs
+- `max_metric_router_lsa_on_startup_time` (Number)
+- `max_metric_router_lsa_on_startup_wait_for_bgp` (Boolean) Let BGP decide when to originate router-LSA with normal metric
+- `max_metric_router_lsa_summary_lsa_metric` (Number)
 - `mpls_ldp_autoconfig` (Boolean) Configure LDP automatic configuration
 - `mpls_ldp_sync` (Boolean) Configure LDP-IGP Synchronization
 - `neighbors` (Attributes List) Specify a neighbor router (see [below for nested schema](#nestedatt--neighbors))
 - `networks` (Attributes List) Enable routing on an IP network (see [below for nested schema](#nestedatt--networks))
+- `nsf_cisco` (Boolean) Cisco Non-stop forwarding
+- `nsf_cisco_enforce_global` (Boolean) For the whole OSPF process
+- `nsf_ietf` (Boolean) IETF graceful restart
+- `nsf_ietf_restart_interval` (Number) Graceful restart interval
 - `passive_interface` (List of String)
 - `passive_interface_default` (Boolean) Suppress routing updates on all interfaces
 - `passive_interface_disable_five_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_five_gigabit_ethernets))
@@ -61,6 +74,8 @@ data "iosxe_ospf" "example" {
 - `passive_interface_disable_two_hundred_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_two_hundred_gigabit_ethernets))
 - `passive_interface_disable_vlans` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_vlans))
 - `priority` (Number) OSPF topology priority
+- `redistribute_connected_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
+- `redistribute_static_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
 - `router_id` (String) Configure router identifier. New router-id will take effect immediately (peers will reset)
 - `shutdown` (Boolean) Shutdown the OSPF protocol under the current instance
 - `summary_addresses` (Attributes List) Configure IP address summaries (see [below for nested schema](#nestedatt--summary_addresses))

--- a/docs/data-sources/ospf_vrf.md
+++ b/docs/data-sources/ospf_vrf.md
@@ -42,10 +42,22 @@ data "iosxe_ospf_vrf" "example" {
 - `distance` (Number) Administrative distance
 - `domain_tag` (Number) OSPF domain-tag
 - `id` (String) The path of the retrieved object.
+- `log_adjacency_changes` (Boolean) Log changes in adjacency state
+- `log_adjacency_changes_detail` (Boolean) Log all state changes
+- `max_metric_router_lsa` (Boolean) Maximum metric in self-originated router-LSAs
+- `max_metric_router_lsa_external_lsa_metric` (Number)
+- `max_metric_router_lsa_include_stub` (Boolean) Set maximum metric for stub links in router-LSAs
+- `max_metric_router_lsa_on_startup_time` (Number)
+- `max_metric_router_lsa_on_startup_wait_for_bgp` (Boolean) Let BGP decide when to originate router-LSA with normal metric
+- `max_metric_router_lsa_summary_lsa_metric` (Number)
 - `mpls_ldp_autoconfig` (Boolean) Configure LDP automatic configuration
 - `mpls_ldp_sync` (Boolean) Configure LDP-IGP Synchronization
 - `neighbor` (Attributes List) Specify a neighbor router (see [below for nested schema](#nestedatt--neighbor))
 - `network` (Attributes List) Enable routing on an IP network (see [below for nested schema](#nestedatt--network))
+- `nsf_cisco` (Boolean) Cisco Non-stop forwarding
+- `nsf_cisco_enforce_global` (Boolean) For the whole OSPF process
+- `nsf_ietf` (Boolean) IETF graceful restart
+- `nsf_ietf_restart_interval` (Number) Graceful restart interval
 - `passive_interface` (List of String)
 - `passive_interface_default` (Boolean) Suppress routing updates on all interfaces
 - `passive_interface_disable_five_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_five_gigabit_ethernets))
@@ -63,6 +75,8 @@ data "iosxe_ospf_vrf" "example" {
 - `passive_interface_disable_two_hundred_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_two_hundred_gigabit_ethernets))
 - `passive_interface_disable_vlans` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_vlans))
 - `priority` (Number) OSPF topology priority
+- `redistribute_connected_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
+- `redistribute_static_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
 - `router_id` (String) Configure router identifier. New router-id will take effect immediately (peers will reset)
 - `shutdown` (Boolean) Shutdown the OSPF protocol under the current instance
 - `summary_address` (Attributes List) Configure IP address summaries (see [below for nested schema](#nestedatt--summary_address))

--- a/docs/resources/interface_ospf.md
+++ b/docs/resources/interface_ospf.md
@@ -36,6 +36,11 @@ resource "iosxe_interface_ospf" "example" {
       ]
     }
   ]
+  multi_area_ids = [
+    {
+      area_id = "10"
+    }
+  ]
   message_digest_keys = [
     {
       id            = 1
@@ -68,6 +73,7 @@ resource "iosxe_interface_ospf" "example" {
   - Range: `1`-`65535`
 - `message_digest_keys` (Attributes List) Message digest authentication password (key) (see [below for nested schema](#nestedatt--message_digest_keys))
 - `mtu_ignore` (Boolean) Ignores the MTU in DBD packets
+- `multi_area_ids` (Attributes List) Set the OSPF multi-area ID (see [below for nested schema](#nestedatt--multi_area_ids))
 - `network_type_broadcast` (Boolean) Specify OSPF broadcast multi-access network
 - `network_type_non_broadcast` (Boolean) Specify OSPF NBMA network
 - `network_type_point_to_multipoint` (Boolean) Specify OSPF point-to-multipoint network
@@ -95,6 +101,14 @@ Optional:
 - `md5_auth_key` (String, Sensitive) The OSPF password (key) (only the first 16 characters are used)
 - `md5_auth_type` (Number) Encryption type (0 for not yet encrypted, 7 for proprietary)
   - Range: `0`-`7`
+
+
+<a id="nestedatt--multi_area_ids"></a>
+### Nested Schema for `multi_area_ids`
+
+Required:
+
+- `area_id` (String) OSPF multi-area ID
 
 
 <a id="nestedatt--process_ids"></a>

--- a/docs/resources/ospf.md
+++ b/docs/resources/ospf.md
@@ -56,8 +56,23 @@ resource "iosxe_ospf" "example" {
       nssa_no_redistribution                         = true
     }
   ]
-  auto_cost_reference_bandwidth = 40000
-  passive_interface_default     = true
+  auto_cost_reference_bandwidth                  = 40000
+  passive_interface_default                      = true
+  log_adjacency_changes                          = true
+  log_adjacency_changes_detail                   = true
+  nsf_cisco                                      = true
+  nsf_cisco_enforce_global                       = true
+  nsf_ietf                                       = true
+  nsf_ietf_restart_interval                      = 120
+  max_metric_router_lsa                          = true
+  max_metric_router_lsa_summary_lsa_metric       = 16711680
+  max_metric_router_lsa_external_lsa_metric      = 16711680
+  max_metric_router_lsa_include_stub             = true
+  max_metric_router_lsa_on_startup_time          = 60
+  max_metric_router_lsa_on_startup_wait_for_bgp  = true
+  fast_reroute_per_prefix_enable_prefix_priority = "high"
+  redistribute_static_subnets                    = true
+  redistribute_connected_subnets                 = true
 }
 ```
 
@@ -86,10 +101,25 @@ resource "iosxe_ospf" "example" {
   - Range: `1`-`255`
 - `domain_tag` (Number) OSPF domain-tag
   - Range: `1`-`4294967295`
+- `fast_reroute_per_prefix_enable_prefix_priority` (String) Priority of prefixes to be protected
+  - Choices: `high`, `low`
+- `log_adjacency_changes` (Boolean) Log changes in adjacency state
+- `log_adjacency_changes_detail` (Boolean) Log all state changes
+- `max_metric_router_lsa` (Boolean) Maximum metric in self-originated router-LSAs
+- `max_metric_router_lsa_external_lsa_metric` (Number) - Range: `1`-`16777214`
+- `max_metric_router_lsa_include_stub` (Boolean) Set maximum metric for stub links in router-LSAs
+- `max_metric_router_lsa_on_startup_time` (Number) - Range: `5`-`86400`
+- `max_metric_router_lsa_on_startup_wait_for_bgp` (Boolean) Let BGP decide when to originate router-LSA with normal metric
+- `max_metric_router_lsa_summary_lsa_metric` (Number) - Range: `1`-`16777214`
 - `mpls_ldp_autoconfig` (Boolean) Configure LDP automatic configuration
 - `mpls_ldp_sync` (Boolean) Configure LDP-IGP Synchronization
 - `neighbors` (Attributes List) Specify a neighbor router (see [below for nested schema](#nestedatt--neighbors))
 - `networks` (Attributes List) Enable routing on an IP network (see [below for nested schema](#nestedatt--networks))
+- `nsf_cisco` (Boolean) Cisco Non-stop forwarding
+- `nsf_cisco_enforce_global` (Boolean) For the whole OSPF process
+- `nsf_ietf` (Boolean) IETF graceful restart
+- `nsf_ietf_restart_interval` (Number) Graceful restart interval
+  - Range: `1`-`1800`
 - `passive_interface` (List of String)
 - `passive_interface_default` (Boolean) Suppress routing updates on all interfaces
 - `passive_interface_disable_five_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_five_gigabit_ethernets))
@@ -108,6 +138,8 @@ resource "iosxe_ospf" "example" {
 - `passive_interface_disable_vlans` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_vlans))
 - `priority` (Number) OSPF topology priority
   - Range: `0`-`127`
+- `redistribute_connected_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
+- `redistribute_static_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
 - `router_id` (String) Configure router identifier. New router-id will take effect immediately (peers will reset)
 - `shutdown` (Boolean) Shutdown the OSPF protocol under the current instance
 - `summary_addresses` (Attributes List) Configure IP address summaries (see [below for nested schema](#nestedatt--summary_addresses))

--- a/docs/resources/ospf_vrf.md
+++ b/docs/resources/ospf_vrf.md
@@ -14,14 +14,28 @@ This resource can manage the OSPF VRF configuration.
 
 ```terraform
 resource "iosxe_ospf_vrf" "example" {
-  process_id                           = 2
-  vrf                                  = "VRF1"
-  bfd_all_interfaces                   = true
-  default_information_originate        = true
-  default_information_originate_always = true
-  default_metric                       = 21
-  distance                             = 120
-  domain_tag                           = 10
+  process_id                                    = 2
+  vrf                                           = "VRF1"
+  bfd_all_interfaces                            = true
+  default_information_originate                 = true
+  default_information_originate_always          = true
+  default_metric                                = 21
+  distance                                      = 120
+  domain_tag                                    = 10
+  log_adjacency_changes                         = true
+  log_adjacency_changes_detail                  = true
+  nsf_cisco                                     = true
+  nsf_cisco_enforce_global                      = true
+  nsf_ietf                                      = true
+  nsf_ietf_restart_interval                     = 120
+  max_metric_router_lsa                         = true
+  max_metric_router_lsa_summary_lsa_metric      = 16711680
+  max_metric_router_lsa_external_lsa_metric     = 16711680
+  max_metric_router_lsa_include_stub            = true
+  max_metric_router_lsa_on_startup_time         = 60
+  max_metric_router_lsa_on_startup_wait_for_bgp = true
+  redistribute_static_subnets                   = true
+  redistribute_connected_subnets                = true
   neighbor = [
     {
       ip       = "2.2.2.2"
@@ -88,10 +102,23 @@ resource "iosxe_ospf_vrf" "example" {
   - Range: `1`-`255`
 - `domain_tag` (Number) OSPF domain-tag
   - Range: `1`-`4294967295`
+- `log_adjacency_changes` (Boolean) Log changes in adjacency state
+- `log_adjacency_changes_detail` (Boolean) Log all state changes
+- `max_metric_router_lsa` (Boolean) Maximum metric in self-originated router-LSAs
+- `max_metric_router_lsa_external_lsa_metric` (Number) - Range: `1`-`16777214`
+- `max_metric_router_lsa_include_stub` (Boolean) Set maximum metric for stub links in router-LSAs
+- `max_metric_router_lsa_on_startup_time` (Number) - Range: `5`-`86400`
+- `max_metric_router_lsa_on_startup_wait_for_bgp` (Boolean) Let BGP decide when to originate router-LSA with normal metric
+- `max_metric_router_lsa_summary_lsa_metric` (Number) - Range: `1`-`16777214`
 - `mpls_ldp_autoconfig` (Boolean) Configure LDP automatic configuration
 - `mpls_ldp_sync` (Boolean) Configure LDP-IGP Synchronization
 - `neighbor` (Attributes List) Specify a neighbor router (see [below for nested schema](#nestedatt--neighbor))
 - `network` (Attributes List) Enable routing on an IP network (see [below for nested schema](#nestedatt--network))
+- `nsf_cisco` (Boolean) Cisco Non-stop forwarding
+- `nsf_cisco_enforce_global` (Boolean) For the whole OSPF process
+- `nsf_ietf` (Boolean) IETF graceful restart
+- `nsf_ietf_restart_interval` (Number) Graceful restart interval
+  - Range: `1`-`1800`
 - `passive_interface` (List of String)
 - `passive_interface_default` (Boolean) Suppress routing updates on all interfaces
 - `passive_interface_disable_five_gigabit_ethernets` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_five_gigabit_ethernets))
@@ -110,6 +137,8 @@ resource "iosxe_ospf_vrf" "example" {
 - `passive_interface_disable_vlans` (Attributes Set) (see [below for nested schema](#nestedatt--passive_interface_disable_vlans))
 - `priority` (Number) OSPF topology priority
   - Range: `0`-`127`
+- `redistribute_connected_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
+- `redistribute_static_subnets` (Boolean) Consider subnets for redistribution into OSPF (Will be removed in the future)
 - `router_id` (String) Configure router identifier. New router-id will take effect immediately (peers will reset)
 - `shutdown` (Boolean) Shutdown the OSPF protocol under the current instance
 - `summary_address` (Attributes List) Configure IP address summaries (see [below for nested schema](#nestedatt--summary_address))

--- a/examples/resources/iosxe_interface_ospf/resource.tf
+++ b/examples/resources/iosxe_interface_ospf/resource.tf
@@ -21,6 +21,11 @@ resource "iosxe_interface_ospf" "example" {
       ]
     }
   ]
+  multi_area_ids = [
+    {
+      area_id = "10"
+    }
+  ]
   message_digest_keys = [
     {
       id            = 1

--- a/examples/resources/iosxe_ospf/resource.tf
+++ b/examples/resources/iosxe_ospf/resource.tf
@@ -41,6 +41,21 @@ resource "iosxe_ospf" "example" {
       nssa_no_redistribution                         = true
     }
   ]
-  auto_cost_reference_bandwidth = 40000
-  passive_interface_default     = true
+  auto_cost_reference_bandwidth                  = 40000
+  passive_interface_default                      = true
+  log_adjacency_changes                          = true
+  log_adjacency_changes_detail                   = true
+  nsf_cisco                                      = true
+  nsf_cisco_enforce_global                       = true
+  nsf_ietf                                       = true
+  nsf_ietf_restart_interval                      = 120
+  max_metric_router_lsa                          = true
+  max_metric_router_lsa_summary_lsa_metric       = 16711680
+  max_metric_router_lsa_external_lsa_metric      = 16711680
+  max_metric_router_lsa_include_stub             = true
+  max_metric_router_lsa_on_startup_time          = 60
+  max_metric_router_lsa_on_startup_wait_for_bgp  = true
+  fast_reroute_per_prefix_enable_prefix_priority = "high"
+  redistribute_static_subnets                    = true
+  redistribute_connected_subnets                 = true
 }

--- a/examples/resources/iosxe_ospf_vrf/resource.tf
+++ b/examples/resources/iosxe_ospf_vrf/resource.tf
@@ -1,12 +1,26 @@
 resource "iosxe_ospf_vrf" "example" {
-  process_id                           = 2
-  vrf                                  = "VRF1"
-  bfd_all_interfaces                   = true
-  default_information_originate        = true
-  default_information_originate_always = true
-  default_metric                       = 21
-  distance                             = 120
-  domain_tag                           = 10
+  process_id                                    = 2
+  vrf                                           = "VRF1"
+  bfd_all_interfaces                            = true
+  default_information_originate                 = true
+  default_information_originate_always          = true
+  default_metric                                = 21
+  distance                                      = 120
+  domain_tag                                    = 10
+  log_adjacency_changes                         = true
+  log_adjacency_changes_detail                  = true
+  nsf_cisco                                     = true
+  nsf_cisco_enforce_global                      = true
+  nsf_ietf                                      = true
+  nsf_ietf_restart_interval                     = 120
+  max_metric_router_lsa                         = true
+  max_metric_router_lsa_summary_lsa_metric      = 16711680
+  max_metric_router_lsa_external_lsa_metric     = 16711680
+  max_metric_router_lsa_include_stub            = true
+  max_metric_router_lsa_on_startup_time         = 60
+  max_metric_router_lsa_on_startup_wait_for_bgp = true
+  redistribute_static_subnets                   = true
+  redistribute_connected_subnets                = true
   neighbor = [
     {
       ip       = "2.2.2.2"

--- a/gen/definitions/interface_ospf.yaml
+++ b/gen/definitions/interface_ospf.yaml
@@ -71,6 +71,14 @@ attributes:
           - yang_name: area-id
             id: true
             example: 0
+  - yang_name: multi-area/multi-area-id
+    tf_name: multi_area_ids
+    type: List
+    attributes:
+      - yang_name: area-id
+        id: true
+        type: String
+        example: "10"
   - yang_name: message-digest-key
     tf_name: message_digest_keys
     type: List

--- a/gen/definitions/ospf.yaml
+++ b/gen/definitions/ospf.yaml
@@ -99,6 +99,52 @@ attributes:
     tf_name: passive_interface
     example: Loopback0
     exclude_test: true
+  - yang_name: log-adjacency-changes-choice/log-adjacency-changes/log-adjacency-changes
+    xpath: log-adjacency-changes
+    tf_name: log_adjacency_changes
+    example: true
+  - yang_name: log-adjacency-changes-choice/log-adjacency-changes-detail/log-adjacency-changes-detail/log-adjacency-changes/detail
+    xpath: log-adjacency-changes-detail/log-adjacency-changes/detail
+    tf_name: log_adjacency_changes_detail
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-cisco/nsf-cisco
+    xpath: nsf/nsf-cisco
+    tf_name: nsf_cisco
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-cisco/nsf-cisco/enforce/global
+    xpath: nsf/nsf-cisco/enforce/global
+    tf_name: nsf_cisco_enforce_global
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-ietf/nsf-ietf
+    xpath: nsf/nsf-ietf
+    tf_name: nsf_ietf
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-ietf/nsf-ietf/restart-interval
+    xpath: nsf/nsf-ietf/restart-interval
+    tf_name: nsf_ietf_restart_interval
+    example: 120
+  - yang_name: max-metric/router-lsa
+    example: true
+  - yang_name: max-metric/router-lsa/summary-lsa/metric
+    example: 16711680
+  - yang_name: max-metric/router-lsa/external-lsa/metric
+    example: 16711680
+  - yang_name: max-metric/router-lsa/include-stub
+    example: true
+  - yang_name: max-metric/router-lsa/on-startup/time-wait-for-bgp-choice/time/time
+    xpath: max-metric/router-lsa/on-startup/time
+    tf_name: max_metric_router_lsa_on_startup_time
+    example: 60
+  - yang_name: max-metric/router-lsa/on-startup/time-wait-for-bgp-choice/wait-for-bgp/wait-for-bgp
+    xpath: max-metric/router-lsa/on-startup/wait-for-bgp
+    tf_name: max_metric_router_lsa_on_startup_wait_for_bgp
+    example: true
+  - yang_name: fast-reroute/per-prefix/enable/prefix-priority
+    example: high
+  - yang_name: redistribute/static/subnets
+    example: true
+  - yang_name: redistribute/connected/subnets
+    example: true
   - yang_name: passive-interface-config/disable-interface/GigabitEthernet
     tf_name: passive_interface_disable_gigabit_ethernets
     type: Set

--- a/gen/definitions/ospf_vrf.yaml
+++ b/gen/definitions/ospf_vrf.yaml
@@ -21,6 +21,50 @@ attributes:
     example: 120
   - yang_name: domain-tag
     example: 10
+  - yang_name: log-adjacency-changes-choice/log-adjacency-changes/log-adjacency-changes
+    xpath: log-adjacency-changes
+    tf_name: log_adjacency_changes
+    example: true
+  - yang_name: log-adjacency-changes-choice/log-adjacency-changes-detail/log-adjacency-changes-detail/log-adjacency-changes/detail
+    xpath: log-adjacency-changes-detail/log-adjacency-changes/detail
+    tf_name: log_adjacency_changes_detail
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-cisco/nsf-cisco
+    xpath: nsf/nsf-cisco
+    tf_name: nsf_cisco
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-cisco/nsf-cisco/enforce/global
+    xpath: nsf/nsf-cisco/enforce/global
+    tf_name: nsf_cisco_enforce_global
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-ietf/nsf-ietf
+    xpath: nsf/nsf-ietf
+    tf_name: nsf_ietf
+    example: true
+  - yang_name: nsf/nsf-cisco-ietf/nsf-ietf/nsf-ietf/restart-interval
+    xpath: nsf/nsf-ietf/restart-interval
+    tf_name: nsf_ietf_restart_interval
+    example: 120
+  - yang_name: max-metric/router-lsa
+    example: true
+  - yang_name: max-metric/router-lsa/summary-lsa/metric
+    example: 16711680
+  - yang_name: max-metric/router-lsa/external-lsa/metric
+    example: 16711680
+  - yang_name: max-metric/router-lsa/include-stub
+    example: true
+  - yang_name: max-metric/router-lsa/on-startup/time-wait-for-bgp-choice/time/time
+    xpath: max-metric/router-lsa/on-startup/time
+    tf_name: max_metric_router_lsa_on_startup_time
+    example: 60
+  - yang_name: max-metric/router-lsa/on-startup/time-wait-for-bgp-choice/wait-for-bgp/wait-for-bgp
+    xpath: max-metric/router-lsa/on-startup/wait-for-bgp
+    tf_name: max_metric_router_lsa_on_startup_wait_for_bgp
+    example: true
+  - yang_name: redistribute/static/subnets
+    example: true
+  - yang_name: redistribute/connected/subnets
+    example: true
   - yang_name: mpls/ldp/autoconfig
     exclude_test: true
     example: true

--- a/internal/provider/data_source_iosxe_interface_ospf.go
+++ b/internal/provider/data_source_iosxe_interface_ospf.go
@@ -139,6 +139,18 @@ func (d *InterfaceOSPFDataSource) Schema(ctx context.Context, req datasource.Sch
 					},
 				},
 			},
+			"multi_area_ids": schema.ListNestedAttribute{
+				MarkdownDescription: "Set the OSPF multi-area ID",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"area_id": schema.StringAttribute{
+							MarkdownDescription: "OSPF multi-area ID",
+							Computed:            true,
+						},
+					},
+				},
+			},
 			"message_digest_keys": schema.ListNestedAttribute{
 				MarkdownDescription: "Message digest authentication password (key)",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_interface_ospf_test.go
+++ b/internal/provider/data_source_iosxe_interface_ospf_test.go
@@ -44,6 +44,7 @@ func TestAccDataSourceIosxeInterfaceOSPF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ospf.test", "ttl_security_hops", "2"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ospf.test", "process_ids.0.id", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ospf.test", "process_ids.0.areas.0.area_id", "0"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ospf.test", "multi_area_ids.0.area_id", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ospf.test", "message_digest_keys.0.id", "1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -101,6 +102,9 @@ func testAccDataSourceIosxeInterfaceOSPFConfig() string {
 	config += `		areas = [{` + "\n"
 	config += `			area_id = "0"` + "\n"
 	config += `		}]` + "\n"
+	config += `	}]` + "\n"
+	config += `	multi_area_ids = [{` + "\n"
+	config += `		area_id = "10"` + "\n"
 	config += `	}]` + "\n"
 	config += `	message_digest_keys = [{` + "\n"
 	config += `		id = 1` + "\n"

--- a/internal/provider/data_source_iosxe_ospf.go
+++ b/internal/provider/data_source_iosxe_ospf.go
@@ -224,6 +224,66 @@ func (d *OSPFDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				ElementType:         types.StringType,
 				Computed:            true,
 			},
+			"log_adjacency_changes": schema.BoolAttribute{
+				MarkdownDescription: "Log changes in adjacency state",
+				Computed:            true,
+			},
+			"log_adjacency_changes_detail": schema.BoolAttribute{
+				MarkdownDescription: "Log all state changes",
+				Computed:            true,
+			},
+			"nsf_cisco": schema.BoolAttribute{
+				MarkdownDescription: "Cisco Non-stop forwarding",
+				Computed:            true,
+			},
+			"nsf_cisco_enforce_global": schema.BoolAttribute{
+				MarkdownDescription: "For the whole OSPF process",
+				Computed:            true,
+			},
+			"nsf_ietf": schema.BoolAttribute{
+				MarkdownDescription: "IETF graceful restart",
+				Computed:            true,
+			},
+			"nsf_ietf_restart_interval": schema.Int64Attribute{
+				MarkdownDescription: "Graceful restart interval",
+				Computed:            true,
+			},
+			"max_metric_router_lsa": schema.BoolAttribute{
+				MarkdownDescription: "Maximum metric in self-originated router-LSAs",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_summary_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_external_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_include_stub": schema.BoolAttribute{
+				MarkdownDescription: "Set maximum metric for stub links in router-LSAs",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_on_startup_time": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_on_startup_wait_for_bgp": schema.BoolAttribute{
+				MarkdownDescription: "Let BGP decide when to originate router-LSA with normal metric",
+				Computed:            true,
+			},
+			"fast_reroute_per_prefix_enable_prefix_priority": schema.StringAttribute{
+				MarkdownDescription: "Priority of prefixes to be protected",
+				Computed:            true,
+			},
+			"redistribute_static_subnets": schema.BoolAttribute{
+				MarkdownDescription: "Consider subnets for redistribution into OSPF (Will be removed in the future)",
+				Computed:            true,
+			},
+			"redistribute_connected_subnets": schema.BoolAttribute{
+				MarkdownDescription: "Consider subnets for redistribution into OSPF (Will be removed in the future)",
+				Computed:            true,
+			},
 			"passive_interface_disable_gigabit_ethernets": schema.SetNestedAttribute{
 				MarkdownDescription: "",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_ospf_test.go
+++ b/internal/provider/data_source_iosxe_ospf_test.go
@@ -59,6 +59,21 @@ func TestAccDataSourceIosxeOSPF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "areas.0.nssa_no_redistribution", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "auto_cost_reference_bandwidth", "40000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "passive_interface_default", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "log_adjacency_changes", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "log_adjacency_changes_detail", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "nsf_cisco", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "nsf_cisco_enforce_global", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "nsf_ietf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "nsf_ietf_restart_interval", "120"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa_summary_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa_include_stub", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa_on_startup_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "max_metric_router_lsa_on_startup_wait_for_bgp", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "fast_reroute_per_prefix_enable_prefix_priority", "high"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "redistribute_static_subnets", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf.test", "redistribute_connected_subnets", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -117,6 +132,21 @@ func testAccDataSourceIosxeOSPFConfig() string {
 	config += `	}]` + "\n"
 	config += `	auto_cost_reference_bandwidth = 40000` + "\n"
 	config += `	passive_interface_default = true` + "\n"
+	config += `	log_adjacency_changes = true` + "\n"
+	config += `	log_adjacency_changes_detail = true` + "\n"
+	config += `	nsf_cisco = true` + "\n"
+	config += `	nsf_cisco_enforce_global = true` + "\n"
+	config += `	nsf_ietf = true` + "\n"
+	config += `	nsf_ietf_restart_interval = 120` + "\n"
+	config += `	max_metric_router_lsa = true` + "\n"
+	config += `	max_metric_router_lsa_summary_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_include_stub = true` + "\n"
+	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
+	config += `	max_metric_router_lsa_on_startup_wait_for_bgp = true` + "\n"
+	config += `	fast_reroute_per_prefix_enable_prefix_priority = "high"` + "\n"
+	config += `	redistribute_static_subnets = true` + "\n"
+	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/data_source_iosxe_ospf_vrf.go
+++ b/internal/provider/data_source_iosxe_ospf_vrf.go
@@ -99,6 +99,62 @@ func (d *OSPFVRFDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "OSPF domain-tag",
 				Computed:            true,
 			},
+			"log_adjacency_changes": schema.BoolAttribute{
+				MarkdownDescription: "Log changes in adjacency state",
+				Computed:            true,
+			},
+			"log_adjacency_changes_detail": schema.BoolAttribute{
+				MarkdownDescription: "Log all state changes",
+				Computed:            true,
+			},
+			"nsf_cisco": schema.BoolAttribute{
+				MarkdownDescription: "Cisco Non-stop forwarding",
+				Computed:            true,
+			},
+			"nsf_cisco_enforce_global": schema.BoolAttribute{
+				MarkdownDescription: "For the whole OSPF process",
+				Computed:            true,
+			},
+			"nsf_ietf": schema.BoolAttribute{
+				MarkdownDescription: "IETF graceful restart",
+				Computed:            true,
+			},
+			"nsf_ietf_restart_interval": schema.Int64Attribute{
+				MarkdownDescription: "Graceful restart interval",
+				Computed:            true,
+			},
+			"max_metric_router_lsa": schema.BoolAttribute{
+				MarkdownDescription: "Maximum metric in self-originated router-LSAs",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_summary_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_external_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_include_stub": schema.BoolAttribute{
+				MarkdownDescription: "Set maximum metric for stub links in router-LSAs",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_on_startup_time": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Computed:            true,
+			},
+			"max_metric_router_lsa_on_startup_wait_for_bgp": schema.BoolAttribute{
+				MarkdownDescription: "Let BGP decide when to originate router-LSA with normal metric",
+				Computed:            true,
+			},
+			"redistribute_static_subnets": schema.BoolAttribute{
+				MarkdownDescription: "Consider subnets for redistribution into OSPF (Will be removed in the future)",
+				Computed:            true,
+			},
+			"redistribute_connected_subnets": schema.BoolAttribute{
+				MarkdownDescription: "Consider subnets for redistribution into OSPF (Will be removed in the future)",
+				Computed:            true,
+			},
 			"mpls_ldp_autoconfig": schema.BoolAttribute{
 				MarkdownDescription: "Configure LDP automatic configuration",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_ospf_vrf_test.go
+++ b/internal/provider/data_source_iosxe_ospf_vrf_test.go
@@ -38,6 +38,20 @@ func TestAccDataSourceIosxeOSPFVRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "default_metric", "21"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "distance", "120"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "domain_tag", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "log_adjacency_changes", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "log_adjacency_changes_detail", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "nsf_cisco", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "nsf_cisco_enforce_global", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "nsf_ietf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "nsf_ietf_restart_interval", "120"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_summary_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_include_stub", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_wait_for_bgp", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_static_subnets", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_connected_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "neighbor.0.ip", "2.2.2.2"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "neighbor.0.priority", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "neighbor.0.cost", "100"))
@@ -101,6 +115,20 @@ func testAccDataSourceIosxeOSPFVRFConfig() string {
 	config += `	default_metric = 21` + "\n"
 	config += `	distance = 120` + "\n"
 	config += `	domain_tag = 10` + "\n"
+	config += `	log_adjacency_changes = true` + "\n"
+	config += `	log_adjacency_changes_detail = true` + "\n"
+	config += `	nsf_cisco = true` + "\n"
+	config += `	nsf_cisco_enforce_global = true` + "\n"
+	config += `	nsf_ietf = true` + "\n"
+	config += `	nsf_ietf_restart_interval = 120` + "\n"
+	config += `	max_metric_router_lsa = true` + "\n"
+	config += `	max_metric_router_lsa_summary_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_include_stub = true` + "\n"
+	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
+	config += `	max_metric_router_lsa_on_startup_wait_for_bgp = true` + "\n"
+	config += `	redistribute_static_subnets = true` + "\n"
+	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `	neighbor = [{` + "\n"
 	config += `		ip = "2.2.2.2"` + "\n"
 	config += `		priority = 10` + "\n"

--- a/internal/provider/model_iosxe_ospf.go
+++ b/internal/provider/model_iosxe_ospf.go
@@ -61,6 +61,21 @@ type OSPF struct {
 	AutoCostReferenceBandwidth                         types.Int64                                              `tfsdk:"auto_cost_reference_bandwidth"`
 	PassiveInterfaceDefault                            types.Bool                                               `tfsdk:"passive_interface_default"`
 	PassiveInterface                                   types.List                                               `tfsdk:"passive_interface"`
+	LogAdjacencyChanges                                types.Bool                                               `tfsdk:"log_adjacency_changes"`
+	LogAdjacencyChangesDetail                          types.Bool                                               `tfsdk:"log_adjacency_changes_detail"`
+	NsfCisco                                           types.Bool                                               `tfsdk:"nsf_cisco"`
+	NsfCiscoEnforceGlobal                              types.Bool                                               `tfsdk:"nsf_cisco_enforce_global"`
+	NsfIetf                                            types.Bool                                               `tfsdk:"nsf_ietf"`
+	NsfIetfRestartInterval                             types.Int64                                              `tfsdk:"nsf_ietf_restart_interval"`
+	MaxMetricRouterLsa                                 types.Bool                                               `tfsdk:"max_metric_router_lsa"`
+	MaxMetricRouterLsaSummaryLsaMetric                 types.Int64                                              `tfsdk:"max_metric_router_lsa_summary_lsa_metric"`
+	MaxMetricRouterLsaExternalLsaMetric                types.Int64                                              `tfsdk:"max_metric_router_lsa_external_lsa_metric"`
+	MaxMetricRouterLsaIncludeStub                      types.Bool                                               `tfsdk:"max_metric_router_lsa_include_stub"`
+	MaxMetricRouterLsaOnStartupTime                    types.Int64                                              `tfsdk:"max_metric_router_lsa_on_startup_time"`
+	MaxMetricRouterLsaOnStartupWaitForBgp              types.Bool                                               `tfsdk:"max_metric_router_lsa_on_startup_wait_for_bgp"`
+	FastReroutePerPrefixEnablePrefixPriority           types.String                                             `tfsdk:"fast_reroute_per_prefix_enable_prefix_priority"`
+	RedistributeStaticSubnets                          types.Bool                                               `tfsdk:"redistribute_static_subnets"`
+	RedistributeConnectedSubnets                       types.Bool                                               `tfsdk:"redistribute_connected_subnets"`
 	PassiveInterfaceDisableGigabitEthernets            []OSPFPassiveInterfaceDisableGigabitEthernets            `tfsdk:"passive_interface_disable_gigabit_ethernets"`
 	PassiveInterfaceDisableTwoGigabitEthernets         []OSPFPassiveInterfaceDisableTwoGigabitEthernets         `tfsdk:"passive_interface_disable_two_gigabit_ethernets"`
 	PassiveInterfaceDisableFiveGigabitEthernets        []OSPFPassiveInterfaceDisableFiveGigabitEthernets        `tfsdk:"passive_interface_disable_five_gigabit_ethernets"`
@@ -99,6 +114,21 @@ type OSPFData struct {
 	AutoCostReferenceBandwidth                         types.Int64                                              `tfsdk:"auto_cost_reference_bandwidth"`
 	PassiveInterfaceDefault                            types.Bool                                               `tfsdk:"passive_interface_default"`
 	PassiveInterface                                   types.List                                               `tfsdk:"passive_interface"`
+	LogAdjacencyChanges                                types.Bool                                               `tfsdk:"log_adjacency_changes"`
+	LogAdjacencyChangesDetail                          types.Bool                                               `tfsdk:"log_adjacency_changes_detail"`
+	NsfCisco                                           types.Bool                                               `tfsdk:"nsf_cisco"`
+	NsfCiscoEnforceGlobal                              types.Bool                                               `tfsdk:"nsf_cisco_enforce_global"`
+	NsfIetf                                            types.Bool                                               `tfsdk:"nsf_ietf"`
+	NsfIetfRestartInterval                             types.Int64                                              `tfsdk:"nsf_ietf_restart_interval"`
+	MaxMetricRouterLsa                                 types.Bool                                               `tfsdk:"max_metric_router_lsa"`
+	MaxMetricRouterLsaSummaryLsaMetric                 types.Int64                                              `tfsdk:"max_metric_router_lsa_summary_lsa_metric"`
+	MaxMetricRouterLsaExternalLsaMetric                types.Int64                                              `tfsdk:"max_metric_router_lsa_external_lsa_metric"`
+	MaxMetricRouterLsaIncludeStub                      types.Bool                                               `tfsdk:"max_metric_router_lsa_include_stub"`
+	MaxMetricRouterLsaOnStartupTime                    types.Int64                                              `tfsdk:"max_metric_router_lsa_on_startup_time"`
+	MaxMetricRouterLsaOnStartupWaitForBgp              types.Bool                                               `tfsdk:"max_metric_router_lsa_on_startup_wait_for_bgp"`
+	FastReroutePerPrefixEnablePrefixPriority           types.String                                             `tfsdk:"fast_reroute_per_prefix_enable_prefix_priority"`
+	RedistributeStaticSubnets                          types.Bool                                               `tfsdk:"redistribute_static_subnets"`
+	RedistributeConnectedSubnets                       types.Bool                                               `tfsdk:"redistribute_connected_subnets"`
 	PassiveInterfaceDisableGigabitEthernets            []OSPFPassiveInterfaceDisableGigabitEthernets            `tfsdk:"passive_interface_disable_gigabit_ethernets"`
 	PassiveInterfaceDisableTwoGigabitEthernets         []OSPFPassiveInterfaceDisableTwoGigabitEthernets         `tfsdk:"passive_interface_disable_two_gigabit_ethernets"`
 	PassiveInterfaceDisableFiveGigabitEthernets        []OSPFPassiveInterfaceDisableFiveGigabitEthernets        `tfsdk:"passive_interface_disable_five_gigabit_ethernets"`
@@ -266,6 +296,69 @@ func (data OSPF) toBody(ctx context.Context) string {
 		var values []string
 		data.PassiveInterface.ElementsAs(ctx, &values, false)
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"passive-interface.interface", values)
+	}
+	if !data.LogAdjacencyChanges.IsNull() && !data.LogAdjacencyChanges.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"log-adjacency-changes", data.LogAdjacencyChanges.ValueBool())
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() && !data.LogAdjacencyChangesDetail.IsUnknown() {
+		if data.LogAdjacencyChangesDetail.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"log-adjacency-changes-detail.log-adjacency-changes.detail", map[string]string{})
+		}
+	}
+	if !data.NsfCisco.IsNull() && !data.NsfCisco.IsUnknown() {
+		if data.NsfCisco.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-cisco", map[string]string{})
+		}
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() && !data.NsfCiscoEnforceGlobal.IsUnknown() {
+		if data.NsfCiscoEnforceGlobal.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-cisco.enforce.global", map[string]string{})
+		}
+	}
+	if !data.NsfIetf.IsNull() && !data.NsfIetf.IsUnknown() {
+		if data.NsfIetf.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-ietf", map[string]string{})
+		}
+	}
+	if !data.NsfIetfRestartInterval.IsNull() && !data.NsfIetfRestartInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-ietf.restart-interval", strconv.FormatInt(data.NsfIetfRestartInterval.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() && !data.MaxMetricRouterLsa.IsUnknown() {
+		if data.MaxMetricRouterLsa.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa", map[string]string{})
+		}
+	}
+	if !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() && !data.MaxMetricRouterLsaSummaryLsaMetric.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.summary-lsa.metric", strconv.FormatInt(data.MaxMetricRouterLsaSummaryLsaMetric.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() && !data.MaxMetricRouterLsaExternalLsaMetric.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.external-lsa.metric", strconv.FormatInt(data.MaxMetricRouterLsaExternalLsaMetric.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() && !data.MaxMetricRouterLsaIncludeStub.IsUnknown() {
+		if data.MaxMetricRouterLsaIncludeStub.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.include-stub", map[string]string{})
+		}
+	}
+	if !data.MaxMetricRouterLsaOnStartupTime.IsNull() && !data.MaxMetricRouterLsaOnStartupTime.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.on-startup.time", strconv.FormatInt(data.MaxMetricRouterLsaOnStartupTime.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsUnknown() {
+		if data.MaxMetricRouterLsaOnStartupWaitForBgp.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.on-startup.wait-for-bgp", map[string]string{})
+		}
+	}
+	if !data.FastReroutePerPrefixEnablePrefixPriority.IsNull() && !data.FastReroutePerPrefixEnablePrefixPriority.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"fast-reroute.per-prefix.enable.prefix-priority", data.FastReroutePerPrefixEnablePrefixPriority.ValueString())
+	}
+	if !data.RedistributeStaticSubnets.IsNull() && !data.RedistributeStaticSubnets.IsUnknown() {
+		if data.RedistributeStaticSubnets.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"redistribute.static.subnets", map[string]string{})
+		}
+	}
+	if !data.RedistributeConnectedSubnets.IsNull() && !data.RedistributeConnectedSubnets.IsUnknown() {
+		if data.RedistributeConnectedSubnets.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"redistribute.connected.subnets", map[string]string{})
+		}
 	}
 	if len(data.Neighbors) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"neighbor", []interface{}{})
@@ -763,6 +856,119 @@ func (data *OSPF) updateFromBody(ctx context.Context, res gjson.Result) {
 		data.PassiveInterface = helpers.GetStringList(value.Array())
 	} else {
 		data.PassiveInterface = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "log-adjacency-changes"); !data.LogAdjacencyChanges.IsNull() {
+		if value.Exists() {
+			data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); !data.LogAdjacencyChangesDetail.IsNull() {
+		if value.Exists() {
+			data.LogAdjacencyChangesDetail = types.BoolValue(true)
+		} else {
+			data.LogAdjacencyChangesDetail = types.BoolValue(false)
+		}
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); !data.NsfCisco.IsNull() {
+		if value.Exists() {
+			data.NsfCisco = types.BoolValue(true)
+		} else {
+			data.NsfCisco = types.BoolValue(false)
+		}
+	} else {
+		data.NsfCisco = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); !data.NsfCiscoEnforceGlobal.IsNull() {
+		if value.Exists() {
+			data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+		} else {
+			data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+		}
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); !data.NsfIetf.IsNull() {
+		if value.Exists() {
+			data.NsfIetf = types.BoolValue(true)
+		} else {
+			data.NsfIetf = types.BoolValue(false)
+		}
+	} else {
+		data.NsfIetf = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() && !data.NsfIetfRestartInterval.IsNull() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	} else {
+		data.NsfIetfRestartInterval = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); !data.MaxMetricRouterLsa.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsa = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsa = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsa = types.BoolNull()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() && !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() && !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); !data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolNull()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() && !data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolNull()
+	}
+	if value := res.Get(prefix + "fast-reroute.per-prefix.enable.prefix-priority"); value.Exists() && !data.FastReroutePerPrefixEnablePrefixPriority.IsNull() {
+		data.FastReroutePerPrefixEnablePrefixPriority = types.StringValue(value.String())
+	} else {
+		data.FastReroutePerPrefixEnablePrefixPriority = types.StringNull()
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); !data.RedistributeStaticSubnets.IsNull() {
+		if value.Exists() {
+			data.RedistributeStaticSubnets = types.BoolValue(true)
+		} else {
+			data.RedistributeStaticSubnets = types.BoolValue(false)
+		}
+	} else {
+		data.RedistributeStaticSubnets = types.BoolNull()
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); !data.RedistributeConnectedSubnets.IsNull() {
+		if value.Exists() {
+			data.RedistributeConnectedSubnets = types.BoolValue(true)
+		} else {
+			data.RedistributeConnectedSubnets = types.BoolValue(false)
+		}
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolNull()
 	}
 	for i := range data.PassiveInterfaceDisableGigabitEthernets {
 		keys := [...]string{"name"}
@@ -1329,6 +1535,71 @@ func (data *OSPF) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.PassiveInterface = types.ListNull(types.StringType)
 	}
+	if value := res.Get(prefix + "log-adjacency-changes"); value.Exists() {
+		data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); value.Exists() {
+		data.LogAdjacencyChangesDetail = types.BoolValue(true)
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); value.Exists() {
+		data.NsfCisco = types.BoolValue(true)
+	} else {
+		data.NsfCisco = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); value.Exists() {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); value.Exists() {
+		data.NsfIetf = types.BoolValue(true)
+	} else {
+		data.NsfIetf = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); value.Exists() {
+		data.MaxMetricRouterLsa = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsa = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); value.Exists() {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "fast-reroute.per-prefix.enable.prefix-priority"); value.Exists() {
+		data.FastReroutePerPrefixEnablePrefixPriority = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); value.Exists() {
+		data.RedistributeStaticSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeStaticSubnets = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); value.Exists() {
+		data.RedistributeConnectedSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "passive-interface-config.disable-interface.GigabitEthernet"); value.Exists() {
 		data.PassiveInterfaceDisableGigabitEthernets = make([]OSPFPassiveInterfaceDisableGigabitEthernets, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
@@ -1641,6 +1912,71 @@ func (data *OSPFData) fromBody(ctx context.Context, res gjson.Result) {
 		data.PassiveInterface = helpers.GetStringList(value.Array())
 	} else {
 		data.PassiveInterface = types.ListNull(types.StringType)
+	}
+	if value := res.Get(prefix + "log-adjacency-changes"); value.Exists() {
+		data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); value.Exists() {
+		data.LogAdjacencyChangesDetail = types.BoolValue(true)
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); value.Exists() {
+		data.NsfCisco = types.BoolValue(true)
+	} else {
+		data.NsfCisco = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); value.Exists() {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); value.Exists() {
+		data.NsfIetf = types.BoolValue(true)
+	} else {
+		data.NsfIetf = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); value.Exists() {
+		data.MaxMetricRouterLsa = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsa = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); value.Exists() {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "fast-reroute.per-prefix.enable.prefix-priority"); value.Exists() {
+		data.FastReroutePerPrefixEnablePrefixPriority = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); value.Exists() {
+		data.RedistributeStaticSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeStaticSubnets = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); value.Exists() {
+		data.RedistributeConnectedSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolValue(false)
 	}
 	if value := res.Get(prefix + "passive-interface-config.disable-interface.GigabitEthernet"); value.Exists() {
 		data.PassiveInterfaceDisableGigabitEthernets = make([]OSPFPassiveInterfaceDisableGigabitEthernets, 0)
@@ -2154,6 +2490,51 @@ func (data *OSPF) getDeletedItems(ctx context.Context, state OSPF) []string {
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/passive-interface-config/disable-interface/GigabitEthernet=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 		}
 	}
+	if !state.RedistributeConnectedSubnets.IsNull() && data.RedistributeConnectedSubnets.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/redistribute/connected/subnets", state.getPath()))
+	}
+	if !state.RedistributeStaticSubnets.IsNull() && data.RedistributeStaticSubnets.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/redistribute/static/subnets", state.getPath()))
+	}
+	if !state.FastReroutePerPrefixEnablePrefixPriority.IsNull() && data.FastReroutePerPrefixEnablePrefixPriority.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/fast-reroute/per-prefix/enable/prefix-priority", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaOnStartupTime.IsNull() && data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/time", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaIncludeStub.IsNull() && data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaExternalLsaMetric.IsNull() && data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/external-lsa/metric", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaSummaryLsaMetric.IsNull() && data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/summary-lsa/metric", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsa.IsNull() && data.MaxMetricRouterLsa.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa", state.getPath()))
+	}
+	if !state.NsfIetfRestartInterval.IsNull() && data.NsfIetfRestartInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-ietf/restart-interval", state.getPath()))
+	}
+	if !state.NsfIetf.IsNull() && data.NsfIetf.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-ietf", state.getPath()))
+	}
+	if !state.NsfCiscoEnforceGlobal.IsNull() && data.NsfCiscoEnforceGlobal.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", state.getPath()))
+	}
+	if !state.NsfCisco.IsNull() && data.NsfCisco.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-cisco", state.getPath()))
+	}
+	if !state.LogAdjacencyChangesDetail.IsNull() && data.LogAdjacencyChangesDetail.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", state.getPath()))
+	}
+	if !state.LogAdjacencyChanges.IsNull() && data.LogAdjacencyChanges.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/log-adjacency-changes", state.getPath()))
+	}
 	if !state.PassiveInterface.IsNull() {
 		if data.PassiveInterface.IsNull() {
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/passive-interface/interface", state.getPath()))
@@ -2361,6 +2742,34 @@ func (data *OSPF) getDeletedItems(ctx context.Context, state OSPF) []string {
 func (data *OSPF) getEmptyLeafsDelete(ctx context.Context) []string {
 	emptyLeafsDelete := make([]string, 0)
 
+	if !data.RedistributeConnectedSubnets.IsNull() && !data.RedistributeConnectedSubnets.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/redistribute/connected/subnets", data.getPath()))
+	}
+	if !data.RedistributeStaticSubnets.IsNull() && !data.RedistributeStaticSubnets.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/redistribute/static/subnets", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && !data.MaxMetricRouterLsaOnStartupWaitForBgp.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() && !data.MaxMetricRouterLsaIncludeStub.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() && !data.MaxMetricRouterLsa.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa", data.getPath()))
+	}
+	if !data.NsfIetf.IsNull() && !data.NsfIetf.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-ietf", data.getPath()))
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() && !data.NsfCiscoEnforceGlobal.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", data.getPath()))
+	}
+	if !data.NsfCisco.IsNull() && !data.NsfCisco.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-cisco", data.getPath()))
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() && !data.LogAdjacencyChangesDetail.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", data.getPath()))
+	}
+
 	for i := range data.Areas {
 		keyValues := [...]string{data.Areas[i].AreaId.ValueString()}
 		if !data.Areas[i].NssaNoRedistribution.IsNull() && !data.Areas[i].NssaNoRedistribution.ValueBool() {
@@ -2474,6 +2883,51 @@ func (data *OSPF) getDeletePaths(ctx context.Context) []string {
 		keyValues := [...]string{data.PassiveInterfaceDisableGigabitEthernets[i].Name.ValueString()}
 
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/passive-interface-config/disable-interface/GigabitEthernet=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
+	if !data.RedistributeConnectedSubnets.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/redistribute/connected/subnets", data.getPath()))
+	}
+	if !data.RedistributeStaticSubnets.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/redistribute/static/subnets", data.getPath()))
+	}
+	if !data.FastReroutePerPrefixEnablePrefixPriority.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/fast-reroute/per-prefix/enable/prefix-priority", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/time", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/external-lsa/metric", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/summary-lsa/metric", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa", data.getPath()))
+	}
+	if !data.NsfIetfRestartInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-ietf/restart-interval", data.getPath()))
+	}
+	if !data.NsfIetf.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-ietf", data.getPath()))
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", data.getPath()))
+	}
+	if !data.NsfCisco.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-cisco", data.getPath()))
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", data.getPath()))
+	}
+	if !data.LogAdjacencyChanges.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/log-adjacency-changes", data.getPath()))
 	}
 	if !data.PassiveInterface.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/passive-interface/interface", data.getPath()))

--- a/internal/provider/model_iosxe_ospf_vrf.go
+++ b/internal/provider/model_iosxe_ospf_vrf.go
@@ -50,6 +50,20 @@ type OSPFVRF struct {
 	DefaultMetric                                      types.Int64                                                 `tfsdk:"default_metric"`
 	Distance                                           types.Int64                                                 `tfsdk:"distance"`
 	DomainTag                                          types.Int64                                                 `tfsdk:"domain_tag"`
+	LogAdjacencyChanges                                types.Bool                                                  `tfsdk:"log_adjacency_changes"`
+	LogAdjacencyChangesDetail                          types.Bool                                                  `tfsdk:"log_adjacency_changes_detail"`
+	NsfCisco                                           types.Bool                                                  `tfsdk:"nsf_cisco"`
+	NsfCiscoEnforceGlobal                              types.Bool                                                  `tfsdk:"nsf_cisco_enforce_global"`
+	NsfIetf                                            types.Bool                                                  `tfsdk:"nsf_ietf"`
+	NsfIetfRestartInterval                             types.Int64                                                 `tfsdk:"nsf_ietf_restart_interval"`
+	MaxMetricRouterLsa                                 types.Bool                                                  `tfsdk:"max_metric_router_lsa"`
+	MaxMetricRouterLsaSummaryLsaMetric                 types.Int64                                                 `tfsdk:"max_metric_router_lsa_summary_lsa_metric"`
+	MaxMetricRouterLsaExternalLsaMetric                types.Int64                                                 `tfsdk:"max_metric_router_lsa_external_lsa_metric"`
+	MaxMetricRouterLsaIncludeStub                      types.Bool                                                  `tfsdk:"max_metric_router_lsa_include_stub"`
+	MaxMetricRouterLsaOnStartupTime                    types.Int64                                                 `tfsdk:"max_metric_router_lsa_on_startup_time"`
+	MaxMetricRouterLsaOnStartupWaitForBgp              types.Bool                                                  `tfsdk:"max_metric_router_lsa_on_startup_wait_for_bgp"`
+	RedistributeStaticSubnets                          types.Bool                                                  `tfsdk:"redistribute_static_subnets"`
+	RedistributeConnectedSubnets                       types.Bool                                                  `tfsdk:"redistribute_connected_subnets"`
 	MplsLdpAutoconfig                                  types.Bool                                                  `tfsdk:"mpls_ldp_autoconfig"`
 	MplsLdpSync                                        types.Bool                                                  `tfsdk:"mpls_ldp_sync"`
 	Neighbor                                           []OSPFVRFNeighbor                                           `tfsdk:"neighbor"`
@@ -89,6 +103,20 @@ type OSPFVRFData struct {
 	DefaultMetric                                      types.Int64                                                 `tfsdk:"default_metric"`
 	Distance                                           types.Int64                                                 `tfsdk:"distance"`
 	DomainTag                                          types.Int64                                                 `tfsdk:"domain_tag"`
+	LogAdjacencyChanges                                types.Bool                                                  `tfsdk:"log_adjacency_changes"`
+	LogAdjacencyChangesDetail                          types.Bool                                                  `tfsdk:"log_adjacency_changes_detail"`
+	NsfCisco                                           types.Bool                                                  `tfsdk:"nsf_cisco"`
+	NsfCiscoEnforceGlobal                              types.Bool                                                  `tfsdk:"nsf_cisco_enforce_global"`
+	NsfIetf                                            types.Bool                                                  `tfsdk:"nsf_ietf"`
+	NsfIetfRestartInterval                             types.Int64                                                 `tfsdk:"nsf_ietf_restart_interval"`
+	MaxMetricRouterLsa                                 types.Bool                                                  `tfsdk:"max_metric_router_lsa"`
+	MaxMetricRouterLsaSummaryLsaMetric                 types.Int64                                                 `tfsdk:"max_metric_router_lsa_summary_lsa_metric"`
+	MaxMetricRouterLsaExternalLsaMetric                types.Int64                                                 `tfsdk:"max_metric_router_lsa_external_lsa_metric"`
+	MaxMetricRouterLsaIncludeStub                      types.Bool                                                  `tfsdk:"max_metric_router_lsa_include_stub"`
+	MaxMetricRouterLsaOnStartupTime                    types.Int64                                                 `tfsdk:"max_metric_router_lsa_on_startup_time"`
+	MaxMetricRouterLsaOnStartupWaitForBgp              types.Bool                                                  `tfsdk:"max_metric_router_lsa_on_startup_wait_for_bgp"`
+	RedistributeStaticSubnets                          types.Bool                                                  `tfsdk:"redistribute_static_subnets"`
+	RedistributeConnectedSubnets                       types.Bool                                                  `tfsdk:"redistribute_connected_subnets"`
 	MplsLdpAutoconfig                                  types.Bool                                                  `tfsdk:"mpls_ldp_autoconfig"`
 	MplsLdpSync                                        types.Bool                                                  `tfsdk:"mpls_ldp_sync"`
 	Neighbor                                           []OSPFVRFNeighbor                                           `tfsdk:"neighbor"`
@@ -241,6 +269,66 @@ func (data OSPFVRF) toBody(ctx context.Context) string {
 	}
 	if !data.DomainTag.IsNull() && !data.DomainTag.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"domain-tag", strconv.FormatInt(data.DomainTag.ValueInt64(), 10))
+	}
+	if !data.LogAdjacencyChanges.IsNull() && !data.LogAdjacencyChanges.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"log-adjacency-changes", data.LogAdjacencyChanges.ValueBool())
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() && !data.LogAdjacencyChangesDetail.IsUnknown() {
+		if data.LogAdjacencyChangesDetail.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"log-adjacency-changes-detail.log-adjacency-changes.detail", map[string]string{})
+		}
+	}
+	if !data.NsfCisco.IsNull() && !data.NsfCisco.IsUnknown() {
+		if data.NsfCisco.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-cisco", map[string]string{})
+		}
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() && !data.NsfCiscoEnforceGlobal.IsUnknown() {
+		if data.NsfCiscoEnforceGlobal.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-cisco.enforce.global", map[string]string{})
+		}
+	}
+	if !data.NsfIetf.IsNull() && !data.NsfIetf.IsUnknown() {
+		if data.NsfIetf.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-ietf", map[string]string{})
+		}
+	}
+	if !data.NsfIetfRestartInterval.IsNull() && !data.NsfIetfRestartInterval.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"nsf.nsf-ietf.restart-interval", strconv.FormatInt(data.NsfIetfRestartInterval.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() && !data.MaxMetricRouterLsa.IsUnknown() {
+		if data.MaxMetricRouterLsa.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa", map[string]string{})
+		}
+	}
+	if !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() && !data.MaxMetricRouterLsaSummaryLsaMetric.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.summary-lsa.metric", strconv.FormatInt(data.MaxMetricRouterLsaSummaryLsaMetric.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() && !data.MaxMetricRouterLsaExternalLsaMetric.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.external-lsa.metric", strconv.FormatInt(data.MaxMetricRouterLsaExternalLsaMetric.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() && !data.MaxMetricRouterLsaIncludeStub.IsUnknown() {
+		if data.MaxMetricRouterLsaIncludeStub.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.include-stub", map[string]string{})
+		}
+	}
+	if !data.MaxMetricRouterLsaOnStartupTime.IsNull() && !data.MaxMetricRouterLsaOnStartupTime.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.on-startup.time", strconv.FormatInt(data.MaxMetricRouterLsaOnStartupTime.ValueInt64(), 10))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsUnknown() {
+		if data.MaxMetricRouterLsaOnStartupWaitForBgp.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"max-metric.router-lsa.on-startup.wait-for-bgp", map[string]string{})
+		}
+	}
+	if !data.RedistributeStaticSubnets.IsNull() && !data.RedistributeStaticSubnets.IsUnknown() {
+		if data.RedistributeStaticSubnets.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"redistribute.static.subnets", map[string]string{})
+		}
+	}
+	if !data.RedistributeConnectedSubnets.IsNull() && !data.RedistributeConnectedSubnets.IsUnknown() {
+		if data.RedistributeConnectedSubnets.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"redistribute.connected.subnets", map[string]string{})
+		}
 	}
 	if !data.MplsLdpAutoconfig.IsNull() && !data.MplsLdpAutoconfig.IsUnknown() {
 		if data.MplsLdpAutoconfig.ValueBool() {
@@ -525,6 +613,114 @@ func (data *OSPFVRF) updateFromBody(ctx context.Context, res gjson.Result) {
 		data.DomainTag = types.Int64Value(value.Int())
 	} else {
 		data.DomainTag = types.Int64Null()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes"); !data.LogAdjacencyChanges.IsNull() {
+		if value.Exists() {
+			data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); !data.LogAdjacencyChangesDetail.IsNull() {
+		if value.Exists() {
+			data.LogAdjacencyChangesDetail = types.BoolValue(true)
+		} else {
+			data.LogAdjacencyChangesDetail = types.BoolValue(false)
+		}
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); !data.NsfCisco.IsNull() {
+		if value.Exists() {
+			data.NsfCisco = types.BoolValue(true)
+		} else {
+			data.NsfCisco = types.BoolValue(false)
+		}
+	} else {
+		data.NsfCisco = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); !data.NsfCiscoEnforceGlobal.IsNull() {
+		if value.Exists() {
+			data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+		} else {
+			data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+		}
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); !data.NsfIetf.IsNull() {
+		if value.Exists() {
+			data.NsfIetf = types.BoolValue(true)
+		} else {
+			data.NsfIetf = types.BoolValue(false)
+		}
+	} else {
+		data.NsfIetf = types.BoolNull()
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() && !data.NsfIetfRestartInterval.IsNull() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	} else {
+		data.NsfIetfRestartInterval = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); !data.MaxMetricRouterLsa.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsa = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsa = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsa = types.BoolNull()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() && !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() && !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); !data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolNull()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() && !data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	} else {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Null()
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		if value.Exists() {
+			data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+		} else {
+			data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+		}
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolNull()
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); !data.RedistributeStaticSubnets.IsNull() {
+		if value.Exists() {
+			data.RedistributeStaticSubnets = types.BoolValue(true)
+		} else {
+			data.RedistributeStaticSubnets = types.BoolValue(false)
+		}
+	} else {
+		data.RedistributeStaticSubnets = types.BoolNull()
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); !data.RedistributeConnectedSubnets.IsNull() {
+		if value.Exists() {
+			data.RedistributeConnectedSubnets = types.BoolValue(true)
+		} else {
+			data.RedistributeConnectedSubnets = types.BoolValue(false)
+		}
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolNull()
 	}
 	if value := res.Get(prefix + "mpls.ldp.autoconfig"); !data.MplsLdpAutoconfig.IsNull() {
 		if value.Exists() {
@@ -1215,6 +1411,68 @@ func (data *OSPFVRF) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "domain-tag"); value.Exists() {
 		data.DomainTag = types.Int64Value(value.Int())
 	}
+	if value := res.Get(prefix + "log-adjacency-changes"); value.Exists() {
+		data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); value.Exists() {
+		data.LogAdjacencyChangesDetail = types.BoolValue(true)
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); value.Exists() {
+		data.NsfCisco = types.BoolValue(true)
+	} else {
+		data.NsfCisco = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); value.Exists() {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); value.Exists() {
+		data.NsfIetf = types.BoolValue(true)
+	} else {
+		data.NsfIetf = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); value.Exists() {
+		data.MaxMetricRouterLsa = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsa = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); value.Exists() {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); value.Exists() {
+		data.RedistributeStaticSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeStaticSubnets = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); value.Exists() {
+		data.RedistributeConnectedSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "mpls.ldp.autoconfig"); value.Exists() {
 		data.MplsLdpAutoconfig = types.BoolValue(true)
 	} else {
@@ -1527,6 +1785,68 @@ func (data *OSPFVRFData) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "domain-tag"); value.Exists() {
 		data.DomainTag = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "log-adjacency-changes"); value.Exists() {
+		data.LogAdjacencyChanges = types.BoolValue(value.Bool())
+	} else {
+		data.LogAdjacencyChanges = types.BoolNull()
+	}
+	if value := res.Get(prefix + "log-adjacency-changes-detail.log-adjacency-changes.detail"); value.Exists() {
+		data.LogAdjacencyChangesDetail = types.BoolValue(true)
+	} else {
+		data.LogAdjacencyChangesDetail = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco"); value.Exists() {
+		data.NsfCisco = types.BoolValue(true)
+	} else {
+		data.NsfCisco = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-cisco.enforce.global"); value.Exists() {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(true)
+	} else {
+		data.NsfCiscoEnforceGlobal = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf"); value.Exists() {
+		data.NsfIetf = types.BoolValue(true)
+	} else {
+		data.NsfIetf = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "nsf.nsf-ietf.restart-interval"); value.Exists() {
+		data.NsfIetfRestartInterval = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa"); value.Exists() {
+		data.MaxMetricRouterLsa = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsa = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.summary-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaSummaryLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.external-lsa.metric"); value.Exists() {
+		data.MaxMetricRouterLsaExternalLsaMetric = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.include-stub"); value.Exists() {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaIncludeStub = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.time"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupTime = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "max-metric.router-lsa.on-startup.wait-for-bgp"); value.Exists() {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(true)
+	} else {
+		data.MaxMetricRouterLsaOnStartupWaitForBgp = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.static.subnets"); value.Exists() {
+		data.RedistributeStaticSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeStaticSubnets = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "redistribute.connected.subnets"); value.Exists() {
+		data.RedistributeConnectedSubnets = types.BoolValue(true)
+	} else {
+		data.RedistributeConnectedSubnets = types.BoolValue(false)
 	}
 	if value := res.Get(prefix + "mpls.ldp.autoconfig"); value.Exists() {
 		data.MplsLdpAutoconfig = types.BoolValue(true)
@@ -2342,6 +2662,48 @@ func (data *OSPFVRF) getDeletedItems(ctx context.Context, state OSPFVRF) []strin
 	if !state.MplsLdpAutoconfig.IsNull() && data.MplsLdpAutoconfig.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/mpls/ldp/autoconfig", state.getPath()))
 	}
+	if !state.RedistributeConnectedSubnets.IsNull() && data.RedistributeConnectedSubnets.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/redistribute/connected/subnets", state.getPath()))
+	}
+	if !state.RedistributeStaticSubnets.IsNull() && data.RedistributeStaticSubnets.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/redistribute/static/subnets", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaOnStartupTime.IsNull() && data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/time", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaIncludeStub.IsNull() && data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaExternalLsaMetric.IsNull() && data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/external-lsa/metric", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsaSummaryLsaMetric.IsNull() && data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa/summary-lsa/metric", state.getPath()))
+	}
+	if !state.MaxMetricRouterLsa.IsNull() && data.MaxMetricRouterLsa.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/max-metric/router-lsa", state.getPath()))
+	}
+	if !state.NsfIetfRestartInterval.IsNull() && data.NsfIetfRestartInterval.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-ietf/restart-interval", state.getPath()))
+	}
+	if !state.NsfIetf.IsNull() && data.NsfIetf.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-ietf", state.getPath()))
+	}
+	if !state.NsfCiscoEnforceGlobal.IsNull() && data.NsfCiscoEnforceGlobal.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", state.getPath()))
+	}
+	if !state.NsfCisco.IsNull() && data.NsfCisco.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/nsf/nsf-cisco", state.getPath()))
+	}
+	if !state.LogAdjacencyChangesDetail.IsNull() && data.LogAdjacencyChangesDetail.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", state.getPath()))
+	}
+	if !state.LogAdjacencyChanges.IsNull() && data.LogAdjacencyChanges.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/log-adjacency-changes", state.getPath()))
+	}
 	if !state.DomainTag.IsNull() && data.DomainTag.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/domain-tag", state.getPath()))
 	}
@@ -2395,6 +2757,33 @@ func (data *OSPFVRF) getEmptyLeafsDelete(ctx context.Context) []string {
 	}
 	if !data.MplsLdpAutoconfig.IsNull() && !data.MplsLdpAutoconfig.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/mpls/ldp/autoconfig", data.getPath()))
+	}
+	if !data.RedistributeConnectedSubnets.IsNull() && !data.RedistributeConnectedSubnets.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/redistribute/connected/subnets", data.getPath()))
+	}
+	if !data.RedistributeStaticSubnets.IsNull() && !data.RedistributeStaticSubnets.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/redistribute/static/subnets", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() && !data.MaxMetricRouterLsaOnStartupWaitForBgp.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() && !data.MaxMetricRouterLsaIncludeStub.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() && !data.MaxMetricRouterLsa.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/max-metric/router-lsa", data.getPath()))
+	}
+	if !data.NsfIetf.IsNull() && !data.NsfIetf.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-ietf", data.getPath()))
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() && !data.NsfCiscoEnforceGlobal.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", data.getPath()))
+	}
+	if !data.NsfCisco.IsNull() && !data.NsfCisco.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/nsf/nsf-cisco", data.getPath()))
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() && !data.LogAdjacencyChangesDetail.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", data.getPath()))
 	}
 	if !data.DefaultInformationOriginateAlways.IsNull() && !data.DefaultInformationOriginateAlways.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/default-information/originate/always", data.getPath()))
@@ -2528,6 +2917,48 @@ func (data *OSPFVRF) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.MplsLdpAutoconfig.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/mpls/ldp/autoconfig", data.getPath()))
+	}
+	if !data.RedistributeConnectedSubnets.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/redistribute/connected/subnets", data.getPath()))
+	}
+	if !data.RedistributeStaticSubnets.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/redistribute/static/subnets", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupWaitForBgp.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/wait-for-bgp", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaOnStartupTime.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/on-startup/time", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaIncludeStub.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/include-stub", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaExternalLsaMetric.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/external-lsa/metric", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsaSummaryLsaMetric.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa/summary-lsa/metric", data.getPath()))
+	}
+	if !data.MaxMetricRouterLsa.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/max-metric/router-lsa", data.getPath()))
+	}
+	if !data.NsfIetfRestartInterval.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-ietf/restart-interval", data.getPath()))
+	}
+	if !data.NsfIetf.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-ietf", data.getPath()))
+	}
+	if !data.NsfCiscoEnforceGlobal.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-cisco/enforce/global", data.getPath()))
+	}
+	if !data.NsfCisco.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/nsf/nsf-cisco", data.getPath()))
+	}
+	if !data.LogAdjacencyChangesDetail.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/log-adjacency-changes-detail/log-adjacency-changes/detail", data.getPath()))
+	}
+	if !data.LogAdjacencyChanges.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/log-adjacency-changes", data.getPath()))
 	}
 	if !data.DomainTag.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/domain-tag", data.getPath()))

--- a/internal/provider/resource_iosxe_interface_ospf.go
+++ b/internal/provider/resource_iosxe_interface_ospf.go
@@ -188,6 +188,18 @@ func (r *InterfaceOSPFResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 				},
 			},
+			"multi_area_ids": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Set the OSPF multi-area ID").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"area_id": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("OSPF multi-area ID").String,
+							Required:            true,
+						},
+					},
+				},
+			},
 			"message_digest_keys": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Message digest authentication password (key)").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_interface_ospf_test.go
+++ b/internal/provider/resource_iosxe_interface_ospf_test.go
@@ -46,6 +46,7 @@ func TestAccIosxeInterfaceOSPF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ospf.test", "ttl_security_hops", "2"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ospf.test", "process_ids.0.id", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ospf.test", "process_ids.0.areas.0.area_id", "0"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ospf.test", "multi_area_ids.0.area_id", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ospf.test", "message_digest_keys.0.id", "1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -140,6 +141,9 @@ func testAccIosxeInterfaceOSPFConfig_all() string {
 	config += `		areas = [{` + "\n"
 	config += `			area_id = "0"` + "\n"
 	config += `		}]` + "\n"
+	config += `	}]` + "\n"
+	config += `	multi_area_ids = [{` + "\n"
+	config += `		area_id = "10"` + "\n"
 	config += `	}]` + "\n"
 	config += `	message_digest_keys = [{` + "\n"
 	config += `		id = 1` + "\n"

--- a/internal/provider/resource_iosxe_ospf.go
+++ b/internal/provider/resource_iosxe_ospf.go
@@ -296,6 +296,81 @@ func (r *OSPFResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
+			"log_adjacency_changes": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Log changes in adjacency state").String,
+				Optional:            true,
+			},
+			"log_adjacency_changes_detail": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Log all state changes").String,
+				Optional:            true,
+			},
+			"nsf_cisco": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Cisco Non-stop forwarding").String,
+				Optional:            true,
+			},
+			"nsf_cisco_enforce_global": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("For the whole OSPF process").String,
+				Optional:            true,
+			},
+			"nsf_ietf": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("IETF graceful restart").String,
+				Optional:            true,
+			},
+			"nsf_ietf_restart_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Graceful restart interval").AddIntegerRangeDescription(1, 1800).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 1800),
+				},
+			},
+			"max_metric_router_lsa": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Maximum metric in self-originated router-LSAs").String,
+				Optional:            true,
+			},
+			"max_metric_router_lsa_summary_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 16777214).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 16777214),
+				},
+			},
+			"max_metric_router_lsa_external_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 16777214).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 16777214),
+				},
+			},
+			"max_metric_router_lsa_include_stub": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Set maximum metric for stub links in router-LSAs").String,
+				Optional:            true,
+			},
+			"max_metric_router_lsa_on_startup_time": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(5, 86400).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(5, 86400),
+				},
+			},
+			"max_metric_router_lsa_on_startup_wait_for_bgp": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Let BGP decide when to originate router-LSA with normal metric").String,
+				Optional:            true,
+			},
+			"fast_reroute_per_prefix_enable_prefix_priority": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Priority of prefixes to be protected").AddStringEnumDescription("high", "low").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("high", "low"),
+				},
+			},
+			"redistribute_static_subnets": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Consider subnets for redistribution into OSPF (Will be removed in the future)").String,
+				Optional:            true,
+			},
+			"redistribute_connected_subnets": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Consider subnets for redistribution into OSPF (Will be removed in the future)").String,
+				Optional:            true,
+			},
 			"passive_interface_disable_gigabit_ethernets": schema.SetNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_ospf_test.go
+++ b/internal/provider/resource_iosxe_ospf_test.go
@@ -62,6 +62,21 @@ func TestAccIosxeOSPF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "areas.0.nssa_no_redistribution", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "auto_cost_reference_bandwidth", "40000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "passive_interface_default", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "log_adjacency_changes", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "log_adjacency_changes_detail", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "nsf_cisco", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "nsf_cisco_enforce_global", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "nsf_ietf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "nsf_ietf_restart_interval", "120"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa_summary_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa_include_stub", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa_on_startup_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "max_metric_router_lsa_on_startup_wait_for_bgp", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "fast_reroute_per_prefix_enable_prefix_priority", "high"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "redistribute_static_subnets", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf.test", "redistribute_connected_subnets", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -154,6 +169,21 @@ func testAccIosxeOSPFConfig_all() string {
 	config += `	}]` + "\n"
 	config += `	auto_cost_reference_bandwidth = 40000` + "\n"
 	config += `	passive_interface_default = true` + "\n"
+	config += `	log_adjacency_changes = true` + "\n"
+	config += `	log_adjacency_changes_detail = true` + "\n"
+	config += `	nsf_cisco = true` + "\n"
+	config += `	nsf_cisco_enforce_global = true` + "\n"
+	config += `	nsf_ietf = true` + "\n"
+	config += `	nsf_ietf_restart_interval = 120` + "\n"
+	config += `	max_metric_router_lsa = true` + "\n"
+	config += `	max_metric_router_lsa_summary_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_include_stub = true` + "\n"
+	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
+	config += `	max_metric_router_lsa_on_startup_wait_for_bgp = true` + "\n"
+	config += `	fast_reroute_per_prefix_enable_prefix_priority = "high"` + "\n"
+	config += `	redistribute_static_subnets = true` + "\n"
+	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `}` + "\n"
 	return config
 }

--- a/internal/provider/resource_iosxe_ospf_vrf.go
+++ b/internal/provider/resource_iosxe_ospf_vrf.go
@@ -138,6 +138,74 @@ func (r *OSPFVRFResource) Schema(ctx context.Context, req resource.SchemaRequest
 					int64validator.Between(1, 4294967295),
 				},
 			},
+			"log_adjacency_changes": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Log changes in adjacency state").String,
+				Optional:            true,
+			},
+			"log_adjacency_changes_detail": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Log all state changes").String,
+				Optional:            true,
+			},
+			"nsf_cisco": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Cisco Non-stop forwarding").String,
+				Optional:            true,
+			},
+			"nsf_cisco_enforce_global": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("For the whole OSPF process").String,
+				Optional:            true,
+			},
+			"nsf_ietf": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("IETF graceful restart").String,
+				Optional:            true,
+			},
+			"nsf_ietf_restart_interval": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Graceful restart interval").AddIntegerRangeDescription(1, 1800).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 1800),
+				},
+			},
+			"max_metric_router_lsa": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Maximum metric in self-originated router-LSAs").String,
+				Optional:            true,
+			},
+			"max_metric_router_lsa_summary_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 16777214).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 16777214),
+				},
+			},
+			"max_metric_router_lsa_external_lsa_metric": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1, 16777214).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 16777214),
+				},
+			},
+			"max_metric_router_lsa_include_stub": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Set maximum metric for stub links in router-LSAs").String,
+				Optional:            true,
+			},
+			"max_metric_router_lsa_on_startup_time": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(5, 86400).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(5, 86400),
+				},
+			},
+			"max_metric_router_lsa_on_startup_wait_for_bgp": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Let BGP decide when to originate router-LSA with normal metric").String,
+				Optional:            true,
+			},
+			"redistribute_static_subnets": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Consider subnets for redistribution into OSPF (Will be removed in the future)").String,
+				Optional:            true,
+			},
+			"redistribute_connected_subnets": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Consider subnets for redistribution into OSPF (Will be removed in the future)").String,
+				Optional:            true,
+			},
 			"mpls_ldp_autoconfig": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Configure LDP automatic configuration").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_ospf_vrf_test.go
+++ b/internal/provider/resource_iosxe_ospf_vrf_test.go
@@ -42,6 +42,20 @@ func TestAccIosxeOSPFVRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "default_metric", "21"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "distance", "120"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "domain_tag", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "log_adjacency_changes", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "log_adjacency_changes_detail", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "nsf_cisco", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "nsf_cisco_enforce_global", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "nsf_ietf", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "nsf_ietf_restart_interval", "120"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_summary_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_include_stub", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_time", "60"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_wait_for_bgp", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_static_subnets", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_connected_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "neighbor.0.ip", "2.2.2.2"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "neighbor.0.priority", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "neighbor.0.cost", "100"))
@@ -142,6 +156,20 @@ func testAccIosxeOSPFVRFConfig_all() string {
 	config += `	default_metric = 21` + "\n"
 	config += `	distance = 120` + "\n"
 	config += `	domain_tag = 10` + "\n"
+	config += `	log_adjacency_changes = true` + "\n"
+	config += `	log_adjacency_changes_detail = true` + "\n"
+	config += `	nsf_cisco = true` + "\n"
+	config += `	nsf_cisco_enforce_global = true` + "\n"
+	config += `	nsf_ietf = true` + "\n"
+	config += `	nsf_ietf_restart_interval = 120` + "\n"
+	config += `	max_metric_router_lsa = true` + "\n"
+	config += `	max_metric_router_lsa_summary_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
+	config += `	max_metric_router_lsa_include_stub = true` + "\n"
+	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
+	config += `	max_metric_router_lsa_on_startup_wait_for_bgp = true` + "\n"
+	config += `	redistribute_static_subnets = true` + "\n"
+	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `	neighbor = [{` + "\n"
 	config += `		ip = "2.2.2.2"` + "\n"
 	config += `		priority = 10` + "\n"


### PR DESCRIPTION
## Related Issues

Fixes #507

## Changes

### Router-Level OSPF Attributes 

**Log Adjacency Changes:**
- `log_adjacency_changes` - Log changes in adjacency state (choice option)
- `log_adjacency_changes_detail` - Log changes with detail (mutually exclusive with above)

**NSF (Non-Stop Forwarding):**
- `nsf_cisco` - Enable Cisco NSF (choice option)
- `nsf_cisco_enforce_global` - Enforce global NSF neighbors
- `nsf_ietf` - Enable IETF graceful restart (mutually exclusive with cisco)
- `nsf_ietf_restart_interval` - Restart interval in seconds (1-3600)

**Max-Metric Router LSA:**
- `max_metric_router_lsa` - Set maximum metric temporarily
- `max_metric_router_lsa_summary_lsa_metric` - Summary LSA metric (1-16777215)
- `max_metric_router_lsa_external_lsa_metric` - External LSA metric (1-16777215)
- `max_metric_router_lsa_include_stub` - Include stub networks
- `max_metric_router_lsa_on_startup_time` - Duration in seconds (5-86400)
- `max_metric_router_lsa_on_startup_wait_for_bgp` - Wait for BGP (mutually exclusive with time)

**Fast-Reroute:**
- `fast_reroute_per_prefix_enable_prefix_priority` - Priority of prefixes to protect (high/low)
  - **Note**: Requires network-advantage license
  - **Note**: Non-VRF only (not available in `ospf_vrf` resource)

**Redistribute:**
- `redistribute_static_subnets` - Redistribute static routes with subnets
- `redistribute_connected_subnets` - Redistribute connected routes with subnets

### Interface-Level OSPF Attributes (1 attribute)

**Multi-Area:**
- `multi_area_ids` - List of additional OSPF area IDs for multi-homing
  - Supports both decimal (0-4294967295) and IPv4 address format

## YANG Model Details

### Choice Structures Handled
- `log-adjacency-changes-choice` - Base vs detail logging
- `nsf-cisco-ietf` - Cisco NSF vs IETF graceful restart
- `time-wait-for-bgp-choice` - Time-based vs BGP-triggered max-metric

### Presence Containers
- `nsf-cisco`, `nsf-ietf` - Enabled when present
- `router-lsa` - Max-metric configuration container

### Union Types
- `area-id` in multi-area - Accepts uint32 or ipv4-address

## Version Compatibility

**YANG Version Analysis Performed:**
- ✅ All features verified to exist in IOS-XE **17.12.1** YANG model
- ✅ All features verified to exist in IOS-XE **17.15.1** YANG model
- ✅ **No test_tags required** - Features compatible with all pipeline test devices

Analysis documented in: `EPIC-510-ospf_advanced_support/YANG-VERSION-COMPATIBILITY.md`

## Testing

### Direct Provider Testing
- [x] Provider build successful (`make gen` + `go build`)
- [x] Terraform init/plan/apply successful
- [x] Device configuration verified via CLI
- [x] Idempotency confirmed (no changes on second apply)
- [x] Terraform destroy successful

### Device Testing Details
- **Device**: Cat8kv at 10.81.239.57
- **IOS-XE Version**: 17.15.1a
- **License**: network-advantage (required for fast-reroute)

### Configuration Verified on Device

```
router ospf 100
 max-metric router-lsa include-stub summary-lsa 16711680 external-lsa 16711680 on-startup 60
 nsf cisco enforce global
 fast-reroute per-prefix enable prefix-priority high
 redistribute connected
 redistribute static
 log-adjacency-changes
```

### Test Files (Not Committed)
- Local testing performed with `test-ospf-epic510.tf`
- Test files excluded from PR per project standards

## Key Implementation Notes

### VRF Limitations
- `fast-reroute` is **not available in VRF OSPF** per YANG model
- Only included in `ospf.yaml`, excluded from `ospf_vrf.yaml`
- Module implementation reflects this limitation

### License Requirements
- `fast-reroute` requires **network-advantage** license
- Feature not visible on devices with network-essentials license
- Documented in testing results

### Default Value Behavior
- `log-adjacency-changes` defaults to `true` in IOS-XE
- Appears in `show run all` but not in `show run`
- Provider correctly manages this default

## Files Modified

### Definition Files (3)
- `gen/definitions/ospf.yaml` - Added 17 router-level attributes
- `gen/definitions/ospf_vrf.yaml` - Added VRF-compatible attributes (no fast-reroute)
- `gen/definitions/interface_ospf.yaml` - Added multi-area support

### Generated Files (24)
- Resource/Data source files for ospf, ospf_vrf, interface_ospf
- Model files
- Test files
- Documentation and examples

## Breaking Changes

None. All new attributes are optional.

## Documentation

Comprehensive documentation created in `EPIC-510-ospf_advanced_support/`:
- `YANG-EXPLORATION-NOTES.md` - Complete YANG analysis
- `CLI-VERIFICATION-RESULTS.md` - Device testing results
- `YANG-VERSION-COMPATIBILITY.md` - Version compatibility analysis
- `PROVIDER-TEST-RESULTS.md` - Testing evidence
- `PROVIDER-PHASE-COMPLETE.md` - Phase summary

## Additional Notes

- Implementation follows established patterns from previous Epics
- All YANG paths verified in YANG Suite
- CLI behavior validated on live devices
- Version compatibility ensures pipeline success
- Ready for schema and module implementation

---

**This PR implements advanced OSPF configuration features for the IOS-XE provider, adding support for log-adjacency-changes, NSF (Non-Stop Forwarding), max-metric router-lsa, fast-reroute, redistribute options, and multi-area interface configurations.**