### PR TITLE
Fix: Allow IOSXE_URL environment variable in acceptance test pre-check

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -44,6 +44,8 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("IOSXE_PASSWORD env variable must be set for acceptance tests")
 	}
 	if v := os.Getenv("IOSXE_HOST"); v == "" {
-		t.Fatal("IOSXE_HOST env variable must be set for acceptance tests")
+		if v := os.Getenv("IOSXE_URL"); v == "" {
+			t.Fatal("IOSXE_HOST or IOSXE_URL env variable must be set for acceptance tests")
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where acceptance tests would fail if only the `IOSXE_URL` environment variable was set without `IOSXE_HOST` being defined, despite the provider correctly supporting `IOSXE_URL` as a fallback.

## Problem

Since version 0.10.0, which introduced the `host` provider attribute and deprecated `url`, the `testAccPreCheck` function in `provider_test.go` has required the `IOSXE_HOST` environment variable to be set. This prevented users from running acceptance tests using the deprecated but still supported `IOSXE_URL` environment variable.

The provider's configuration logic (in `provider.go` lines 289-319) correctly implements a fallback chain:
1. `host` config attribute
2. `url` config attribute
3. `IOSXE_HOST` environment variable
4. `IOSXE_URL` environment variable ← **This fallback was blocked by tests**
5. First device from devices list

However, the test pre-check function was overly restrictive and didn't allow this fallback behavior.

## Changes

Modified `testAccPreCheck` function in `internal/provider/provider_test.go` to check for either `IOSXE_HOST` or `IOSXE_URL` environment variables, matching the provider's actual behavior.

**Before:**
```go
if v := os.Getenv("IOSXE_HOST"); v == "" {
    t.Fatal("IOSXE_HOST env variable must be set for acceptance tests")
}
```

**After:**
```go
if v := os.Getenv("IOSXE_HOST"); v == "" {
    if v := os.Getenv("IOSXE_URL"); v == "" {
        t.Fatal("IOSXE_HOST or IOSXE_URL env variable must be set for acceptance tests")
    }
}
```

## Testing

- [x] Verified acceptance tests run successfully with `IOSXE_URL` set and `IOSXE_HOST` unset
- [x] Verified acceptance tests still work with `IOSXE_HOST` set (backward compatibility)
- [x] Confirmed error message is clear when neither variable is set

## Impact

- ✅ Restores ability to run acceptance tests using `IOSXE_URL` environment variable
- ✅ Maintains backward compatibility with `IOSXE_HOST`
- ✅ Aligns test requirements with actual provider behavior
- ✅ No breaking changes

## Related Issues

Closes #365 