### PR TITLE
fix: Fix route-map `set_communities` test failure on IOS-XE 17.12.4

### DIFF
--- a/docs/resources/route_map.md
+++ b/docs/resources/route_map.md
@@ -70,7 +70,6 @@ resource "iosxe_route_map" "example" {
       set_tag                                = 100
       set_as_path_prepend_as                 = "65001 65001"
       set_as_path_prepend_last_as            = 5
-      set_communities                        = ["no-export"]
       set_extcomunity_rt                     = ["10:10"]
       set_extcomunity_soo                    = "10:10"
       set_extcomunity_vpn_distinguisher      = "10:10"

--- a/examples/resources/iosxe_route_map/resource.tf
+++ b/examples/resources/iosxe_route_map/resource.tf
@@ -55,7 +55,6 @@ resource "iosxe_route_map" "example" {
       set_tag                                = 100
       set_as_path_prepend_as                 = "65001 65001"
       set_as_path_prepend_last_as            = 5
-      set_communities                        = ["no-export"]
       set_extcomunity_rt                     = ["10:10"]
       set_extcomunity_soo                    = "10:10"
       set_extcomunity_vpn_distinguisher      = "10:10"

--- a/gen/definitions/route_map.yaml
+++ b/gen/definitions/route_map.yaml
@@ -313,6 +313,7 @@ attributes:
         tf_name: set_communities
         example: "no-export"
         description: "BGP community value - can be a number (AA:NN format) or well-known value (internet, local-AS, no-advertise, no-export, gshut)"
+        test_tags: [IOSXE1715]
       - yang_name: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known-choice/community-well-known/community-well-known/additive
         xpath: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/additive
         tf_name: set_communities_additive

--- a/internal/provider/data_source_iosxe_route_map_test.go
+++ b/internal/provider/data_source_iosxe_route_map_test.go
@@ -140,7 +140,9 @@ func TestAccDataSourceIosxeRouteMap(t *testing.T) {
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_route_map.test", "entries.0.set_as_path_prepend_as", "65001 65001"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_route_map.test", "entries.0.set_as_path_prepend_last_as", "5"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_route_map.test", "entries.0.set_communities.0", "no-export"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_route_map.test", "entries.0.set_communities.0", "no-export"))
+	}
 	if os.Getenv("IOSXE1712") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_route_map.test", "entries.0.set_community_list_name", "COMML1"))
 	}
@@ -289,7 +291,9 @@ func testAccDataSourceIosxeRouteMapConfig() string {
 	}
 	config += `		set_as_path_prepend_as = "65001 65001"` + "\n"
 	config += `		set_as_path_prepend_last_as = 5` + "\n"
-	config += `		set_communities = ["no-export"]` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `		set_communities = ["no-export"]` + "\n"
+	}
 	if os.Getenv("IOSXE1712") != "" {
 		config += `		set_community_list_name = "COMML1"` + "\n"
 	}

--- a/internal/provider/resource_iosxe_route_map_test.go
+++ b/internal/provider/resource_iosxe_route_map_test.go
@@ -143,7 +143,9 @@ func TestAccIosxeRouteMap(t *testing.T) {
 	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_route_map.test", "entries.0.set_as_path_prepend_as", "65001 65001"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_route_map.test", "entries.0.set_as_path_prepend_last_as", "5"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_route_map.test", "entries.0.set_communities.0", "no-export"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_route_map.test", "entries.0.set_communities.0", "no-export"))
+	}
 	if os.Getenv("IOSXE1712") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_route_map.test", "entries.0.set_community_list_name", "COMML1"))
 	}
@@ -328,7 +330,9 @@ func testAccIosxeRouteMapConfig_all() string {
 	}
 	config += `		set_as_path_prepend_as = "65001 65001"` + "\n"
 	config += `		set_as_path_prepend_last_as = 5` + "\n"
-	config += `		set_communities = ["no-export"]` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `		set_communities = ["no-export"]` + "\n"
+	}
 	if os.Getenv("IOSXE1712") != "" {
 		config += `		set_community_list_name = "COMML1"` + "\n"
 	}


### PR DESCRIPTION
  Adds missing `test_tags: [IOSXE1715]` to the `set_communities` 
  attribute in route-map configuration to prevent YANG path conflicts 
  on IOS-XE 17.12.4 devices.

  ### Problem Statement
  **Test Failure**: `TestAccDataSourceIosxeRouteMap` fails on C8000v 
  17.12.4 with:

```
  Attribute 'entries.0.set_communities_legacy.0' expected "1:2", got
  "no-export"
```

  #### The Breaking Change
  **Introduced by**: Commit `9f03003` (PR #323 - "Add advanced route
  map set actions")
  - **Author**: @camschaecisco 
  - **Date**: Thursday, October 30, 2025 at 17:06:58 EDT

  **What changed** in `gen/definitions/route_map.yaml`:
  ```diff
    tf_name: set_communities
  - example: "1:2"
  - test_tags: [IOSXE1712]
  + example: "no-export"
  + description: "BGP community value - can be a number (AA:NN format) or well-known value..."
```

  Error: Removed test_tags: [IOSXE1712] without adding
  test_tags: [IOSXE1715], causing the attribute to be tested on all 
  versions.

### Some digging

  IOS-XE 17.12.x supports TWO paths:
  1. Legacy (deprecated):
  `set/community/community-well-known/community-list`
  3. New BGP path: `set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list`

  IOS-XE 17.15.x supports ONE path:
  - New BGP path only (legacy path removed from YANG model)

This creates a conflict...Without version-specific test tags, BOTH attributes are configured on
   17.12.4 devices:

```
  set_communities_legacy = ["1:2"]       # ← Configured (IOSXE1712)
```

```
  set_communities        = ["no-export"]  # ← Also configured
```

  Device behavior: The new BGP path takes precedence, causing
  set_communities_legacy to read "no-export" instead of the expected
  "1:2".

###  Solution

  Follow the existing pattern for version-specific attributes (lines
  70-76 in route_map.yaml):

  # Legacy - 17.12 ONLY

```yaml
  - yang_name: match/route-type/local
    tf_name: match_route_type_local_legacy
    test_tags: [IOSXE1712] 
```

  # New - 17.15+ ONLY

```yaml
  - yang_name:
  match/Cisco-IOS-XE-bgp:bgp-route-map-match/route-type/local
    tf_name: match_route_type_local
    test_tags: [IOSXE1715] 
```

  Applied to set_communities:
```yaml
  - yang_name:
  set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-k
  nown-choice/community-well-known/community-well-known/community-list
    xpath: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/communi
  ty-well-known/community-list
    tf_name: set_communities
    example: "no-export"
    description: "BGP community value - can be a number (AA:NN format) 
  or well-known value (internet, local-AS, no-advertise, no-export, 
  gshut)"
    test_tags: [IOSXE1715]  # ← ADDED
```