### PR TITLE
feat: add multi-device testing support to GNUmakefile

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,25 +6,21 @@ IOSXE_USERNAME=admin
 IOSXE_PASSWORD=password
 
 # 17.15.x Router (e.g., C8000V)
-IOSXE_1715_ROUTER_URL=https://192.0.2.10
 IOSXE_1715_ROUTER_HOST=192.0.2.10
 # IOSXE_1715_ROUTER_USERNAME=admin  # Optional: Override global username
 # IOSXE_1715_ROUTER_PASSWORD=password  # Optional: Override global password
 
 # 17.15.x Switch (e.g., C9000V)
-IOSXE_1715_SWITCH_URL=https://192.0.2.11
 IOSXE_1715_SWITCH_HOST=192.0.2.11
 # IOSXE_1715_SWITCH_USERNAME=admin  # Optional: Override global username
 # IOSXE_1715_SWITCH_PASSWORD=password  # Optional: Override global password
 
 # 17.12.x Router (e.g., C8000V)
-IOSXE_1712_ROUTER_URL=https://192.0.2.12
 IOSXE_1712_ROUTER_HOST=192.0.2.12
 # IOSXE_1712_ROUTER_USERNAME=admin  # Optional: Override global username
 # IOSXE_1712_ROUTER_PASSWORD=changeme  # Optional: Override global password
 
 # 17.12.x Switch (e.g., C9000V)
-IOSXE_1712_SWITCH_URL=https://192.0.2.13
 IOSXE_1712_SWITCH_HOST=192.0.2.13
 # IOSXE_1712_SWITCH_USERNAME=admin  # Optional: Override global username
 # IOSXE_1712_SWITCH_PASSWORD=changeme  # Optional: Override global password

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,37 @@
+# IOS XE Test Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# Global credentials (used as fallback if device-specific credentials are not set)
+IOSXE_USERNAME=admin
+IOSXE_PASSWORD=password
+
+# 17.15.x Router (e.g., C8000V)
+IOSXE_1715_ROUTER_URL=https://192.0.2.10
+IOSXE_1715_ROUTER_HOST=192.0.2.10
+# IOSXE_1715_ROUTER_USERNAME=admin  # Optional: Override global username
+# IOSXE_1715_ROUTER_PASSWORD=password  # Optional: Override global password
+
+# 17.15.x Switch (e.g., C9000V)
+IOSXE_1715_SWITCH_URL=https://192.0.2.11
+IOSXE_1715_SWITCH_HOST=192.0.2.11
+# IOSXE_1715_SWITCH_USERNAME=admin  # Optional: Override global username
+# IOSXE_1715_SWITCH_PASSWORD=password  # Optional: Override global password
+
+# 17.12.x Router (e.g., C8000V)
+IOSXE_1712_ROUTER_URL=https://192.0.2.12
+IOSXE_1712_ROUTER_HOST=192.0.2.12
+# IOSXE_1712_ROUTER_USERNAME=admin  # Optional: Override global username
+# IOSXE_1712_ROUTER_PASSWORD=changeme  # Optional: Override global password
+
+# 17.12.x Switch (e.g., C9000V)
+IOSXE_1712_SWITCH_URL=https://192.0.2.13
+IOSXE_1712_SWITCH_HOST=192.0.2.13
+# IOSXE_1712_SWITCH_USERNAME=admin  # Optional: Override global username
+# IOSXE_1712_SWITCH_PASSWORD=changeme  # Optional: Override global password
+
+# Test Options
+# Set to 1 to skip resource cleanup after tests
+# SKIP_DESTROY=0
+
+# Set to 1 to enable debug logging
+# DEBUG=0

--- a/.env.sample
+++ b/.env.sample
@@ -25,9 +25,5 @@ IOSXE_1712_SWITCH_HOST=192.0.2.13
 # IOSXE_1712_SWITCH_USERNAME=admin  # Optional: Override global username
 # IOSXE_1712_SWITCH_PASSWORD=changeme  # Optional: Override global password
 
-# Test Options
-# Set to 1 to skip resource cleanup after tests
-# SKIP_DESTROY=0
-
 # Set to 1 to enable debug logging
 # DEBUG=0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,11 +142,10 @@ make test NAME=Logging  # Legacy single-device test
 make test-1715-router NAME=TestAccResourceIosxeVlan  # Specific test on specific device
 ```
 
-**Debug and options:**
+**Debug mode:**
 
 ```shell
-DEBUG=1 make test-1715-switch           # Enable debug logging (writes to test-output-*.log)
-SKIP_DESTROY=1 make test-1712-router    # Preserve test resources after test completion
+DEBUG=1 make test-1715-switch    # Enable debug logging (writes to test-output-*.log)
 ```
 
 > **Note**: Acceptance tests create real resources on the target devices.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,26 +91,22 @@ Edit the `.env` file to set your device credentials and connection details. The 
 
 - **Global credentials**: `IOSXE_USERNAME` and `IOSXE_PASSWORD` apply to all devices by default
 - **Device-specific overrides**: Optional `IOSXE_XXXX_DEVICE_USERNAME` and `IOSXE_XXXX_DEVICE_PASSWORD` for devices with different credentials
-- **Device URLs**: Separate URLs for each device and version combination
+- **Device hosts**: Separate host addresses for each device and version combination
 
 Example `.env` configuration:
 
 ```shell
 # Global credentials (used for all devices unless overridden)
 IOSXE_USERNAME=admin
-IOSXE_PASSWORD=cisco!123
+IOSXE_PASSWORD=password
 
-# 17.15.x Router
-IOSXE_1715_ROUTER_URL=https://10.81.239.57
-IOSXE_1715_ROUTER_HOST=10.81.239.57
+# 17.15.x Router and Switch
+IOSXE_1715_ROUTER_HOST=192.0.2.10
+IOSXE_1715_SWITCH_HOST=192.0.2.11
 
-# 17.15.x Switch
-IOSXE_1715_SWITCH_URL=https://10.81.239.61
-IOSXE_1715_SWITCH_HOST=10.81.239.61
-
-# 17.12.x devices (optional, for testing older versions)
-# IOSXE_1712_ROUTER_URL=https://192.168.1.1
-# IOSXE_1712_ROUTER_HOST=192.168.1.1
+# 17.12.x Router and Switch
+IOSXE_1712_ROUTER_HOST=192.0.2.12
+IOSXE_1712_SWITCH_HOST=192.0.2.13
 ```
 
 #### Running Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,23 +79,81 @@ make genall
 
 ### Acceptance Tests
 
-In order to run the full suite of Acceptance tests, run `make testacc`. Make sure the respective environment variables are set (e.g., `IOSXE_USERNAME`, `IOSXE_PASSWORD`, `IOSXE_URL`).
+#### Configuration
 
-Every resource and data source implemented has a corresponding acceptance test. To run a single acceptance test use the following command:
+Before running acceptance tests, configure your test environment by creating a `.env` file from the provided sample:
 
 ```shell
-make test NAME=Logging
+cp .env.sample .env
 ```
 
-Where `NAME` is the camelcase name of the resource or data source to test. Make sure the respective environment variables to configure the provider are set (e.g., `IOSXE_USERNAME`, `IOSXE_PASSWORD`, `IOSXE_URL`).
+Edit the `.env` file to set your device credentials and connection details. The configuration supports:
 
-In order to run the full suite of Acceptance tests, run `make testall`.
+- **Global credentials**: `IOSXE_USERNAME` and `IOSXE_PASSWORD` apply to all devices by default
+- **Device-specific overrides**: Optional `IOSXE_XXXX_DEVICE_USERNAME` and `IOSXE_XXXX_DEVICE_PASSWORD` for devices with different credentials
+- **Device URLs**: Separate URLs for each device and version combination
 
-Note: Acceptance tests create real resources.
+Example `.env` configuration:
+
+```shell
+# Global credentials (used for all devices unless overridden)
+IOSXE_USERNAME=admin
+IOSXE_PASSWORD=cisco!123
+
+# 17.15.x Router
+IOSXE_1715_ROUTER_URL=https://10.81.239.57
+IOSXE_1715_ROUTER_HOST=10.81.239.57
+
+# 17.15.x Switch
+IOSXE_1715_SWITCH_URL=https://10.81.239.61
+IOSXE_1715_SWITCH_HOST=10.81.239.61
+
+# 17.12.x devices (optional, for testing older versions)
+# IOSXE_1712_ROUTER_URL=https://192.168.1.1
+# IOSXE_1712_ROUTER_HOST=192.168.1.1
+```
+
+#### Running Tests
+
+**Run all tests across all devices:**
 
 ```shell
 make testall
 ```
+
+This will regenerate code and run tests against all configured devices (17.15.x and 17.12.x versions).
+
+**Run tests for a specific version:**
+
+```shell
+make test-1715  # Test all 17.15.x devices
+make test-1712  # Test all 17.12.x devices
+```
+
+**Run tests for a specific device:**
+
+```shell
+make test-1715-router   # Test 17.15.x router only
+make test-1715-switch   # Test 17.15.x switch only
+make test-1712-router   # Test 17.12.x router only
+make test-1712-switch   # Test 17.12.x switch only
+```
+
+**Run specific tests by name:**
+
+```shell
+make test NAME=Logging  # Legacy single-device test
+make test-1715-router NAME=TestAccResourceIosxeVlan  # Specific test on specific device
+```
+
+**Debug and options:**
+
+```shell
+DEBUG=1 make test-1715-switch           # Enable debug logging (writes to test-output-*.log)
+SKIP_DESTROY=1 make test-1712-router    # Preserve test resources after test completion
+```
+
+> **Note**: Acceptance tests create real resources on the target devices.
 
 ## Sending Pull Requests
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ test:
 	TF_ACC=1 go test ./... -v -run $(NAME) -count 1 -timeout 60m
 
 # Test against 17.15.x Router (C8000V)
-# Usage: make test-1715-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+# Usage: make test-1715-router [NAME=TestName] [DEBUG=1]
 .PHONY: test-1715-router
 test-1715-router:
 	@echo "========================================="
@@ -37,13 +37,12 @@ test-1715-router:
 		IOSXE_PASSWORD=$(or $(IOSXE_1715_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
 		IOSXE1715=1 \
 		C8000V=1 \
-		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
 		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log); \
 	fi
 
 # Test against 17.15.x Switch (C9000V)
-# Usage: make test-1715-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+# Usage: make test-1715-switch [NAME=TestName] [DEBUG=1]
 .PHONY: test-1715-switch
 test-1715-switch:
 	@echo "========================================="
@@ -61,13 +60,12 @@ test-1715-switch:
 		IOSXE_PASSWORD=$(or $(IOSXE_1715_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
 		IOSXE1715=1 \
 		C9000V=1 \
-		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
 		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log); \
 	fi
 
 # Test against 17.12.x Router (C8000V)
-# Usage: make test-1712-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+# Usage: make test-1712-router [NAME=TestName] [DEBUG=1]
 .PHONY: test-1712-router
 test-1712-router:
 	@echo "========================================="
@@ -85,13 +83,12 @@ test-1712-router:
 		IOSXE_PASSWORD=$(or $(IOSXE_1712_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
 		IOSXE1712=1 \
 		C8000V=1 \
-		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
 		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log); \
 	fi
 
 # Test against 17.12.x Switch (C9000V)
-# Usage: make test-1712-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+# Usage: make test-1712-switch [NAME=TestName] [DEBUG=1]
 .PHONY: test-1712-switch
 test-1712-switch:
 	@echo "========================================="
@@ -109,7 +106,6 @@ test-1712-switch:
 		IOSXE_PASSWORD=$(or $(IOSXE_1712_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
 		IOSXE1712=1 \
 		C9000V=1 \
-		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
 		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log); \
 	fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,7 +28,6 @@ test-1715-router:
 	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-router.log")
 	$(if $(NAME),@echo "Running tests matching: $(NAME)")
 	@TF_ACC=1 \
-	IOSXE_URL=$(IOSXE_1715_ROUTER_URL) \
 	IOSXE_HOST=$(IOSXE_1715_ROUTER_HOST) \
 	IOSXE_USERNAME=$(or $(IOSXE_1715_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
 	IOSXE_PASSWORD=$(or $(IOSXE_1715_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
@@ -48,7 +47,6 @@ test-1715-switch:
 	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-switch.log")
 	$(if $(NAME),@echo "Running tests matching: $(NAME)")
 	@TF_ACC=1 \
-	IOSXE_URL=$(IOSXE_1715_SWITCH_URL) \
 	IOSXE_HOST=$(IOSXE_1715_SWITCH_HOST) \
 	IOSXE_USERNAME=$(or $(IOSXE_1715_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
 	IOSXE_PASSWORD=$(or $(IOSXE_1715_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
@@ -68,7 +66,6 @@ test-1712-router:
 	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-router.log")
 	$(if $(NAME),@echo "Running tests matching: $(NAME)")
 	@TF_ACC=1 \
-	IOSXE_URL=$(IOSXE_1712_ROUTER_URL) \
 	IOSXE_HOST=$(IOSXE_1712_ROUTER_HOST) \
 	IOSXE_USERNAME=$(or $(IOSXE_1712_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
 	IOSXE_PASSWORD=$(or $(IOSXE_1712_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
@@ -88,7 +85,6 @@ test-1712-switch:
 	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-switch.log")
 	$(if $(NAME),@echo "Running tests matching: $(NAME)")
 	@TF_ACC=1 \
-	IOSXE_URL=$(IOSXE_1712_SWITCH_URL) \
 	IOSXE_HOST=$(IOSXE_1712_SWITCH_HOST) \
 	IOSXE_USERNAME=$(or $(IOSXE_1712_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
 	IOSXE_PASSWORD=$(or $(IOSXE_1712_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ testall: gen test-1715-router test-1715-switch test-1712-router test-1712-switch
 # Usage: make test NAME=IosxeLogging
 .PHONY: test
 test:
-	TF_ACC=1 go test ./... -v -run $(NAME) -timeout 60m
+	TF_ACC=1 go test ./... -v -run $(NAME) -count 1 -timeout 60m
 
 # Test against 17.15.x Router (C8000V)
 # Usage: make test-1715-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
@@ -39,7 +39,7 @@ test-1715-router:
 		C8000V=1 \
 		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log); \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log); \
 	fi
 
 # Test against 17.15.x Switch (C9000V)
@@ -63,7 +63,7 @@ test-1715-switch:
 		C9000V=1 \
 		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log); \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log); \
 	fi
 
 # Test against 17.12.x Router (C8000V)
@@ -87,7 +87,7 @@ test-1712-router:
 		C8000V=1 \
 		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log); \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log); \
 	fi
 
 # Test against 17.12.x Switch (C9000V)
@@ -111,7 +111,7 @@ test-1712-switch:
 		C9000V=1 \
 		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
 		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log); \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -count 1 -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log); \
 	fi
 
 # Test all 17.15.x devices (router and switch)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,17 +25,22 @@ test-1715-router:
 	@echo "========================================="
 	@echo "Testing against 17.15.x Router..."
 	@echo "========================================="
-	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-router.log")
-	$(if $(NAME),@echo "Running tests matching: $(NAME)")
-	@TF_ACC=1 \
-	IOSXE_HOST=$(IOSXE_1715_ROUTER_HOST) \
-	IOSXE_USERNAME=$(or $(IOSXE_1715_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
-	IOSXE_PASSWORD=$(or $(IOSXE_1715_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
-	IOSXE1715=1 \
-	C8000V=1 \
-	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
-	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log)
+	@if [ -z "$(IOSXE_1715_ROUTER_HOST)" ]; then \
+		echo "SKIPPED: IOSXE_1715_ROUTER_HOST is not configured"; \
+		echo "To enable this test, configure IOSXE_1715_ROUTER_HOST in your .env file"; \
+	else \
+		$(if $(DEBUG),echo "Debug mode enabled - logs will be written to test-output-1715-router.log";) \
+		$(if $(NAME),echo "Running tests matching: $(NAME)";) \
+		TF_ACC=1 \
+		IOSXE_HOST=$(IOSXE_1715_ROUTER_HOST) \
+		IOSXE_USERNAME=$(or $(IOSXE_1715_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
+		IOSXE_PASSWORD=$(or $(IOSXE_1715_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
+		IOSXE1715=1 \
+		C8000V=1 \
+		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log); \
+	fi
 
 # Test against 17.15.x Switch (C9000V)
 # Usage: make test-1715-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
@@ -44,17 +49,22 @@ test-1715-switch:
 	@echo "========================================="
 	@echo "Testing against 17.15.x Switch..."
 	@echo "========================================="
-	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-switch.log")
-	$(if $(NAME),@echo "Running tests matching: $(NAME)")
-	@TF_ACC=1 \
-	IOSXE_HOST=$(IOSXE_1715_SWITCH_HOST) \
-	IOSXE_USERNAME=$(or $(IOSXE_1715_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
-	IOSXE_PASSWORD=$(or $(IOSXE_1715_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
-	IOSXE1715=1 \
-	C9000V=1 \
-	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
-	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log)
+	@if [ -z "$(IOSXE_1715_SWITCH_HOST)" ]; then \
+		echo "SKIPPED: IOSXE_1715_SWITCH_HOST is not configured"; \
+		echo "To enable this test, configure IOSXE_1715_SWITCH_HOST in your .env file"; \
+	else \
+		$(if $(DEBUG),echo "Debug mode enabled - logs will be written to test-output-1715-switch.log";) \
+		$(if $(NAME),echo "Running tests matching: $(NAME)";) \
+		TF_ACC=1 \
+		IOSXE_HOST=$(IOSXE_1715_SWITCH_HOST) \
+		IOSXE_USERNAME=$(or $(IOSXE_1715_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
+		IOSXE_PASSWORD=$(or $(IOSXE_1715_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
+		IOSXE1715=1 \
+		C9000V=1 \
+		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log); \
+	fi
 
 # Test against 17.12.x Router (C8000V)
 # Usage: make test-1712-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
@@ -63,17 +73,22 @@ test-1712-router:
 	@echo "========================================="
 	@echo "Testing against 17.12.x Router..."
 	@echo "========================================="
-	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-router.log")
-	$(if $(NAME),@echo "Running tests matching: $(NAME)")
-	@TF_ACC=1 \
-	IOSXE_HOST=$(IOSXE_1712_ROUTER_HOST) \
-	IOSXE_USERNAME=$(or $(IOSXE_1712_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
-	IOSXE_PASSWORD=$(or $(IOSXE_1712_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
-	IOSXE1712=1 \
-	C8000V=1 \
-	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
-	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log)
+	@if [ -z "$(IOSXE_1712_ROUTER_HOST)" ]; then \
+		echo "SKIPPED: IOSXE_1712_ROUTER_HOST is not configured"; \
+		echo "To enable this test, configure IOSXE_1712_ROUTER_HOST in your .env file"; \
+	else \
+		$(if $(DEBUG),echo "Debug mode enabled - logs will be written to test-output-1712-router.log";) \
+		$(if $(NAME),echo "Running tests matching: $(NAME)";) \
+		TF_ACC=1 \
+		IOSXE_HOST=$(IOSXE_1712_ROUTER_HOST) \
+		IOSXE_USERNAME=$(or $(IOSXE_1712_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
+		IOSXE_PASSWORD=$(or $(IOSXE_1712_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
+		IOSXE1712=1 \
+		C8000V=1 \
+		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log); \
+	fi
 
 # Test against 17.12.x Switch (C9000V)
 # Usage: make test-1712-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
@@ -82,17 +97,22 @@ test-1712-switch:
 	@echo "========================================="
 	@echo "Testing against 17.12.x Switch..."
 	@echo "========================================="
-	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-switch.log")
-	$(if $(NAME),@echo "Running tests matching: $(NAME)")
-	@TF_ACC=1 \
-	IOSXE_HOST=$(IOSXE_1712_SWITCH_HOST) \
-	IOSXE_USERNAME=$(or $(IOSXE_1712_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
-	IOSXE_PASSWORD=$(or $(IOSXE_1712_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
-	IOSXE1712=1 \
-	C9000V=1 \
-	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
-	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
-	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log)
+	@if [ -z "$(IOSXE_1712_SWITCH_HOST)" ]; then \
+		echo "SKIPPED: IOSXE_1712_SWITCH_HOST is not configured"; \
+		echo "To enable this test, configure IOSXE_1712_SWITCH_HOST in your .env file"; \
+	else \
+		$(if $(DEBUG),echo "Debug mode enabled - logs will be written to test-output-1712-switch.log";) \
+		$(if $(NAME),echo "Running tests matching: $(NAME)";) \
+		TF_ACC=1 \
+		IOSXE_HOST=$(IOSXE_1712_SWITCH_HOST) \
+		IOSXE_USERNAME=$(or $(IOSXE_1712_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
+		IOSXE_PASSWORD=$(or $(IOSXE_1712_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
+		IOSXE1712=1 \
+		C9000V=1 \
+		$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+		$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+		go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log); \
+	fi
 
 # Test all 17.15.x devices (router and switch)
 .PHONY: test-1715

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,15 +1,114 @@
 default: testall
 
-# Run all acceptance tests
+# Load environment variables from .env file if it exists
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+
+# Run all acceptance tests across all devices and versions
 .PHONY: testall
-testall:
-	TF_ACC=1 go test -v $(TESTARGS) -timeout 60m ./internal/provider
+testall: gen test-1715-router test-1715-switch test-1712-router test-1712-switch
+	@echo ""
+	@echo "All multi-device tests completed!"
 
 # Run a subset of tests by specifying a regex (NAME).
 # Usage: make test NAME=IosxeLogging
 .PHONY: test
 test:
 	TF_ACC=1 go test ./... -v -run $(NAME) -timeout 60m
+
+# Test against 17.15.x Router (C8000V)
+# Usage: make test-1715-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+.PHONY: test-1715-router
+test-1715-router:
+	@echo "========================================="
+	@echo "Testing against 17.15.x Router..."
+	@echo "========================================="
+	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-router.log")
+	$(if $(NAME),@echo "Running tests matching: $(NAME)")
+	@TF_ACC=1 \
+	IOSXE_URL=$(IOSXE_1715_ROUTER_URL) \
+	IOSXE_HOST=$(IOSXE_1715_ROUTER_HOST) \
+	IOSXE_USERNAME=$(or $(IOSXE_1715_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
+	IOSXE_PASSWORD=$(or $(IOSXE_1715_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
+	IOSXE1715=1 \
+	C8000V=1 \
+	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-router.log)
+
+# Test against 17.15.x Switch (C9000V)
+# Usage: make test-1715-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+.PHONY: test-1715-switch
+test-1715-switch:
+	@echo "========================================="
+	@echo "Testing against 17.15.x Switch..."
+	@echo "========================================="
+	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1715-switch.log")
+	$(if $(NAME),@echo "Running tests matching: $(NAME)")
+	@TF_ACC=1 \
+	IOSXE_URL=$(IOSXE_1715_SWITCH_URL) \
+	IOSXE_HOST=$(IOSXE_1715_SWITCH_HOST) \
+	IOSXE_USERNAME=$(or $(IOSXE_1715_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
+	IOSXE_PASSWORD=$(or $(IOSXE_1715_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
+	IOSXE1715=1 \
+	C9000V=1 \
+	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1715-switch.log)
+
+# Test against 17.12.x Router (C8000V)
+# Usage: make test-1712-router [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+.PHONY: test-1712-router
+test-1712-router:
+	@echo "========================================="
+	@echo "Testing against 17.12.x Router..."
+	@echo "========================================="
+	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-router.log")
+	$(if $(NAME),@echo "Running tests matching: $(NAME)")
+	@TF_ACC=1 \
+	IOSXE_URL=$(IOSXE_1712_ROUTER_URL) \
+	IOSXE_HOST=$(IOSXE_1712_ROUTER_HOST) \
+	IOSXE_USERNAME=$(or $(IOSXE_1712_ROUTER_USERNAME),$(IOSXE_USERNAME)) \
+	IOSXE_PASSWORD=$(or $(IOSXE_1712_ROUTER_PASSWORD),$(IOSXE_PASSWORD)) \
+	IOSXE1712=1 \
+	C8000V=1 \
+	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-router.log)
+
+# Test against 17.12.x Switch (C9000V)
+# Usage: make test-1712-switch [NAME=TestName] [DEBUG=1] [SKIP_DESTROY=1]
+.PHONY: test-1712-switch
+test-1712-switch:
+	@echo "========================================="
+	@echo "Testing against 17.12.x Switch..."
+	@echo "========================================="
+	$(if $(DEBUG),@echo "Debug mode enabled - logs will be written to test-output-1712-switch.log")
+	$(if $(NAME),@echo "Running tests matching: $(NAME)")
+	@TF_ACC=1 \
+	IOSXE_URL=$(IOSXE_1712_SWITCH_URL) \
+	IOSXE_HOST=$(IOSXE_1712_SWITCH_HOST) \
+	IOSXE_USERNAME=$(or $(IOSXE_1712_SWITCH_USERNAME),$(IOSXE_USERNAME)) \
+	IOSXE_PASSWORD=$(or $(IOSXE_1712_SWITCH_PASSWORD),$(IOSXE_PASSWORD)) \
+	IOSXE1712=1 \
+	C9000V=1 \
+	$(if $(SKIP_DESTROY),SKIP_DESTROY=1) \
+	$(if $(DEBUG),TF_ACC_LOG=1 TF_LOG_SDK_FRAMEWORK=DEBUG) \
+	go test -v $(if $(NAME),-run $(NAME)) $(TESTARGS) -timeout 60m ./... $(if $(DEBUG),2>&1 | tee test-output-1712-switch.log)
+
+# Test all 17.15.x devices (router and switch)
+.PHONY: test-1715
+test-1715: gen test-1715-router test-1715-switch
+	@echo ""
+	@echo "All 17.15.x tests completed!"
+
+# Test all 17.12.x devices (router and switch)
+.PHONY: test-1712
+test-1712: gen test-1712-router test-1712-switch
+	@echo ""
+	@echo "All 17.12.x tests completed!"
 
 # Update a files from a single definition
 # Usage: make gen NAME="Logging"

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ More information about how the code generation works can be found in the [contri
 
 ## Acceptance tests
 
-In order to run the full suite of acceptance tests, run `make testall`. Make sure the respective environment variables are set (e.g., `MERAKI_API_KEY`).
-
-Note: Acceptance tests create real resources.
+In order to run the full suite of acceptance tests, set up a `.env` file with the appropriate environment variables. Copy the sample file at `.env.sample` to `.env`, then edit the file to set the appropriate environment variables.
 
 ```shell
-make testall
+cp .env.sample .env
 ```
+
+Then, run `make testall` to execute all acceptance tests across all devices and versions.
+
+> **Note**: Acceptance tests create real resources.
 
 More information about how the acceptance tests work can be found in the [contribution guide](https://github.com/CiscoDevNet/terraform-provider-iosxe/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Enhances the GNUMakefile to support testing across multiple IOS XE devices and versions with
environment-based configuration pulled from a `.env` file.

## Motivation

Today, individuals must manually manipulate environment variables in their shell to test against different IOS-XE devices and software versions. This is error-prone, time-consuming, and annoying.

With this PR, environment variables are pulled from a `.env` file, making developer experience more pleasant. Additionally, environment variables are translated into the equivalent variables needed for Go's unit test frameworks. This is continuously done for each set of targeted devices.

This enables developers to easily test against different devices and versions without having to manually manipulate environment variables.

## Changes

- **Environment Configuration**: Added `.env.sample` template for device credentials and connection details
- **Credential Fallback**: Global `IOSXE_USERNAME`/`IOSXE_PASSWORD` variables with optional device-specific overrides
- **New Test Targets**:
    - `test-1715-router` / `test-1715-switch` - Test 17.15.x devices individually
    - `test-1712-router` / `test-1712-switch` - Test 17.12.x devices individually
    - `test-1715` / `test-1712` - Test all devices for a specific version
- **Enhanced `testall`**: Now runs tests across all devices and versions by default
- **Optional Parameters**: `NAME` (filter tests), `DEBUG` (enable logging), `SKIP_DESTROY` (preserve resources)

## Usage

```bash
# Copy and configure environment
cp .env.sample .env

# Run all tests across all devices
make testall

# Test IOS-XE 17.15.x devices
make test-1715

# Test IOS-XE 17.12.x devices
make test-1712

# Run specific test on a specific IOS-XE 17.15.x router
make test-1715-router NAME=TestAccResourceIosxeVlan

# Run specific test on a specific IOS-XE 17.12.x switch
make test-1712-switch NAME=TestAccResourceIosxeVlan
```
