### PR TITLE
fix: logging persistent_url flash vs. bootflash

### DIFF
--- a/docs/resources/logging.md
+++ b/docs/resources/logging.md
@@ -135,7 +135,6 @@ resource "iosxe_logging" "example" {
       ]
     }
   ]
-  persistent_url      = "flash:/local_logging"
   persistent_size     = 1000000
   persistent_filesize = 500000
   rate_limit_all      = 200

--- a/examples/resources/iosxe_logging/resource.tf
+++ b/examples/resources/iosxe_logging/resource.tf
@@ -120,7 +120,6 @@ resource "iosxe_logging" "example" {
       ]
     }
   ]
-  persistent_url      = "flash:/local_logging"
   persistent_size     = 1000000
   persistent_filesize = 500000
   rate_limit_all      = 200

--- a/gen/definitions/logging.yaml
+++ b/gen/definitions/logging.yaml
@@ -240,6 +240,7 @@ attributes:
     test_tags: [IOSXE1715]
   - yang_name: persistent/url
     example: flash:/local_logging
+    test_tags: [IOSXE1712]
   - yang_name: persistent/size
     example: 1000000
   - yang_name: persistent/filesize

--- a/internal/provider/data_source_iosxe_logging_test.go
+++ b/internal/provider/data_source_iosxe_logging_test.go
@@ -73,7 +73,9 @@ func TestAccDataSourceIosxeLogging(t *testing.T) {
 	if os.Getenv("IOSXE1715") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "logging_count", "true"))
 	}
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_url", "flash:/local_logging"))
+	if os.Getenv("IOSXE1712") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_url", "flash:/local_logging"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_size", "1000000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "persistent_filesize", "500000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_logging.test", "rate_limit_all", "200"))
@@ -202,7 +204,9 @@ func testAccDataSourceIosxeLoggingConfig() string {
 	if os.Getenv("IOSXE1715") != "" {
 		config += `	logging_count = true` + "\n"
 	}
-	config += `	persistent_url = "flash:/local_logging"` + "\n"
+	if os.Getenv("IOSXE1712") != "" {
+		config += `	persistent_url = "flash:/local_logging"` + "\n"
+	}
 	config += `	persistent_size = 1000000` + "\n"
 	config += `	persistent_filesize = 500000` + "\n"
 	config += `	rate_limit_all = 200` + "\n"

--- a/internal/provider/resource_iosxe_logging_test.go
+++ b/internal/provider/resource_iosxe_logging_test.go
@@ -75,7 +75,9 @@ func TestAccIosxeLogging(t *testing.T) {
 	if os.Getenv("IOSXE1715") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "logging_count", "true"))
 	}
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_url", "flash:/local_logging"))
+	if os.Getenv("IOSXE1712") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_url", "flash:/local_logging"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_size", "1000000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "persistent_filesize", "500000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_logging.test", "rate_limit_all", "200"))
@@ -237,7 +239,9 @@ func testAccIosxeLoggingConfig_all() string {
 	if os.Getenv("IOSXE1715") != "" {
 		config += `	logging_count = true` + "\n"
 	}
-	config += `	persistent_url = "flash:/local_logging"` + "\n"
+	if os.Getenv("IOSXE1712") != "" {
+		config += `	persistent_url = "flash:/local_logging"` + "\n"
+	}
 	config += `	persistent_size = 1000000` + "\n"
 	config += `	persistent_filesize = 500000` + "\n"
 	config += `	rate_limit_all = 200` + "\n"


### PR DESCRIPTION
  ## Problem

  The `persistent_url` attribute in the logging resource causes test failures on C8000v 17.15.3 due to
  version-specific path normalization behavior. When the test configures `flash:/local_logging`, IOS-XE 17.15.3
  normalizes this to the canonical device name `bootflash:/local_logging`, causing Terraform to detect configuration
  drift.

  **Test failures:**
  - `TestAccDataSourceIosxeLogging` on C8000v 17.15.3
  - `TestAccIosxeLogging` on C8000v 17.15.3

  **Error observed:**
  ```
  persistent_url = "bootflash:/local_logging" -> "flash:/local_logging"
  Plan: 0 to add, 1 to change, 0 to destroy.
  ```

  ## Root Cause

  Cisco changed storage path normalization behavior between IOS-XE versions:

  **IOS-XE 17.12.4 behavior:**
  - Accepts `bootflash:` input
  - Normalizes TO `flash:` (alias form)
  - Test configures `flash:`, device returns `flash:` → No drift ✓

  **IOS-XE 17.15.3 behavior:**
  - Accepts `flash:` input
  - Normalizes TO `bootflash:` (canonical form)
  - Test configures `flash:`, device returns `bootflash:` → Drift detected ✗

  **CLI verification on C9300 17.12.4:**
  ```cli
  Switch(config)# logging persistent url bootflash:/local_logging
  Switch(config)#
  *Nov  8 20:32:41.411: %SYS-5-LOG_CONFIG_CHANGE: Persistent logging: enabled, url flash:/local_logging

  Switch(config)# do show running-config | inc logging persistent
  logging persistent url flash:/local_logging
  ```

  The device accepted `bootflash:` but stored/returned `flash:` in the running config, confirming version-specific
  normalization.

  ## Related Issues

  **Introduced by:**
  - Commit: `eebfc47` (PR #334)
  - Author: @tech-of-all-trades
  - Date: November 4, 2025
  - PR Title: "Add logging attributes"

  The original PR added persistent logging attributes with `flash:/local_logging` as the example, which works on
  17.12 but causes drift on 17.15.3 due to the version-specific normalization behavior discovered during testing.