### PR TITLE
[ENHANCEMENT] Stopbits option missing for line aux

### DIFF
--- a/docs/data-sources/line.md
+++ b/docs/data-sources/line.md
@@ -42,6 +42,7 @@ Read-Only:
 - `first` (String) Auxiliary line number
 - `logging_synchronous` (Boolean) Synchronized message output
 - `monitor` (Boolean) Copy debug output to the current terminal line
+- `stopbits` (String) Set async line stop bits
 - `transport_output_none` (Boolean) Define no transport protocols for line
 
 

--- a/docs/resources/line.md
+++ b/docs/resources/line.md
@@ -85,6 +85,8 @@ Optional:
   - Range: `0`-`2147483`
 - `logging_synchronous` (Boolean) Synchronized message output
 - `monitor` (Boolean) Copy debug output to the current terminal line
+- `stopbits` (String) Set async line stop bits
+  - Choices: `1`, `1.5`, `2`
 - `transport_output_none` (Boolean) Define no transport protocols for line
 
 

--- a/gen/definitions/line.yaml
+++ b/gen/definitions/line.yaml
@@ -175,6 +175,8 @@ attributes:
         example: 25
       - yang_name: monitor
         example: true
+      - yang_name: stopbits
+        example: 1
       - yang_name: transport/output/output-protocol/no-protocol/none
         xpath: transport/output/none
         example: true

--- a/internal/provider/data_source_iosxe_line.go
+++ b/internal/provider/data_source_iosxe_line.go
@@ -286,6 +286,10 @@ func (d *LineDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 							MarkdownDescription: "Copy debug output to the current terminal line",
 							Computed:            true,
 						},
+						"stopbits": schema.StringAttribute{
+							MarkdownDescription: "Set async line stop bits",
+							Computed:            true,
+						},
 						"transport_output_none": schema.BoolAttribute{
 							MarkdownDescription: "Define no transport protocols for line",
 							Computed:            true,

--- a/internal/provider/model_iosxe_line.go
+++ b/internal/provider/model_iosxe_line.go
@@ -105,6 +105,7 @@ type LineAux struct {
 	ExecTimeoutMinutes  types.Int64  `tfsdk:"exec_timeout_minutes"`
 	ExecTimeoutSeconds  types.Int64  `tfsdk:"exec_timeout_seconds"`
 	Monitor             types.Bool   `tfsdk:"monitor"`
+	Stopbits            types.String `tfsdk:"stopbits"`
 	TransportOutputNone types.Bool   `tfsdk:"transport_output_none"`
 }
 type LineVtyAccessClasses struct {
@@ -342,6 +343,9 @@ func (data Line) toBody(ctx context.Context) string {
 				if item.Monitor.ValueBool() {
 					body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"aux"+"."+strconv.Itoa(index)+"."+"monitor", map[string]string{})
 				}
+			}
+			if !item.Stopbits.IsNull() && !item.Stopbits.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"aux"+"."+strconv.Itoa(index)+"."+"stopbits", item.Stopbits.ValueString())
 			}
 			if !item.TransportOutputNone.IsNull() && !item.TransportOutputNone.IsUnknown() {
 				if item.TransportOutputNone.ValueBool() {
@@ -585,6 +589,9 @@ func (data Line) toBodyXML(ctx context.Context) string {
 				} else {
 					cBody = helpers.RemoveFromXPath(cBody, "monitor")
 				}
+			}
+			if !item.Stopbits.IsNull() && !item.Stopbits.IsUnknown() {
+				cBody = helpers.SetFromXPath(cBody, "stopbits", item.Stopbits.ValueString())
 			}
 			if !item.TransportOutputNone.IsNull() && !item.TransportOutputNone.IsUnknown() {
 				if item.TransportOutputNone.ValueBool() {
@@ -973,6 +980,11 @@ func (data *Line) updateFromBody(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Aux[i].Monitor = types.BoolNull()
 		}
+		if value := r.Get("stopbits"); value.Exists() && !data.Aux[i].Stopbits.IsNull() {
+			data.Aux[i].Stopbits = types.StringValue(value.String())
+		} else {
+			data.Aux[i].Stopbits = types.StringNull()
+		}
 		if value := r.Get("transport.output.none"); !data.Aux[i].TransportOutputNone.IsNull() {
 			if value.Exists() {
 				data.Aux[i].TransportOutputNone = types.BoolValue(true)
@@ -1351,6 +1363,11 @@ func (data *Line) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		} else {
 			data.Aux[i].Monitor = types.BoolNull()
 		}
+		if value := helpers.GetFromXPath(r, "stopbits"); value.Exists() && !data.Aux[i].Stopbits.IsNull() {
+			data.Aux[i].Stopbits = types.StringValue(value.String())
+		} else {
+			data.Aux[i].Stopbits = types.StringNull()
+		}
 		if value := helpers.GetFromXPath(r, "transport/output/none"); !data.Aux[i].TransportOutputNone.IsNull() {
 			if value.Exists() {
 				data.Aux[i].TransportOutputNone = types.BoolValue(true)
@@ -1572,6 +1589,9 @@ func (data *Line) fromBody(ctx context.Context, res gjson.Result) {
 			} else {
 				item.Monitor = types.BoolValue(false)
 			}
+			if cValue := v.Get("stopbits"); cValue.Exists() {
+				item.Stopbits = types.StringValue(cValue.String())
+			}
 			if cValue := v.Get("transport.output.none"); cValue.Exists() {
 				item.TransportOutputNone = types.BoolValue(true)
 			} else {
@@ -1792,6 +1812,9 @@ func (data *LineData) fromBody(ctx context.Context, res gjson.Result) {
 			} else {
 				item.Monitor = types.BoolValue(false)
 			}
+			if cValue := v.Get("stopbits"); cValue.Exists() {
+				item.Stopbits = types.StringValue(cValue.String())
+			}
 			if cValue := v.Get("transport.output.none"); cValue.Exists() {
 				item.TransportOutputNone = types.BoolValue(true)
 			} else {
@@ -2007,6 +2030,9 @@ func (data *Line) fromBodyXML(ctx context.Context, res xmldot.Result) {
 				item.Monitor = types.BoolValue(true)
 			} else {
 				item.Monitor = types.BoolValue(false)
+			}
+			if cValue := helpers.GetFromXPath(v, "stopbits"); cValue.Exists() {
+				item.Stopbits = types.StringValue(cValue.String())
 			}
 			if cValue := helpers.GetFromXPath(v, "transport/output/none"); cValue.Exists() {
 				item.TransportOutputNone = types.BoolValue(true)
@@ -2224,6 +2250,9 @@ func (data *LineData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 			} else {
 				item.Monitor = types.BoolValue(false)
 			}
+			if cValue := helpers.GetFromXPath(v, "stopbits"); cValue.Exists() {
+				item.Stopbits = types.StringValue(cValue.String())
+			}
 			if cValue := helpers.GetFromXPath(v, "transport/output/none"); cValue.Exists() {
 				item.TransportOutputNone = types.BoolValue(true)
 			} else {
@@ -2261,6 +2290,9 @@ func (data *Line) getDeletedItems(ctx context.Context, state Line) []string {
 			if found {
 				if !state.Aux[i].TransportOutputNone.IsNull() && data.Aux[j].TransportOutputNone.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/aux=%v/transport/output/none", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+				}
+				if !state.Aux[i].Stopbits.IsNull() && data.Aux[j].Stopbits.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/aux=%v/stopbits", state.getPath(), strings.Join(stateKeyValues[:], ",")))
 				}
 				if !state.Aux[i].Monitor.IsNull() && data.Aux[j].Monitor.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/aux=%v/monitor", state.getPath(), strings.Join(stateKeyValues[:], ",")))
@@ -2559,6 +2591,9 @@ func (data *Line) addDeletedItemsXML(ctx context.Context, state Line, body strin
 			if found {
 				if !state.Aux[i].TransportOutputNone.IsNull() && data.Aux[j].TransportOutputNone.IsNull() {
 					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/aux%v/transport/output/none", predicates))
+				}
+				if !state.Aux[i].Stopbits.IsNull() && data.Aux[j].Stopbits.IsNull() {
+					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/aux%v/stopbits", predicates))
 				}
 				if !state.Aux[i].Monitor.IsNull() && data.Aux[j].Monitor.IsNull() {
 					b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/aux%v/monitor", predicates))

--- a/internal/provider/resource_iosxe_line.go
+++ b/internal/provider/resource_iosxe_line.go
@@ -371,6 +371,13 @@ func (r *LineResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							MarkdownDescription: helpers.NewAttributeDescription("Copy debug output to the current terminal line").String,
 							Optional:            true,
 						},
+						"stopbits": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Set async line stop bits").AddStringEnumDescription("1", "1.5", "2").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("1", "1.5", "2"),
+							},
+						},
 						"transport_output_none": schema.BoolAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Define no transport protocols for line").String,
 							Optional:            true,


### PR DESCRIPTION
# Add stopbits attribute to line aux

Fixes #305

## Description

This PR adds the missing `stopbits` attribute to line aux configuration, matching the existing implementation for console lines.

## Changes

- Added `stopbits` attribute to aux line definition in `gen/definitions/line.yaml`
- Generated Go provider code, documentation, and data sources
- Follows same pattern as console stopbits implementation

## Testing

### Device Testing
- **Device**: Catalyst 8000V (IOS-XE 17.15.01a)
- **Status**: All tests passed

**Tests Performed**:
- ✅ Terraform plan: stopbits attribute present
- ✅ Terraform apply: Configuration applied successfully  
- ✅ Device verification: stopbits visible on device
- ✅ Idempotency: No changes detected on re-apply
- ✅ Change detection: Value updates working correctly

**CLI Verification**:
```
line aux 0
 stopbits 2
```

### Platform Notes
- Line aux supported on routers only (not switches)
- Tested on Catalyst 8000V router
- Feature works as expected

## Version Compatibility

- **IOS-XE 17.15.1**: Supported ✅
- **IOS-XE 17.12.1**: Supported ✅ 

No version-specific tags required.

## Implementation Details

**YANG Path**: `stopbits` (under aux list)  
**Type**: String  
**Valid Values**: "1", "1.5", "2"

**Pattern**: Copied from existing console line stopbits implementation

## Dependencies

None - standalone attribute addition

## Files Modified

- `gen/definitions/line.yaml`: Added stopbits to aux attributes
- `internal/provider/model_iosxe_line.go`: Generated Go model code
- `internal/provider/resource_iosxe_line.go`: Generated resource code
- `internal/provider/data_source_iosxe_line.go`: Generated data source code
- `docs/`: Updated documentation

## Breaking Changes

None - additive change only

## Additional Notes

This matches the existing console line stopbits implementation, ensuring consistency across line types.

