### PR TITLE
[TRM] Implement VRF EVPN-Mcast Support in Terraform Provider

### DIFF
--- a/docs/data-sources/vrf.md
+++ b/docs/data-sources/vrf.md
@@ -53,6 +53,10 @@ data "iosxe_vrf" "example" {
 - `ipv4_route_target_export_stitching` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_export_stitching))
 - `ipv4_route_target_import` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_import))
 - `ipv4_route_target_import_stitching` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_import_stitching))
+- `ipv6_evpn_mcast_anycast` (String) IPv6 address of Rendezvous-point for anycast mode
+- `ipv6_evpn_mcast_data_address` (String) EVPN multicast data MDT group address (IPv6)
+- `ipv6_evpn_mcast_data_mask_bits` (String) EVPN multicast data MDT mask bits (IPv6)
+- `ipv6_evpn_mcast_mdt_default_address` (String) EVPN multicast MDT default group address (IPv6)
 - `ipv6_route_target_export` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_export))
 - `ipv6_route_target_export_stitching` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_export_stitching))
 - `ipv6_route_target_import` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_import))

--- a/docs/resources/vrf.md
+++ b/docs/resources/vrf.md
@@ -116,6 +116,10 @@ resource "iosxe_vrf" "example" {
 - `ipv4_route_target_export_stitching` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_export_stitching))
 - `ipv4_route_target_import` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_import))
 - `ipv4_route_target_import_stitching` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv4_route_target_import_stitching))
+- `ipv6_evpn_mcast_anycast` (String) IPv6 address of Rendezvous-point for anycast mode
+- `ipv6_evpn_mcast_data_address` (String) EVPN multicast data MDT group address (IPv6)
+- `ipv6_evpn_mcast_data_mask_bits` (String) EVPN multicast data MDT mask bits (IPv6)
+- `ipv6_evpn_mcast_mdt_default_address` (String) EVPN multicast MDT default group address (IPv6)
 - `ipv6_route_target_export` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_export))
 - `ipv6_route_target_export_stitching` (Attributes Set) Export Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_export_stitching))
 - `ipv6_route_target_import` (Attributes Set) Import Target-VPN community (see [below for nested schema](#nestedatt--ipv6_route_target_import))

--- a/gen/definitions/vrf.yaml
+++ b/gen/definitions/vrf.yaml
@@ -219,6 +219,26 @@ attributes:
     description: EVPN multicast data MDT mask bits
     exclude_test: true
     example: 0.0.0.255
+  - yang_name: address-family/ipv6/evpn-mcast/mdt-def-addr
+    tf_name: ipv6_evpn_mcast_mdt_default_address
+    description: EVPN multicast MDT default group address (IPv6)
+    exclude_test: true
+    example: ff3e::1
+  - yang_name: address-family/ipv6/evpn-mcast/anycast
+    tf_name: ipv6_evpn_mcast_anycast
+    description: IPv6 address of Rendezvous-point for anycast mode
+    exclude_test: true
+    example: 2001:db8::1
+  - yang_name: address-family/ipv6/evpn-mcast/data/data-addr
+    tf_name: ipv6_evpn_mcast_data_address
+    description: EVPN multicast data MDT group address (IPv6)
+    exclude_test: true
+    example: ff3e::2
+  - yang_name: address-family/ipv6/evpn-mcast/data/mask-bits
+    tf_name: ipv6_evpn_mcast_data_mask_bits
+    description: EVPN multicast data MDT mask bits (IPv6)
+    exclude_test: true
+    example: ::ff
 test_prerequisites:
   - path: Cisco-IOS-XE-native:native/vrf/definition[name=VRF1]
     no_delete: true

--- a/internal/provider/data_source_iosxe_vrf.go
+++ b/internal/provider/data_source_iosxe_vrf.go
@@ -328,6 +328,22 @@ func (d *VRFDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "EVPN multicast data MDT mask bits",
 				Computed:            true,
 			},
+			"ipv6_evpn_mcast_mdt_default_address": schema.StringAttribute{
+				MarkdownDescription: "EVPN multicast MDT default group address (IPv6)",
+				Computed:            true,
+			},
+			"ipv6_evpn_mcast_anycast": schema.StringAttribute{
+				MarkdownDescription: "IPv6 address of Rendezvous-point for anycast mode",
+				Computed:            true,
+			},
+			"ipv6_evpn_mcast_data_address": schema.StringAttribute{
+				MarkdownDescription: "EVPN multicast data MDT group address (IPv6)",
+				Computed:            true,
+			},
+			"ipv6_evpn_mcast_data_mask_bits": schema.StringAttribute{
+				MarkdownDescription: "EVPN multicast data MDT mask bits (IPv6)",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/model_iosxe_vrf.go
+++ b/internal/provider/model_iosxe_vrf.go
@@ -76,6 +76,10 @@ type VRF struct {
 	Ipv4EvpnMcastAnycast                            types.String                        `tfsdk:"ipv4_evpn_mcast_anycast"`
 	Ipv4EvpnMcastDataAddress                        types.String                        `tfsdk:"ipv4_evpn_mcast_data_address"`
 	Ipv4EvpnMcastDataMaskBits                       types.String                        `tfsdk:"ipv4_evpn_mcast_data_mask_bits"`
+	Ipv6EvpnMcastMdtDefaultAddress                  types.String                        `tfsdk:"ipv6_evpn_mcast_mdt_default_address"`
+	Ipv6EvpnMcastAnycast                            types.String                        `tfsdk:"ipv6_evpn_mcast_anycast"`
+	Ipv6EvpnMcastDataAddress                        types.String                        `tfsdk:"ipv6_evpn_mcast_data_address"`
+	Ipv6EvpnMcastDataMaskBits                       types.String                        `tfsdk:"ipv6_evpn_mcast_data_mask_bits"`
 }
 
 type VRFData struct {
@@ -112,6 +116,10 @@ type VRFData struct {
 	Ipv4EvpnMcastAnycast                            types.String                        `tfsdk:"ipv4_evpn_mcast_anycast"`
 	Ipv4EvpnMcastDataAddress                        types.String                        `tfsdk:"ipv4_evpn_mcast_data_address"`
 	Ipv4EvpnMcastDataMaskBits                       types.String                        `tfsdk:"ipv4_evpn_mcast_data_mask_bits"`
+	Ipv6EvpnMcastMdtDefaultAddress                  types.String                        `tfsdk:"ipv6_evpn_mcast_mdt_default_address"`
+	Ipv6EvpnMcastAnycast                            types.String                        `tfsdk:"ipv6_evpn_mcast_anycast"`
+	Ipv6EvpnMcastDataAddress                        types.String                        `tfsdk:"ipv6_evpn_mcast_data_address"`
+	Ipv6EvpnMcastDataMaskBits                       types.String                        `tfsdk:"ipv6_evpn_mcast_data_mask_bits"`
 }
 type VRFRouteTargetImport struct {
 	Value     types.String `tfsdk:"value"`
@@ -276,6 +284,18 @@ func (data VRF) toBody(ctx context.Context) string {
 	}
 	if !data.Ipv4EvpnMcastDataMaskBits.IsNull() && !data.Ipv4EvpnMcastDataMaskBits.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"address-family.ipv4.evpn-mcast.data.mask-bits", data.Ipv4EvpnMcastDataMaskBits.ValueString())
+	}
+	if !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() && !data.Ipv6EvpnMcastMdtDefaultAddress.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"address-family.ipv6.evpn-mcast.mdt-def-addr", data.Ipv6EvpnMcastMdtDefaultAddress.ValueString())
+	}
+	if !data.Ipv6EvpnMcastAnycast.IsNull() && !data.Ipv6EvpnMcastAnycast.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"address-family.ipv6.evpn-mcast.anycast", data.Ipv6EvpnMcastAnycast.ValueString())
+	}
+	if !data.Ipv6EvpnMcastDataAddress.IsNull() && !data.Ipv6EvpnMcastDataAddress.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"address-family.ipv6.evpn-mcast.data.data-addr", data.Ipv6EvpnMcastDataAddress.ValueString())
+	}
+	if !data.Ipv6EvpnMcastDataMaskBits.IsNull() && !data.Ipv6EvpnMcastDataMaskBits.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"address-family.ipv6.evpn-mcast.data.mask-bits", data.Ipv6EvpnMcastDataMaskBits.ValueString())
 	}
 	if len(data.RouteTargetImport) > 0 {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"route-target.import", []interface{}{})
@@ -684,6 +704,18 @@ func (data VRF) toBodyXML(ctx context.Context) string {
 	}
 	if !data.Ipv4EvpnMcastDataMaskBits.IsNull() && !data.Ipv4EvpnMcastDataMaskBits.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/address-family/ipv4/evpn-mcast/data/mask-bits", data.Ipv4EvpnMcastDataMaskBits.ValueString())
+	}
+	if !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() && !data.Ipv6EvpnMcastMdtDefaultAddress.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr", data.Ipv6EvpnMcastMdtDefaultAddress.ValueString())
+	}
+	if !data.Ipv6EvpnMcastAnycast.IsNull() && !data.Ipv6EvpnMcastAnycast.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/address-family/ipv6/evpn-mcast/anycast", data.Ipv6EvpnMcastAnycast.ValueString())
+	}
+	if !data.Ipv6EvpnMcastDataAddress.IsNull() && !data.Ipv6EvpnMcastDataAddress.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr", data.Ipv6EvpnMcastDataAddress.ValueString())
+	}
+	if !data.Ipv6EvpnMcastDataMaskBits.IsNull() && !data.Ipv6EvpnMcastDataMaskBits.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits", data.Ipv6EvpnMcastDataMaskBits.ValueString())
 	}
 	bodyString, err := body.String()
 	if err != nil {
@@ -1258,6 +1290,26 @@ func (data *VRF) updateFromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringNull()
 	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.mdt-def-addr"); value.Exists() && !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringNull()
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.anycast"); value.Exists() && !data.Ipv6EvpnMcastAnycast.IsNull() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastAnycast = types.StringNull()
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.data-addr"); value.Exists() && !data.Ipv6EvpnMcastDataAddress.IsNull() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastDataAddress = types.StringNull()
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.mask-bits"); value.Exists() && !data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringNull()
+	}
 }
 
 // End of section. //template:end updateFromBody
@@ -1822,6 +1874,26 @@ func (data *VRF) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	} else {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr"); value.Exists() && !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/anycast"); value.Exists() && !data.Ipv6EvpnMcastAnycast.IsNull() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastAnycast = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr"); value.Exists() && !data.Ipv6EvpnMcastDataAddress.IsNull() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastDataAddress = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits"); value.Exists() && !data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
+	} else {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringNull()
+	}
 }
 
 // End of section. //template:end updateFromBodyXML
@@ -2080,6 +2152,18 @@ func (data *VRF) fromBody(ctx context.Context, res gjson.Result) {
 	}
 	if value := res.Get(prefix + "address-family.ipv4.evpn-mcast.data.mask-bits"); value.Exists() {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.mdt-def-addr"); value.Exists() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.anycast"); value.Exists() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.data-addr"); value.Exists() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.mask-bits"); value.Exists() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
 	}
 }
 
@@ -2340,6 +2424,18 @@ func (data *VRFData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "address-family.ipv4.evpn-mcast.data.mask-bits"); value.Exists() {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.mdt-def-addr"); value.Exists() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.anycast"); value.Exists() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.data-addr"); value.Exists() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	}
+	if value := res.Get(prefix + "address-family.ipv6.evpn-mcast.data.mask-bits"); value.Exists() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyData
@@ -2594,6 +2690,18 @@ func (data *VRF) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv4/evpn-mcast/data/mask-bits"); value.Exists() {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr"); value.Exists() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/anycast"); value.Exists() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr"); value.Exists() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits"); value.Exists() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
 	}
 }
 
@@ -2850,6 +2958,18 @@ func (data *VRFData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv4/evpn-mcast/data/mask-bits"); value.Exists() {
 		data.Ipv4EvpnMcastDataMaskBits = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr"); value.Exists() {
+		data.Ipv6EvpnMcastMdtDefaultAddress = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/anycast"); value.Exists() {
+		data.Ipv6EvpnMcastAnycast = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr"); value.Exists() {
+		data.Ipv6EvpnMcastDataAddress = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits"); value.Exists() {
+		data.Ipv6EvpnMcastDataMaskBits = types.StringValue(value.String())
+	}
 }
 
 // End of section. //template:end fromBodyDataXML
@@ -2858,6 +2978,18 @@ func (data *VRFData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *VRF) getDeletedItems(ctx context.Context, state VRF) []string {
 	deletedItems := make([]string, 0)
+	if !state.Ipv6EvpnMcastDataMaskBits.IsNull() && data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/data/mask-bits", state.getPath()))
+	}
+	if !state.Ipv6EvpnMcastDataAddress.IsNull() && data.Ipv6EvpnMcastDataAddress.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/data/data-addr", state.getPath()))
+	}
+	if !state.Ipv6EvpnMcastAnycast.IsNull() && data.Ipv6EvpnMcastAnycast.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/anycast", state.getPath()))
+	}
+	if !state.Ipv6EvpnMcastMdtDefaultAddress.IsNull() && data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/mdt-def-addr", state.getPath()))
+	}
 	if !state.Ipv4EvpnMcastDataMaskBits.IsNull() && data.Ipv4EvpnMcastDataMaskBits.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/address-family/ipv4/evpn-mcast/data/mask-bits", state.getPath()))
 	}
@@ -3255,6 +3387,18 @@ func (data *VRF) getDeletedItems(ctx context.Context, state VRF) []string {
 
 func (data *VRF) addDeletedItemsXML(ctx context.Context, state VRF, body string) string {
 	b := netconf.NewBody(body)
+	if !state.Ipv6EvpnMcastDataMaskBits.IsNull() && data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits")
+	}
+	if !state.Ipv6EvpnMcastDataAddress.IsNull() && data.Ipv6EvpnMcastDataAddress.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr")
+	}
+	if !state.Ipv6EvpnMcastAnycast.IsNull() && data.Ipv6EvpnMcastAnycast.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/address-family/ipv6/evpn-mcast/anycast")
+	}
+	if !state.Ipv6EvpnMcastMdtDefaultAddress.IsNull() && data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr")
+	}
 	if !state.Ipv4EvpnMcastDataMaskBits.IsNull() && data.Ipv4EvpnMcastDataMaskBits.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/address-family/ipv4/evpn-mcast/data/mask-bits")
 	}
@@ -3800,6 +3944,18 @@ func (data *VRF) getEmptyLeafsDelete(ctx context.Context) []string {
 
 func (data *VRF) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
+	if !data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/data/mask-bits", data.getPath()))
+	}
+	if !data.Ipv6EvpnMcastDataAddress.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/data/data-addr", data.getPath()))
+	}
+	if !data.Ipv6EvpnMcastAnycast.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/anycast", data.getPath()))
+	}
+	if !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/address-family/ipv6/evpn-mcast/mdt-def-addr", data.getPath()))
+	}
 	if !data.Ipv4EvpnMcastDataMaskBits.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/address-family/ipv4/evpn-mcast/data/mask-bits", data.getPath()))
 	}
@@ -3924,6 +4080,18 @@ func (data *VRF) getDeletePaths(ctx context.Context) []string {
 
 func (data *VRF) addDeletePathsXML(ctx context.Context, body string) string {
 	b := netconf.NewBody(body)
+	if !data.Ipv6EvpnMcastDataMaskBits.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/address-family/ipv6/evpn-mcast/data/mask-bits")
+	}
+	if !data.Ipv6EvpnMcastDataAddress.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/address-family/ipv6/evpn-mcast/data/data-addr")
+	}
+	if !data.Ipv6EvpnMcastAnycast.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/address-family/ipv6/evpn-mcast/anycast")
+	}
+	if !data.Ipv6EvpnMcastMdtDefaultAddress.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/address-family/ipv6/evpn-mcast/mdt-def-addr")
+	}
 	if !data.Ipv4EvpnMcastDataMaskBits.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/address-family/ipv4/evpn-mcast/data/mask-bits")
 	}

--- a/internal/provider/resource_iosxe_vrf.go
+++ b/internal/provider/resource_iosxe_vrf.go
@@ -419,6 +419,26 @@ func (r *VRFResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				MarkdownDescription: helpers.NewAttributeDescription("EVPN multicast data MDT mask bits").String,
 				Optional:            true,
 			},
+			"ipv6_evpn_mcast_mdt_default_address": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("EVPN multicast MDT default group address (IPv6)").String,
+				Optional:            true,
+			},
+			"ipv6_evpn_mcast_anycast": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("IPv6 address of Rendezvous-point for anycast mode").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?`), ""),
+					stringvalidator.RegexMatches(regexp.MustCompile(`(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?`), ""),
+				},
+			},
+			"ipv6_evpn_mcast_data_address": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("EVPN multicast data MDT group address (IPv6)").String,
+				Optional:            true,
+			},
+			"ipv6_evpn_mcast_data_mask_bits": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("EVPN multicast data MDT mask bits (IPv6)").String,
+				Optional:            true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
# This PR adds support for TRM VRF EVPN-Mcast configuration in the Terraform Provider.

## Overview

This PR adds support for Tenant Routed Multicast (TRM) VRF EVPN-Multicast configuration in the `iosxe_vrf` resource in the Terraform Provider.


This extends the `iosxe_vrf` resource with 8 new EVPN-Multicast-related attributes:
### New Attributes

| Attribute | Description | Type |
|-----------|-------------|------|
| `ipv4_evpn_mcast_mdt_default_address` | EVPN multicast MDT default group address | String |
| `ipv4_evpn_mcast_anycast` | IPv4 address of Rendezvous-point for anycast mode | String |
| `ipv4_evpn_mcast_data_address` | EVPN multicast data MDT group address | String |
| `ipv4_evpn_mcast_data_mask_bits` | EVPN multicast data MDT mask bits | String |
| `ipv6_evpn_mcast_mdt_default_address` | EVPN multicast MDT default group address | String |
| `ipv6_evpn_mcast_anycast` | IPv6 address of Rendezvous-point for anycast mode | String |
| `ipv6_evpn_mcast_data_address` | EVPN multicast data MDT group address | String |
| `ipv6_evpn_mcast_data_mask_bits` | EVPN multicast data MDT mask bits | String |

### YANG Paths

- `address-family/ipv4/evpn-mcast/mdt-def-addr`
- `address-family/ipv4/evpn-mcast/anycast`
- `address-family/ipv4/evpn-mcast/data/data-addr`
- `address-family/ipv4/evpn-mcast/data/mask-bits`
- `address-family/ipv6/evpn-mcast/mdt-def-addr`
- `address-family/ipv6/evpn-mcast/anycast`
- `address-family/ipv6/evpn-mcast/data/data-addr`
- `address-family/ipv6/evpn-mcast/data/mask-bits`

### IOS-XE Version Support

- **Minimum Version:** 17.15.1 (*EVPN-mcast support **not** available in 17.12.x*)

### Changes

- `gen/definitions/vrf.yaml`
- `internal/provider/model_iosxe_vrf.go`
- `internal/provider/resource_iosxe_vrf.go`
- `internal/provider/resource_iosxe_vrf_test.go`
- `docs/resources/vrf.md`

## Note on Acceptance Test Exclusion

The new EVPN-mcast attributes are tagged with `exclude_test: true` in the resource definition. This is intentional and necessary because:

1. **Mutual Exclusivity:** The `evpn-mcast` configuration is mutually exclusive with traditional `mdt` (Multicast Distribution Tree) configuration under the same VRF address-family. The existing acceptance tests already validate the traditional MDT attributes, and attempting to configure both simultaneously results in a device error: `"inconsistent value: Device refused one or more commands"`.

2. **Fabric Prerequisites:** EVPN-mcast requires a fully configured EVPN/VXLAN fabric environment including VNID configuration, EVPN instance, NVE interface, BGP EVPN peering, and multicast underlay.

The YANG path mappings have been validated against the IOS-XE 17.15.1 YANG models.

## Current Caveats to Function and Support

**IMPORTANT**:
Provider support for the `vnid <vnid_number> evpn-instance vni <nve_l3vni_number> core-vlan <vlan_number>` CLI command (vrf) does **not yet exist**. Support for this command is a *prerequisite* to the new attributes introduced in this PR.
- Because of this, the attributes provided in this PR are *not yet fully functional and available*, even for users operating in properly configured EVPN/VXLAN fabric environments.

---

## Related Issues

Closes: Issue 394 (Internal)

