### PR TITLE
Increase Github Actions build timeout from 5 to 10 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Builds are currently failing due to timeout in the workflow with the time that it is taking to perform the gen process.  Suggesting doubling this configured time in the workflow.

See PR #341 which is auto-cancelled after having run for 5mins when it needs just slightly more time than that to run.