### PR TITLE
feat(IPv6)/Implement IPv6 Multicast Routing Support in Terraform Provider

### DIFF
--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -140,6 +140,7 @@ data "iosxe_system" "example" {
 - `ip_tacacs_source_interface_vrf` (String) VPN Routing/Forwarding parameters
 - `ipv6_cef_load_sharing_algorithm_include_ports_destination` (Boolean)
 - `ipv6_cef_load_sharing_algorithm_include_ports_source` (Boolean)
+- `ipv6_multicast_routing` (Boolean) Enable IPV6 multicast forwarding
 - `ipv6_unicast_routing` (Boolean) Enable unicast routing
 - `login_delay` (Number) Set delay between successive fail login
 - `login_on_failure` (Boolean) Set options for failed login attempt

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -17,6 +17,7 @@ resource "iosxe_system" "example" {
   hostname                    = "ROUTER-1"
   ip_bgp_community_new_format = true
   ipv6_unicast_routing        = true
+  ipv6_multicast_routing      = true
   ip_source_route             = false
   ip_domain_lookup            = true
   ip_domain_name              = "test.com"
@@ -205,6 +206,7 @@ resource "iosxe_system" "example" {
 - `ip_tacacs_source_interface_vrf` (String) VPN Routing/Forwarding parameters
 - `ipv6_cef_load_sharing_algorithm_include_ports_destination` (Boolean)
 - `ipv6_cef_load_sharing_algorithm_include_ports_source` (Boolean)
+- `ipv6_multicast_routing` (Boolean) Enable IPV6 multicast forwarding
 - `ipv6_unicast_routing` (Boolean) Enable unicast routing
 - `login_delay` (Number) Set delay between successive fail login
   - Range: `1`-`10`

--- a/examples/resources/iosxe_system/resource.tf
+++ b/examples/resources/iosxe_system/resource.tf
@@ -2,6 +2,7 @@ resource "iosxe_system" "example" {
   hostname                    = "ROUTER-1"
   ip_bgp_community_new_format = true
   ipv6_unicast_routing        = true
+  ipv6_multicast_routing      = true
   ip_source_route             = false
   ip_domain_lookup            = true
   ip_domain_name              = "test.com"

--- a/gen/definitions/system.yaml
+++ b/gen/definitions/system.yaml
@@ -15,6 +15,9 @@ attributes:
     allow_import_changes: true
   - yang_name: ipv6/unicast-routing
     example: true
+  - yang_name: ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing
+    tf_name: ipv6_multicast_routing
+    example: true
   - yang_name: system/Cisco-IOS-XE-switch:mtu/size
     tf_name: mtu
     exclude_test: true

--- a/internal/provider/data_source_iosxe_system.go
+++ b/internal/provider/data_source_iosxe_system.go
@@ -84,6 +84,10 @@ func (d *SystemDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "Enable unicast routing",
 				Computed:            true,
 			},
+			"ipv6_multicast_routing": schema.BoolAttribute{
+				MarkdownDescription: "Enable IPV6 multicast forwarding",
+				Computed:            true,
+			},
 			"mtu": schema.Int64Attribute{
 				MarkdownDescription: "",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_system_test.go
+++ b/internal/provider/data_source_iosxe_system_test.go
@@ -36,6 +36,7 @@ func TestAccDataSourceIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "hostname", "ROUTER-1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_bgp_community_new_format", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ipv6_unicast_routing", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ipv6_multicast_routing", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_source_route", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_lookup", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_domain_name", "test.com"))
@@ -130,6 +131,7 @@ func testAccDataSourceIosxeSystemConfig() string {
 	config += `	hostname = "ROUTER-1"` + "\n"
 	config += `	ip_bgp_community_new_format = true` + "\n"
 	config += `	ipv6_unicast_routing = true` + "\n"
+	config += `	ipv6_multicast_routing = true` + "\n"
 	config += `	ip_source_route = false` + "\n"
 	config += `	ip_domain_lookup = true` + "\n"
 	config += `	ip_domain_name = "test.com"` + "\n"

--- a/internal/provider/model_iosxe_system.go
+++ b/internal/provider/model_iosxe_system.go
@@ -47,6 +47,7 @@ type System struct {
 	IpBgpCommunityNewFormat                                types.Bool                                          `tfsdk:"ip_bgp_community_new_format"`
 	IpRouting                                              types.Bool                                          `tfsdk:"ip_routing"`
 	Ipv6UnicastRouting                                     types.Bool                                          `tfsdk:"ipv6_unicast_routing"`
+	Ipv6MulticastRouting                                   types.Bool                                          `tfsdk:"ipv6_multicast_routing"`
 	Mtu                                                    types.Int64                                         `tfsdk:"mtu"`
 	IpSourceRoute                                          types.Bool                                          `tfsdk:"ip_source_route"`
 	IpDomainLookup                                         types.Bool                                          `tfsdk:"ip_domain_lookup"`
@@ -197,6 +198,7 @@ type SystemData struct {
 	IpBgpCommunityNewFormat                                types.Bool                                          `tfsdk:"ip_bgp_community_new_format"`
 	IpRouting                                              types.Bool                                          `tfsdk:"ip_routing"`
 	Ipv6UnicastRouting                                     types.Bool                                          `tfsdk:"ipv6_unicast_routing"`
+	Ipv6MulticastRouting                                   types.Bool                                          `tfsdk:"ipv6_multicast_routing"`
 	Mtu                                                    types.Int64                                         `tfsdk:"mtu"`
 	IpSourceRoute                                          types.Bool                                          `tfsdk:"ip_source_route"`
 	IpDomainLookup                                         types.Bool                                          `tfsdk:"ip_domain_lookup"`
@@ -455,6 +457,11 @@ func (data System) toBody(ctx context.Context) string {
 	if !data.Ipv6UnicastRouting.IsNull() && !data.Ipv6UnicastRouting.IsUnknown() {
 		if data.Ipv6UnicastRouting.ValueBool() {
 			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv6.unicast-routing", map[string]string{})
+		}
+	}
+	if !data.Ipv6MulticastRouting.IsNull() && !data.Ipv6MulticastRouting.IsUnknown() {
+		if data.Ipv6MulticastRouting.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ipv6.Cisco-IOS-XE-multicast:mcr-conf.multicast-routing", map[string]string{})
 		}
 	}
 	if !data.Mtu.IsNull() && !data.Mtu.IsUnknown() {
@@ -1108,6 +1115,13 @@ func (data System) toBodyXML(ctx context.Context) string {
 			body = helpers.SetFromXPath(body, data.getXPath()+"/ipv6/unicast-routing", "")
 		} else {
 			body = helpers.RemoveFromXPath(body, data.getXPath()+"/ipv6/unicast-routing")
+		}
+	}
+	if !data.Ipv6MulticastRouting.IsNull() && !data.Ipv6MulticastRouting.IsUnknown() {
+		if data.Ipv6MulticastRouting.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing")
 		}
 	}
 	if !data.Mtu.IsNull() && !data.Mtu.IsUnknown() {
@@ -1862,6 +1876,15 @@ func (data *System) updateFromBody(ctx context.Context, res gjson.Result) {
 		}
 	} else {
 		data.Ipv6UnicastRouting = types.BoolNull()
+	}
+	if value := res.Get(prefix + "ipv6.Cisco-IOS-XE-multicast:mcr-conf.multicast-routing"); !data.Ipv6MulticastRouting.IsNull() {
+		if value.Exists() {
+			data.Ipv6MulticastRouting = types.BoolValue(true)
+		} else {
+			data.Ipv6MulticastRouting = types.BoolValue(false)
+		}
+	} else {
+		data.Ipv6MulticastRouting = types.BoolNull()
 	}
 	if value := res.Get(prefix + "system.Cisco-IOS-XE-switch:mtu.size"); value.Exists() && !data.Mtu.IsNull() {
 		data.Mtu = types.Int64Value(value.Int())
@@ -3157,6 +3180,15 @@ func (data *System) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	} else {
 		data.Ipv6UnicastRouting = types.BoolNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing"); !data.Ipv6MulticastRouting.IsNull() {
+		if value.Exists() {
+			data.Ipv6MulticastRouting = types.BoolValue(true)
+		} else {
+			data.Ipv6MulticastRouting = types.BoolValue(false)
+		}
+	} else {
+		data.Ipv6MulticastRouting = types.BoolNull()
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/system/Cisco-IOS-XE-switch:mtu/size"); value.Exists() && !data.Mtu.IsNull() {
 		data.Mtu = types.Int64Value(value.Int())
 	} else {
@@ -4443,6 +4475,11 @@ func (data *System) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Ipv6UnicastRouting = types.BoolValue(false)
 	}
+	if value := res.Get(prefix + "ipv6.Cisco-IOS-XE-multicast:mcr-conf.multicast-routing"); value.Exists() {
+		data.Ipv6MulticastRouting = types.BoolValue(true)
+	} else {
+		data.Ipv6MulticastRouting = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "system.Cisco-IOS-XE-switch:mtu.size"); value.Exists() {
 		data.Mtu = types.Int64Value(value.Int())
 	}
@@ -5155,6 +5192,11 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Ipv6UnicastRouting = types.BoolValue(false)
 	}
+	if value := res.Get(prefix + "ipv6.Cisco-IOS-XE-multicast:mcr-conf.multicast-routing"); value.Exists() {
+		data.Ipv6MulticastRouting = types.BoolValue(true)
+	} else {
+		data.Ipv6MulticastRouting = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "system.Cisco-IOS-XE-switch:mtu.size"); value.Exists() {
 		data.Mtu = types.Int64Value(value.Int())
 	}
@@ -5863,6 +5905,11 @@ func (data *System) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	} else {
 		data.Ipv6UnicastRouting = types.BoolValue(false)
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing"); value.Exists() {
+		data.Ipv6MulticastRouting = types.BoolValue(true)
+	} else {
+		data.Ipv6MulticastRouting = types.BoolValue(false)
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/system/Cisco-IOS-XE-switch:mtu/size"); value.Exists() {
 		data.Mtu = types.Int64Value(value.Int())
 	}
@@ -6570,6 +6617,11 @@ func (data *SystemData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.Ipv6UnicastRouting = types.BoolValue(true)
 	} else {
 		data.Ipv6UnicastRouting = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing"); value.Exists() {
+		data.Ipv6MulticastRouting = types.BoolValue(true)
+	} else {
+		data.Ipv6MulticastRouting = types.BoolValue(false)
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/system/Cisco-IOS-XE-switch:mtu/size"); value.Exists() {
 		data.Mtu = types.Int64Value(value.Int())
@@ -8127,6 +8179,9 @@ func (data *System) getDeletedItems(ctx context.Context, state System) []string 
 	if !state.Mtu.IsNull() && data.Mtu.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/system/Cisco-IOS-XE-switch:mtu/size", state.getPath()))
 	}
+	if !state.Ipv6MulticastRouting.IsNull() && data.Ipv6MulticastRouting.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing", state.getPath()))
+	}
 	if !state.Ipv6UnicastRouting.IsNull() && data.Ipv6UnicastRouting.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ipv6/unicast-routing", state.getPath()))
 	}
@@ -9099,6 +9154,9 @@ func (data *System) addDeletedItemsXML(ctx context.Context, state System, body s
 	if !state.Mtu.IsNull() && data.Mtu.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/system/Cisco-IOS-XE-switch:mtu/size")
 	}
+	if !state.Ipv6MulticastRouting.IsNull() && data.Ipv6MulticastRouting.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing")
+	}
 	if !state.Ipv6UnicastRouting.IsNull() && data.Ipv6UnicastRouting.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ipv6/unicast-routing")
 	}
@@ -9224,6 +9282,9 @@ func (data *System) getEmptyLeafsDelete(ctx context.Context) []string {
 	}
 	if !data.LoginOnFailure.IsNull() && !data.LoginOnFailure.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/login/on-failure", data.getPath()))
+	}
+	if !data.Ipv6MulticastRouting.IsNull() && !data.Ipv6MulticastRouting.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing", data.getPath()))
 	}
 	if !data.Ipv6UnicastRouting.IsNull() && !data.Ipv6UnicastRouting.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/ipv6/unicast-routing", data.getPath()))
@@ -9685,6 +9746,9 @@ func (data *System) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.Mtu.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/system/Cisco-IOS-XE-switch:mtu/size", data.getPath()))
+	}
+	if !data.Ipv6MulticastRouting.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing", data.getPath()))
 	}
 	if !data.Ipv6UnicastRouting.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ipv6/unicast-routing", data.getPath()))
@@ -10215,6 +10279,9 @@ func (data *System) addDeletePathsXML(ctx context.Context, body string) string {
 	}
 	if !data.Mtu.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/system/Cisco-IOS-XE-switch:mtu/size")
+	}
+	if !data.Ipv6MulticastRouting.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing")
 	}
 	if !data.Ipv6UnicastRouting.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ipv6/unicast-routing")

--- a/internal/provider/resource_iosxe_system.go
+++ b/internal/provider/resource_iosxe_system.go
@@ -100,6 +100,10 @@ func (r *SystemResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: helpers.NewAttributeDescription("Enable unicast routing").String,
 				Optional:            true,
 			},
+			"ipv6_multicast_routing": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable IPV6 multicast forwarding").String,
+				Optional:            true,
+			},
 			"mtu": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(1500, 9198).String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_system_test.go
+++ b/internal/provider/resource_iosxe_system_test.go
@@ -38,6 +38,7 @@ func TestAccIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "hostname", "ROUTER-1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_bgp_community_new_format", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ipv6_unicast_routing", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ipv6_multicast_routing", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_source_route", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_lookup", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_domain_name", "test.com"))
@@ -165,6 +166,7 @@ func testAccIosxeSystemConfig_all() string {
 	config += `	hostname = "ROUTER-1"` + "\n"
 	config += `	ip_bgp_community_new_format = true` + "\n"
 	config += `	ipv6_unicast_routing = true` + "\n"
+	config += `	ipv6_multicast_routing = true` + "\n"
 	config += `	ip_source_route = false` + "\n"
 	config += `	ip_domain_lookup = true` + "\n"
 	config += `	ip_domain_name = "test.com"` + "\n"


### PR DESCRIPTION
## This PR adds support for IPv6 multicast routing enablement.

*Note: Support for IPv6 multicast routing configuration was introduced recently in PR #374  when support for VRF-aware IPv6 multicast routing was established.*

### CLI Commands Supported:
- `ipv6 multicast-routing`

### Changes:
- Add ipv6_multicast_routing attribute to system resource schema
- Update YANG mapping: ipv6/Cisco-IOS-XE-multicast:mcr-conf/multicast-routing
- Generate provider code for new attribute (resource, data source, model, tests)
- Update documentation and examples

### YANG Type:
- empty (presence-based)

### YANG mapping is supported in IOS XE Versions:
- 17.15.1
- 17.12.1

### Testing:
- All acceptance tests pass successfully.

### Related:
- Issue #431 (Internal)