### PR TITLE
fix(system): Resolve configuration conflict with domain lookup options

### DIFF
--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -18,7 +18,7 @@ resource "iosxe_system" "example" {
   ip_bgp_community_new_format = true
   ipv6_unicast_routing        = true
   ip_source_route             = false
-  ip_domain_lookup            = false
+  ip_domain_lookup            = true
   ip_domain_name              = "test.com"
   login_delay                 = 10
   login_on_failure            = true

--- a/examples/resources/iosxe_system/resource.tf
+++ b/examples/resources/iosxe_system/resource.tf
@@ -3,7 +3,7 @@ resource "iosxe_system" "example" {
   ip_bgp_community_new_format = true
   ipv6_unicast_routing        = true
   ip_source_route             = false
-  ip_domain_lookup            = false
+  ip_domain_lookup            = true
   ip_domain_name              = "test.com"
   login_delay                 = 10
   login_on_failure            = true

--- a/gen/definitions/system.yaml
+++ b/gen/definitions/system.yaml
@@ -22,7 +22,7 @@ attributes:
   - yang_name: ip/source-route
     example: false
   - yang_name: ip/domain/lookup
-    example: false
+    example: true
   - yang_name: ip/domain/name
     example: test.com
   - yang_name: login/delay

--- a/internal/provider/data_source_iosxe_system_test.go
+++ b/internal/provider/data_source_iosxe_system_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_bgp_community_new_format", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ipv6_unicast_routing", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_source_route", "false"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_lookup", "false"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_lookup", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_name", "test.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "login_delay", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "login_on_failure", "true"))
@@ -122,7 +122,7 @@ func testAccDataSourceIosxeSystemConfig() string {
 	config += `	ip_bgp_community_new_format = true` + "\n"
 	config += `	ipv6_unicast_routing = true` + "\n"
 	config += `	ip_source_route = false` + "\n"
-	config += `	ip_domain_lookup = false` + "\n"
+	config += `	ip_domain_lookup = true` + "\n"
 	config += `	ip_domain_name = "test.com"` + "\n"
 	config += `	login_delay = 10` + "\n"
 	config += `	login_on_failure = true` + "\n"

--- a/internal/provider/resource_iosxe_system_test.go
+++ b/internal/provider/resource_iosxe_system_test.go
@@ -39,7 +39,7 @@ func TestAccIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_bgp_community_new_format", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ipv6_unicast_routing", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_source_route", "false"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_lookup", "false"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_lookup", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_name", "test.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "login_delay", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "login_on_failure", "true"))
@@ -157,7 +157,7 @@ func testAccIosxeSystemConfig_all() string {
 	config += `	ip_bgp_community_new_format = true` + "\n"
 	config += `	ipv6_unicast_routing = true` + "\n"
 	config += `	ip_source_route = false` + "\n"
-	config += `	ip_domain_lookup = false` + "\n"
+	config += `	ip_domain_lookup = true` + "\n"
 	config += `	ip_domain_name = "test.com"` + "\n"
 	config += `	login_delay = 10` + "\n"
 	config += `	login_on_failure = true` + "\n"


### PR DESCRIPTION
  ### Problem

  System resource tests were failing across all platforms (C8000v 17.12.4, C8000v 17.15.3,
  C9000v 17.15.1) with error:

  ```bash
  StatusCode 400: invalid-value
  ErrorMessage: inconsistent value: Device refused one or more commands
  ErrorPath: /Cisco-IOS-XE-native:native
  ```

  **Root Cause**: Test configuration contained logically contradictory settings introduced in
   commit `7a257c6` (PR #318) by @mike-krau  on Oct 29, 2025.

  The test attempted to:
  1. **DISABLE** domain lookup: `ip_domain_lookup = false` → `no ip domain lookup`
  2. **ENABLE** domain lookup options: `ip_domain_lookup_nsap = true`,
  `ip_domain_lookup_recursive = true`, `ip_domain_lookup_vrfs`

  This is equivalent to the following conflicting CLI commands:

  ```cisco
  no ip domain lookup
  ip domain lookup nsap
  ip domain lookup recursive
  ip domain lookup vrf VRF1 source-interface GigabitEthernet1/0/1
  ```

  IOS-XE devices correctly rejected this configuration as semantically invalid.

  ### YANG Sanity Check

  The YANG model structure shows the parent-child relationship:

  - `ip/domain/lookup` → Parent feature (boolean, controls DNS lookup)
  - `ip/domain/lookup-settings/lookup/nsap` → Child feature (requires parent enabled)
  - `ip/domain/lookup-settings/lookup/recursive` → Child feature (requires parent enabled)
  - `ip/domain/lookup-settings/lookup/vrf` → Child feature (requires parent enabled)

  While the YANG schema does not explicitly enforce this constraint with a `when` condition,
  **IOS-XE enforces the logical dependency at runtime**. You cannot configure DNS lookup
  options when DNS lookup itself is disabled.

  ### Fix

  Changed `ip_domain_lookup` example value from `false` to `true` in
  `gen/definitions/system.yaml`:

  ```diff
  - yang_name: ip/domain/lookup
  -   example: false
  +   example: true
  ```

  This resolves the logical contradiction and allows all domain lookup child features to be 
  properly tested.

