### PR TITLE
feature(TRM): Implement PIM Advanced Support in Terraform Provider

### DIFF
--- a/docs/data-sources/pim.md
+++ b/docs/data-sources/pim.md
@@ -33,6 +33,7 @@ data "iosxe_pim" "example" {
 - `bsr_candidate_mask` (Number) Hash Mask length for RP selection
 - `bsr_candidate_priority` (Number) Priority value for candidate bootstrap router
 - `id` (String) The path of the retrieved object.
+- `register_source_loopback` (Number) Loopback interface
 - `rp_address` (String) IP address of Rendezvous-point for group
 - `rp_address_bidir` (Boolean) Group range treated in bidirectional shared-tree mode
 - `rp_address_override` (Boolean) Overrides dynamically learnt RP mappings
@@ -77,6 +78,7 @@ Read-Only:
 - `bsr_candidate_mask` (Number) Hash Mask length for RP selection
 - `bsr_candidate_priority` (Number) Priority value for candidate bootstrap router
 - `cache_rpf_oif` (Boolean) Cache outgoing interface RPF info
+- `register_source_loopback` (Number) Loopback interface
 - `rp_address` (String) IP address of Rendezvous-point for group
 - `rp_address_bidir` (Boolean) Group range treated in bidirectional shared-tree mode
 - `rp_address_override` (Boolean) Overrides dynamically learnt RP mappings

--- a/docs/resources/pim.md
+++ b/docs/resources/pim.md
@@ -14,16 +14,17 @@ This resource can manage the PIM configuration.
 
 ```terraform
 resource "iosxe_pim" "example" {
-  autorp                 = false
-  autorp_listener        = false
-  bsr_candidate_loopback = 100
-  bsr_candidate_mask     = 30
-  bsr_candidate_priority = 10
-  ssm_range              = "10"
-  ssm_default            = false
-  rp_address             = "9.9.9.9"
-  rp_address_override    = false
-  rp_address_bidir       = false
+  autorp                   = false
+  autorp_listener          = false
+  bsr_candidate_loopback   = 100
+  bsr_candidate_mask       = 30
+  bsr_candidate_priority   = 10
+  register_source_loopback = 100
+  ssm_range                = "10"
+  ssm_default              = false
+  rp_address               = "9.9.9.9"
+  rp_address_override      = false
+  rp_address_bidir         = false
   rp_addresses = [
     {
       access_list = "10"
@@ -42,17 +43,18 @@ resource "iosxe_pim" "example" {
   ]
   vrfs = [
     {
-      vrf                    = "VRF1"
-      autorp                 = false
-      autorp_listener        = false
-      bsr_candidate_loopback = 200
-      bsr_candidate_mask     = 30
-      bsr_candidate_priority = 10
-      ssm_range              = "10"
-      ssm_default            = false
-      rp_address             = "19.19.19.19"
-      rp_address_override    = false
-      rp_address_bidir       = false
+      vrf                      = "VRF1"
+      autorp                   = false
+      autorp_listener          = false
+      bsr_candidate_loopback   = 200
+      bsr_candidate_mask       = 30
+      bsr_candidate_priority   = 10
+      register_source_loopback = 200
+      ssm_range                = "10"
+      ssm_default              = false
+      rp_address               = "19.19.19.19"
+      rp_address_override      = false
+      rp_address_bidir         = false
       rp_addresses = [
         {
           access_list = "10"
@@ -91,6 +93,8 @@ resource "iosxe_pim" "example" {
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
+- `register_source_loopback` (Number) Loopback interface
+  - Range: `0`-`2147483647`
 - `rp_address` (String) IP address of Rendezvous-point for group
 - `rp_address_bidir` (Boolean) Group range treated in bidirectional shared-tree mode
 - `rp_address_override` (Boolean) Overrides dynamically learnt RP mappings
@@ -154,6 +158,8 @@ Optional:
 - `bsr_candidate_priority` (Number) Priority value for candidate bootstrap router
   - Range: `0`-`255`
 - `cache_rpf_oif` (Boolean) Cache outgoing interface RPF info
+- `register_source_loopback` (Number) Loopback interface
+  - Range: `0`-`2147483647`
 - `rp_address` (String) IP address of Rendezvous-point for group
 - `rp_address_bidir` (Boolean) Group range treated in bidirectional shared-tree mode
 - `rp_address_override` (Boolean) Overrides dynamically learnt RP mappings

--- a/examples/resources/iosxe_pim/resource.tf
+++ b/examples/resources/iosxe_pim/resource.tf
@@ -1,14 +1,15 @@
 resource "iosxe_pim" "example" {
-  autorp                 = false
-  autorp_listener        = false
-  bsr_candidate_loopback = 100
-  bsr_candidate_mask     = 30
-  bsr_candidate_priority = 10
-  ssm_range              = "10"
-  ssm_default            = false
-  rp_address             = "9.9.9.9"
-  rp_address_override    = false
-  rp_address_bidir       = false
+  autorp                   = false
+  autorp_listener          = false
+  bsr_candidate_loopback   = 100
+  bsr_candidate_mask       = 30
+  bsr_candidate_priority   = 10
+  register_source_loopback = 100
+  ssm_range                = "10"
+  ssm_default              = false
+  rp_address               = "9.9.9.9"
+  rp_address_override      = false
+  rp_address_bidir         = false
   rp_addresses = [
     {
       access_list = "10"
@@ -27,17 +28,18 @@ resource "iosxe_pim" "example" {
   ]
   vrfs = [
     {
-      vrf                    = "VRF1"
-      autorp                 = false
-      autorp_listener        = false
-      bsr_candidate_loopback = 200
-      bsr_candidate_mask     = 30
-      bsr_candidate_priority = 10
-      ssm_range              = "10"
-      ssm_default            = false
-      rp_address             = "19.19.19.19"
-      rp_address_override    = false
-      rp_address_bidir       = false
+      vrf                      = "VRF1"
+      autorp                   = false
+      autorp_listener          = false
+      bsr_candidate_loopback   = 200
+      bsr_candidate_mask       = 30
+      bsr_candidate_priority   = 10
+      register_source_loopback = 200
+      ssm_range                = "10"
+      ssm_default              = false
+      rp_address               = "19.19.19.19"
+      rp_address_override      = false
+      rp_address_bidir         = false
       rp_addresses = [
         {
           access_list = "10"

--- a/gen/definitions/pim.yaml
+++ b/gen/definitions/pim.yaml
@@ -24,6 +24,11 @@ attributes:
     delete_parent: true
     exclude_test: true
     example: 10
+  - yang_name: Cisco-IOS-XE-multicast:register-source/interface-choice/Loopback/Loopback
+    xpath: Cisco-IOS-XE-multicast:register-source/Loopback
+    tf_name: register_source_loopback
+    type: Int64
+    example: 100
   - yang_name: Cisco-IOS-XE-multicast:ssm/range
     example: 10
   - yang_name: Cisco-IOS-XE-multicast:ssm/default
@@ -95,6 +100,11 @@ attributes:
         delete_parent: true
         exclude_test: true
         example: 10
+      - yang_name: register-source/interface-choice/Loopback/Loopback
+        xpath: register-source/Loopback
+        tf_name: register_source_loopback
+        type: Int64
+        example: 200
       - yang_name: ssm/range
         example: 10
       - yang_name: ssm/default

--- a/internal/provider/data_source_iosxe_pim.go
+++ b/internal/provider/data_source_iosxe_pim.go
@@ -92,6 +92,10 @@ func (d *PIMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "BSR RP candidate filter",
 				Computed:            true,
 			},
+			"register_source_loopback": schema.Int64Attribute{
+				MarkdownDescription: "Loopback interface",
+				Computed:            true,
+			},
 			"ssm_range": schema.StringAttribute{
 				MarkdownDescription: "ACL for group range to be used for SSM",
 				Computed:            true,
@@ -195,6 +199,10 @@ func (d *PIMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 						},
 						"bsr_candidate_accept_rp_candidate": schema.StringAttribute{
 							MarkdownDescription: "BSR RP candidate filter",
+							Computed:            true,
+						},
+						"register_source_loopback": schema.Int64Attribute{
+							MarkdownDescription: "Loopback interface",
 							Computed:            true,
 						},
 						"ssm_range": schema.StringAttribute{

--- a/internal/provider/data_source_iosxe_pim_test.go
+++ b/internal/provider/data_source_iosxe_pim_test.go
@@ -37,6 +37,7 @@ func TestAccDataSourceIosxePIM(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "bsr_candidate_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "bsr_candidate_mask", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "bsr_candidate_priority", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "register_source_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "ssm_range", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "ssm_default", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "rp_address", "9.9.9.9"))
@@ -56,6 +57,7 @@ func TestAccDataSourceIosxePIM(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.bsr_candidate_loopback", "200"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.bsr_candidate_mask", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.bsr_candidate_priority", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.register_source_loopback", "200"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.ssm_range", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.ssm_default", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_pim.test", "vrfs.0.rp_address", "19.19.19.19"))
@@ -130,6 +132,7 @@ func testAccDataSourceIosxePIMConfig() string {
 	config += `	bsr_candidate_loopback = 100` + "\n"
 	config += `	bsr_candidate_mask = 30` + "\n"
 	config += `	bsr_candidate_priority = 10` + "\n"
+	config += `	register_source_loopback = 100` + "\n"
 	config += `	ssm_range = "10"` + "\n"
 	config += `	ssm_default = false` + "\n"
 	config += `	rp_address = "9.9.9.9"` + "\n"
@@ -154,6 +157,7 @@ func testAccDataSourceIosxePIMConfig() string {
 	config += `		bsr_candidate_loopback = 200` + "\n"
 	config += `		bsr_candidate_mask = 30` + "\n"
 	config += `		bsr_candidate_priority = 10` + "\n"
+	config += `		register_source_loopback = 200` + "\n"
 	config += `		ssm_range = "10"` + "\n"
 	config += `		ssm_default = false` + "\n"
 	config += `		rp_address = "19.19.19.19"` + "\n"

--- a/internal/provider/model_iosxe_pim.go
+++ b/internal/provider/model_iosxe_pim.go
@@ -50,6 +50,7 @@ type PIM struct {
 	BsrCandidateMask              types.Int64       `tfsdk:"bsr_candidate_mask"`
 	BsrCandidatePriority          types.Int64       `tfsdk:"bsr_candidate_priority"`
 	BsrCandidateAcceptRpCandidate types.String      `tfsdk:"bsr_candidate_accept_rp_candidate"`
+	RegisterSourceLoopback        types.Int64       `tfsdk:"register_source_loopback"`
 	SsmRange                      types.String      `tfsdk:"ssm_range"`
 	SsmDefault                    types.Bool        `tfsdk:"ssm_default"`
 	RpAddress                     types.String      `tfsdk:"rp_address"`
@@ -69,6 +70,7 @@ type PIMData struct {
 	BsrCandidateMask              types.Int64       `tfsdk:"bsr_candidate_mask"`
 	BsrCandidatePriority          types.Int64       `tfsdk:"bsr_candidate_priority"`
 	BsrCandidateAcceptRpCandidate types.String      `tfsdk:"bsr_candidate_accept_rp_candidate"`
+	RegisterSourceLoopback        types.Int64       `tfsdk:"register_source_loopback"`
 	SsmRange                      types.String      `tfsdk:"ssm_range"`
 	SsmDefault                    types.Bool        `tfsdk:"ssm_default"`
 	RpAddress                     types.String      `tfsdk:"rp_address"`
@@ -99,6 +101,7 @@ type PIMVrfs struct {
 	BsrCandidateMask              types.Int64           `tfsdk:"bsr_candidate_mask"`
 	BsrCandidatePriority          types.Int64           `tfsdk:"bsr_candidate_priority"`
 	BsrCandidateAcceptRpCandidate types.String          `tfsdk:"bsr_candidate_accept_rp_candidate"`
+	RegisterSourceLoopback        types.Int64           `tfsdk:"register_source_loopback"`
 	SsmRange                      types.String          `tfsdk:"ssm_range"`
 	SsmDefault                    types.Bool            `tfsdk:"ssm_default"`
 	RpAddress                     types.String          `tfsdk:"rp_address"`
@@ -181,6 +184,9 @@ func (data PIM) toBody(ctx context.Context) string {
 	}
 	if !data.BsrCandidateAcceptRpCandidate.IsNull() && !data.BsrCandidateAcceptRpCandidate.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:bsr-candidate.accept-rp-candidate", data.BsrCandidateAcceptRpCandidate.ValueString())
+	}
+	if !data.RegisterSourceLoopback.IsNull() && !data.RegisterSourceLoopback.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:register-source.Loopback", strconv.FormatInt(data.RegisterSourceLoopback.ValueInt64(), 10))
 	}
 	if !data.SsmRange.IsNull() && !data.SsmRange.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:ssm.range", data.SsmRange.ValueString())
@@ -271,6 +277,9 @@ func (data PIM) toBody(ctx context.Context) string {
 			}
 			if !item.BsrCandidateAcceptRpCandidate.IsNull() && !item.BsrCandidateAcceptRpCandidate.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:vrf"+"."+strconv.Itoa(index)+"."+"bsr-candidate.accept-rp-candidate", item.BsrCandidateAcceptRpCandidate.ValueString())
+			}
+			if !item.RegisterSourceLoopback.IsNull() && !item.RegisterSourceLoopback.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:vrf"+"."+strconv.Itoa(index)+"."+"register-source.Loopback", strconv.FormatInt(item.RegisterSourceLoopback.ValueInt64(), 10))
 			}
 			if !item.SsmRange.IsNull() && !item.SsmRange.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-multicast:vrf"+"."+strconv.Itoa(index)+"."+"ssm.range", item.SsmRange.ValueString())
@@ -373,6 +382,9 @@ func (data PIM) toBodyXML(ctx context.Context) string {
 	}
 	if !data.BsrCandidateAcceptRpCandidate.IsNull() && !data.BsrCandidateAcceptRpCandidate.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-multicast:bsr-candidate/accept-rp-candidate", data.BsrCandidateAcceptRpCandidate.ValueString())
+	}
+	if !data.RegisterSourceLoopback.IsNull() && !data.RegisterSourceLoopback.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback", strconv.FormatInt(data.RegisterSourceLoopback.ValueInt64(), 10))
 	}
 	if !data.SsmRange.IsNull() && !data.SsmRange.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range", data.SsmRange.ValueString())
@@ -479,6 +491,9 @@ func (data PIM) toBodyXML(ctx context.Context) string {
 			}
 			if !item.BsrCandidateAcceptRpCandidate.IsNull() && !item.BsrCandidateAcceptRpCandidate.IsUnknown() {
 				cBody = helpers.SetFromXPath(cBody, "bsr-candidate/accept-rp-candidate", item.BsrCandidateAcceptRpCandidate.ValueString())
+			}
+			if !item.RegisterSourceLoopback.IsNull() && !item.RegisterSourceLoopback.IsUnknown() {
+				cBody = helpers.SetFromXPath(cBody, "register-source/Loopback", strconv.FormatInt(item.RegisterSourceLoopback.ValueInt64(), 10))
 			}
 			if !item.SsmRange.IsNull() && !item.SsmRange.IsUnknown() {
 				cBody = helpers.SetFromXPath(cBody, "ssm/range", item.SsmRange.ValueString())
@@ -619,6 +634,11 @@ func (data *PIM) updateFromBody(ctx context.Context, res gjson.Result) {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	} else {
 		data.BsrCandidateAcceptRpCandidate = types.StringNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:register-source.Loopback"); value.Exists() && !data.RegisterSourceLoopback.IsNull() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	} else {
+		data.RegisterSourceLoopback = types.Int64Null()
 	}
 	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:ssm.range"); value.Exists() && !data.SsmRange.IsNull() {
 		data.SsmRange = types.StringValue(value.String())
@@ -826,6 +846,11 @@ func (data *PIM) updateFromBody(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Vrfs[i].BsrCandidateAcceptRpCandidate = types.StringNull()
 		}
+		if value := r.Get("register-source.Loopback"); value.Exists() && !data.Vrfs[i].RegisterSourceLoopback.IsNull() {
+			data.Vrfs[i].RegisterSourceLoopback = types.Int64Value(value.Int())
+		} else {
+			data.Vrfs[i].RegisterSourceLoopback = types.Int64Null()
+		}
 		if value := r.Get("ssm.range"); value.Exists() && !data.Vrfs[i].SsmRange.IsNull() {
 			data.Vrfs[i].SsmRange = types.StringValue(value.String())
 		} else {
@@ -1020,6 +1045,11 @@ func (data *PIM) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	} else {
 		data.BsrCandidateAcceptRpCandidate = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback"); value.Exists() && !data.RegisterSourceLoopback.IsNull() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	} else {
+		data.RegisterSourceLoopback = types.Int64Null()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range"); value.Exists() && !data.SsmRange.IsNull() {
 		data.SsmRange = types.StringValue(value.String())
@@ -1227,6 +1257,11 @@ func (data *PIM) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		} else {
 			data.Vrfs[i].BsrCandidateAcceptRpCandidate = types.StringNull()
 		}
+		if value := helpers.GetFromXPath(r, "register-source/Loopback"); value.Exists() && !data.Vrfs[i].RegisterSourceLoopback.IsNull() {
+			data.Vrfs[i].RegisterSourceLoopback = types.Int64Value(value.Int())
+		} else {
+			data.Vrfs[i].RegisterSourceLoopback = types.Int64Null()
+		}
 		if value := helpers.GetFromXPath(r, "ssm/range"); value.Exists() && !data.Vrfs[i].SsmRange.IsNull() {
 			data.Vrfs[i].SsmRange = types.StringValue(value.String())
 		} else {
@@ -1412,6 +1447,9 @@ func (data *PIM) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:bsr-candidate.accept-rp-candidate"); value.Exists() {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:register-source.Loopback"); value.Exists() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	}
 	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:ssm.range"); value.Exists() {
 		data.SsmRange = types.StringValue(value.String())
 	}
@@ -1510,6 +1548,9 @@ func (data *PIM) fromBody(ctx context.Context, res gjson.Result) {
 			}
 			if cValue := v.Get("bsr-candidate.accept-rp-candidate"); cValue.Exists() {
 				item.BsrCandidateAcceptRpCandidate = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("register-source.Loopback"); cValue.Exists() {
+				item.RegisterSourceLoopback = types.Int64Value(cValue.Int())
 			}
 			if cValue := v.Get("ssm.range"); cValue.Exists() {
 				item.SsmRange = types.StringValue(cValue.String())
@@ -1623,6 +1664,9 @@ func (data *PIMData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:bsr-candidate.accept-rp-candidate"); value.Exists() {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:register-source.Loopback"); value.Exists() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	}
 	if value := res.Get(prefix + "Cisco-IOS-XE-multicast:ssm.range"); value.Exists() {
 		data.SsmRange = types.StringValue(value.String())
 	}
@@ -1721,6 +1765,9 @@ func (data *PIMData) fromBody(ctx context.Context, res gjson.Result) {
 			}
 			if cValue := v.Get("bsr-candidate.accept-rp-candidate"); cValue.Exists() {
 				item.BsrCandidateAcceptRpCandidate = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("register-source.Loopback"); cValue.Exists() {
+				item.RegisterSourceLoopback = types.Int64Value(cValue.Int())
 			}
 			if cValue := v.Get("ssm.range"); cValue.Exists() {
 				item.SsmRange = types.StringValue(cValue.String())
@@ -1830,6 +1877,9 @@ func (data *PIM) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:bsr-candidate/accept-rp-candidate"); value.Exists() {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback"); value.Exists() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range"); value.Exists() {
 		data.SsmRange = types.StringValue(value.String())
 	}
@@ -1928,6 +1978,9 @@ func (data *PIM) fromBodyXML(ctx context.Context, res xmldot.Result) {
 			}
 			if cValue := helpers.GetFromXPath(v, "bsr-candidate/accept-rp-candidate"); cValue.Exists() {
 				item.BsrCandidateAcceptRpCandidate = types.StringValue(cValue.String())
+			}
+			if cValue := helpers.GetFromXPath(v, "register-source/Loopback"); cValue.Exists() {
+				item.RegisterSourceLoopback = types.Int64Value(cValue.Int())
 			}
 			if cValue := helpers.GetFromXPath(v, "ssm/range"); cValue.Exists() {
 				item.SsmRange = types.StringValue(cValue.String())
@@ -2037,6 +2090,9 @@ func (data *PIMData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:bsr-candidate/accept-rp-candidate"); value.Exists() {
 		data.BsrCandidateAcceptRpCandidate = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback"); value.Exists() {
+		data.RegisterSourceLoopback = types.Int64Value(value.Int())
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range"); value.Exists() {
 		data.SsmRange = types.StringValue(value.String())
 	}
@@ -2135,6 +2191,9 @@ func (data *PIMData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 			}
 			if cValue := helpers.GetFromXPath(v, "bsr-candidate/accept-rp-candidate"); cValue.Exists() {
 				item.BsrCandidateAcceptRpCandidate = types.StringValue(cValue.String())
+			}
+			if cValue := helpers.GetFromXPath(v, "register-source/Loopback"); cValue.Exists() {
+				item.RegisterSourceLoopback = types.Int64Value(cValue.Int())
 			}
 			if cValue := helpers.GetFromXPath(v, "ssm/range"); cValue.Exists() {
 				item.SsmRange = types.StringValue(cValue.String())
@@ -2327,6 +2386,9 @@ func (data *PIM) getDeletedItems(ctx context.Context, state PIM) []string {
 				if !state.Vrfs[i].SsmRange.IsNull() && data.Vrfs[j].SsmRange.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:vrf=%v/ssm/range", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 				}
+				if !state.Vrfs[i].RegisterSourceLoopback.IsNull() && data.Vrfs[j].RegisterSourceLoopback.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:vrf=%v/register-source/Loopback", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
 				if !state.Vrfs[i].BsrCandidateAcceptRpCandidate.IsNull() && data.Vrfs[j].BsrCandidateAcceptRpCandidate.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:vrf=%v/bsr-candidate", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 				}
@@ -2437,6 +2499,9 @@ func (data *PIM) getDeletedItems(ctx context.Context, state PIM) []string {
 	}
 	if !state.SsmRange.IsNull() && data.SsmRange.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:ssm/range", state.getPath()))
+	}
+	if !state.RegisterSourceLoopback.IsNull() && data.RegisterSourceLoopback.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:register-source/Loopback", state.getPath()))
 	}
 	if !state.BsrCandidateAcceptRpCandidate.IsNull() && data.BsrCandidateAcceptRpCandidate.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:bsr-candidate", state.getPath()))
@@ -2585,6 +2650,9 @@ func (data *PIM) addDeletedItemsXML(ctx context.Context, state PIM, body string)
 				if !state.Vrfs[i].SsmRange.IsNull() && data.Vrfs[j].SsmRange.IsNull() {
 					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/Cisco-IOS-XE-multicast:vrf%v/ssm/range", predicates))
 				}
+				if !state.Vrfs[i].RegisterSourceLoopback.IsNull() && data.Vrfs[j].RegisterSourceLoopback.IsNull() {
+					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/Cisco-IOS-XE-multicast:vrf%v/register-source/Loopback", predicates))
+				}
 				if !state.Vrfs[i].BsrCandidateAcceptRpCandidate.IsNull() && data.Vrfs[j].BsrCandidateAcceptRpCandidate.IsNull() {
 					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/Cisco-IOS-XE-multicast:vrf%v/bsr-candidate", predicates))
 				}
@@ -2705,6 +2773,9 @@ func (data *PIM) addDeletedItemsXML(ctx context.Context, state PIM, body string)
 	}
 	if !state.SsmRange.IsNull() && data.SsmRange.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range")
+	}
+	if !state.RegisterSourceLoopback.IsNull() && data.RegisterSourceLoopback.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback")
 	}
 	if !state.BsrCandidateAcceptRpCandidate.IsNull() && data.BsrCandidateAcceptRpCandidate.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-multicast:bsr-candidate")
@@ -2840,6 +2911,9 @@ func (data *PIM) getDeletePaths(ctx context.Context) []string {
 	if !data.SsmRange.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:ssm/range", data.getPath()))
 	}
+	if !data.RegisterSourceLoopback.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:register-source/Loopback", data.getPath()))
+	}
 	if !data.BsrCandidateAcceptRpCandidate.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-multicast:bsr-candidate", data.getPath()))
 	}
@@ -2912,6 +2986,9 @@ func (data *PIM) addDeletePathsXML(ctx context.Context, body string) string {
 	}
 	if !data.SsmRange.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-multicast:ssm/range")
+	}
+	if !data.RegisterSourceLoopback.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-multicast:register-source/Loopback")
 	}
 	if !data.BsrCandidateAcceptRpCandidate.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-multicast:bsr-candidate")

--- a/internal/provider/resource_iosxe_pim.go
+++ b/internal/provider/resource_iosxe_pim.go
@@ -120,6 +120,13 @@ func (r *PIMResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				MarkdownDescription: helpers.NewAttributeDescription("BSR RP candidate filter").String,
 				Optional:            true,
 			},
+			"register_source_loopback": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Loopback interface").AddIntegerRangeDescription(0, 2147483647).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 2147483647),
+				},
+			},
 			"ssm_range": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("ACL for group range to be used for SSM").String,
 				Optional:            true,
@@ -245,6 +252,13 @@ func (r *PIMResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 						"bsr_candidate_accept_rp_candidate": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("BSR RP candidate filter").String,
 							Optional:            true,
+						},
+						"register_source_loopback": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Loopback interface").AddIntegerRangeDescription(0, 2147483647).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(0, 2147483647),
+							},
 						},
 						"ssm_range": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("ACL for group range to be used for SSM").String,

--- a/internal/provider/resource_iosxe_pim_test.go
+++ b/internal/provider/resource_iosxe_pim_test.go
@@ -39,6 +39,7 @@ func TestAccIosxePIM(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "bsr_candidate_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "bsr_candidate_mask", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "bsr_candidate_priority", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "register_source_loopback", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "ssm_range", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "ssm_default", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "rp_address", "9.9.9.9"))
@@ -58,6 +59,7 @@ func TestAccIosxePIM(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.bsr_candidate_loopback", "200"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.bsr_candidate_mask", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.bsr_candidate_priority", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.register_source_loopback", "200"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.ssm_range", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.ssm_default", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_pim.test", "vrfs.0.rp_address", "19.19.19.19"))
@@ -164,6 +166,7 @@ func testAccIosxePIMConfig_all() string {
 	config += `	bsr_candidate_loopback = 100` + "\n"
 	config += `	bsr_candidate_mask = 30` + "\n"
 	config += `	bsr_candidate_priority = 10` + "\n"
+	config += `	register_source_loopback = 100` + "\n"
 	config += `	ssm_range = "10"` + "\n"
 	config += `	ssm_default = false` + "\n"
 	config += `	rp_address = "9.9.9.9"` + "\n"
@@ -188,6 +191,7 @@ func testAccIosxePIMConfig_all() string {
 	config += `		bsr_candidate_loopback = 200` + "\n"
 	config += `		bsr_candidate_mask = 30` + "\n"
 	config += `		bsr_candidate_priority = 10` + "\n"
+	config += `		register_source_loopback = 200` + "\n"
 	config += `		ssm_range = "10"` + "\n"
 	config += `		ssm_default = false` + "\n"
 	config += `		rp_address = "19.19.19.19"` + "\n"


### PR DESCRIPTION
### This PR adds support for PIM advanced configuration including VRF register-source and SSM range in the terraform-provider-iosxe.

These improvements enhance the `iosxe_pim` resource with PIM advanced configuration capabilities.

---

### CLI Commands Supported

```code
# Global PIM configuration:
ip pim register-source Loopback<number>
ip pim ssm range <access-list>

# VRF PIM configuration:
ip pim vrf <vrf> register-source Loopback<number>
ip pim vrf <vrf> ssm range <access-list>
```

### Benefits:

- Enables comprehensive PIM multicast configuration management for both global and VRF-specific contexts
- Supports PIM register-source interface configuration to enhance multicast register message handling and optimize RP communication
- Provides Source-Specific Multicast (SSM) range configuration across global and VRF-isolated network topologies
- Enhances multicast routing capabilities with flexible register-source and SSM configurations for advanced PIM deployments

**Platform Compatibility:**
This PR includes standard PIM configuration support available on IOS-XE platforms, ensuring consistent operation across Catalyst 9000 series switches and Catalyst 8000/CSR1000v router platforms.

---

### New Attributes Added (2 total):

**Global PIM configuration:**
- `register_source_loopback` - Loopback interface for PIM register messages (Range: 0-2147483647)

**VRF PIM configuration (within `vrfs` list):**
- `register_source_loopback` - Loopback interface for PIM register messages in VRF context (Range: 0-2147483647)

**Note:** SSM range configuration (`ssm_range` and `ssm_default`) was already supported for both global and VRF contexts and has been verified as part of this enhancement.

---

### Files Modified:
- `gen/definitions/pim.yaml`
- `docs/data-sources/pim.md`
- `docs/resources/pim.md`
- `examples/data-sources/iosxe_pim/data-source.tf`
- `examples/resources/iosxe_pim/resource.tf`
- `internal/provider/data_source_iosxe_pim.go`
- `internal/provider/data_source_iosxe_pim_test.go`
- `internal/provider/model_iosxe_pim.go`
- `internal/provider/resource_iosxe_pim.go`
- `internal/provider/resource_iosxe_pim_test.go`