### PR TITLE
[TCP] Implement Global TCP Support in Terraform Provider

### DIFF
--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -142,6 +142,9 @@ data "iosxe_system" "example" {
 - `ip_tacacs_source_interface_two_gigabit_ethernet` (String) Two GigabitEthernet
 - `ip_tacacs_source_interface_vlan` (Number) Iosxr Vlans
 - `ip_tacacs_source_interface_vrf` (String) VPN Routing/Forwarding parameters
+- `ip_tcp_mss` (Number) TCP initial maximum segment size
+- `ip_tcp_path_mtu_discovery` (Boolean) Enable path-MTU discovery on new TCP connections
+- `ip_tcp_window_size` (Number) TCP window size. Note - IOS-XE 17.15.1 and later uses a default of 131072 when not specified. For consistent behavior across mixed-version environments, always specify this value explicitly.
 - `ipv6_cef_load_sharing_algorithm_include_ports_destination` (Boolean)
 - `ipv6_cef_load_sharing_algorithm_include_ports_source` (Boolean)
 - `ipv6_multicast_routing` (Boolean) Enable IPV6 multicast forwarding

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -42,6 +42,9 @@ resource "iosxe_system" "example" {
   call_home_contact_email                            = "email@test.com"
   call_home_cisco_tac_1_profile_active               = true
   call_home_cisco_tac_1_destination_transport_method = "email"
+  ip_tcp_path_mtu_discovery                          = true
+  ip_tcp_mss                                         = 1460
+  ip_tcp_window_size                                 = 65536
   ip_nbar_classification_dns_classify_by_domain      = true
   ip_multicast_route_limit                           = 200000
   igmp_snooping_querier                              = true
@@ -203,6 +206,11 @@ resource "iosxe_system" "example" {
 - `ip_tacacs_source_interface_vlan` (Number) Iosxr Vlans
   - Range: `0`-`65535`
 - `ip_tacacs_source_interface_vrf` (String) VPN Routing/Forwarding parameters
+- `ip_tcp_mss` (Number) TCP initial maximum segment size
+  - Range: `0`-`10000`
+- `ip_tcp_path_mtu_discovery` (Boolean) Enable path-MTU discovery on new TCP connections
+- `ip_tcp_window_size` (Number) TCP window size. Note - IOS-XE 17.15.1 and later uses a default of 131072 when not specified. For consistent behavior across mixed-version environments, always specify this value explicitly.
+  - Range: `0`-`1073741823`
 - `ipv6_cef_load_sharing_algorithm_include_ports_destination` (Boolean)
 - `ipv6_cef_load_sharing_algorithm_include_ports_source` (Boolean)
 - `ipv6_multicast_routing` (Boolean) Enable IPV6 multicast forwarding

--- a/examples/resources/iosxe_system/resource.tf
+++ b/examples/resources/iosxe_system/resource.tf
@@ -27,6 +27,9 @@ resource "iosxe_system" "example" {
   call_home_contact_email                            = "email@test.com"
   call_home_cisco_tac_1_profile_active               = true
   call_home_cisco_tac_1_destination_transport_method = "email"
+  ip_tcp_path_mtu_discovery                          = true
+  ip_tcp_mss                                         = 1460
+  ip_tcp_window_size                                 = 65536
   ip_nbar_classification_dns_classify_by_domain      = true
   ip_multicast_route_limit                           = 200000
   igmp_snooping_querier                              = true

--- a/gen/definitions/system.yaml
+++ b/gen/definitions/system.yaml
@@ -548,6 +548,16 @@ attributes:
   - yang_name: call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method
     tf_name: call_home_cisco_tac_1_destination_transport_method
     example: email
+  - yang_name: ip/tcp/path-mtu-discovery
+    description: Enable path-MTU discovery on new TCP connections
+    example: true
+  - yang_name: ip/tcp/mss
+    description: TCP initial maximum segment size
+    example: 1460
+  - yang_name: ip/tcp/window-size
+    description: TCP window size. Note - IOS-XE 17.15.1 and later uses a default of 131072 when not specified. For consistent behavior across mixed-version environments, always specify this value explicitly.
+    allow_import_changes: true
+    example: 65536
   - yang_name: ip/ftp/passive-enable
     tf_name: ip_ftp_passive
     example: true

--- a/internal/provider/data_source_iosxe_system.go
+++ b/internal/provider/data_source_iosxe_system.go
@@ -669,6 +669,18 @@ func (d *SystemDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "To specify transport method for this profile",
 				Computed:            true,
 			},
+			"ip_tcp_path_mtu_discovery": schema.BoolAttribute{
+				MarkdownDescription: "Enable path-MTU discovery on new TCP connections",
+				Computed:            true,
+			},
+			"ip_tcp_mss": schema.Int64Attribute{
+				MarkdownDescription: "TCP initial maximum segment size",
+				Computed:            true,
+			},
+			"ip_tcp_window_size": schema.Int64Attribute{
+				MarkdownDescription: "TCP window size. Note - IOS-XE 17.15.1 and later uses a default of 131072 when not specified. For consistent behavior across mixed-version environments, always specify this value explicitly.",
+				Computed:            true,
+			},
 			"ip_ftp_passive": schema.BoolAttribute{
 				MarkdownDescription: "Connect using passive mode",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_system_test.go
+++ b/internal/provider/data_source_iosxe_system_test.go
@@ -82,6 +82,9 @@ func TestAccDataSourceIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "call_home_contact_email", "email@test.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "call_home_cisco_tac_1_profile_active", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "call_home_cisco_tac_1_destination_transport_method", "email"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_tcp_path_mtu_discovery", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_tcp_mss", "1460"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_tcp_window_size", "65536"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_nbar_classification_dns_classify_by_domain", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "ip_multicast_route_limit", "200000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_system.test", "igmp_snooping_querier", "true"))
@@ -189,6 +192,9 @@ func testAccDataSourceIosxeSystemConfig() string {
 	config += `	call_home_contact_email = "email@test.com"` + "\n"
 	config += `	call_home_cisco_tac_1_profile_active = true` + "\n"
 	config += `	call_home_cisco_tac_1_destination_transport_method = "email"` + "\n"
+	config += `	ip_tcp_path_mtu_discovery = true` + "\n"
+	config += `	ip_tcp_mss = 1460` + "\n"
+	config += `	ip_tcp_window_size = 65536` + "\n"
 	config += `	ip_nbar_classification_dns_classify_by_domain = true` + "\n"
 	config += `	ip_multicast_route_limit = 200000` + "\n"
 	config += `	igmp_snooping_querier = true` + "\n"

--- a/internal/provider/model_iosxe_system.go
+++ b/internal/provider/model_iosxe_system.go
@@ -155,6 +155,9 @@ type System struct {
 	CallHomeContactEmail                                   types.String                                        `tfsdk:"call_home_contact_email"`
 	CallHomeCiscoTac1ProfileActive                         types.Bool                                          `tfsdk:"call_home_cisco_tac_1_profile_active"`
 	CallHomeCiscoTac1DestinationTransportMethod            types.String                                        `tfsdk:"call_home_cisco_tac_1_destination_transport_method"`
+	IpTcpPathMtuDiscovery                                  types.Bool                                          `tfsdk:"ip_tcp_path_mtu_discovery"`
+	IpTcpMss                                               types.Int64                                         `tfsdk:"ip_tcp_mss"`
+	IpTcpWindowSize                                        types.Int64                                         `tfsdk:"ip_tcp_window_size"`
 	IpFtpPassive                                           types.Bool                                          `tfsdk:"ip_ftp_passive"`
 	TftpSourceInterfaceGigabitEthernet                     types.String                                        `tfsdk:"tftp_source_interface_gigabit_ethernet"`
 	TftpSourceInterfaceLoopback                            types.Int64                                         `tfsdk:"tftp_source_interface_loopback"`
@@ -312,6 +315,9 @@ type SystemData struct {
 	CallHomeContactEmail                                   types.String                                        `tfsdk:"call_home_contact_email"`
 	CallHomeCiscoTac1ProfileActive                         types.Bool                                          `tfsdk:"call_home_cisco_tac_1_profile_active"`
 	CallHomeCiscoTac1DestinationTransportMethod            types.String                                        `tfsdk:"call_home_cisco_tac_1_destination_transport_method"`
+	IpTcpPathMtuDiscovery                                  types.Bool                                          `tfsdk:"ip_tcp_path_mtu_discovery"`
+	IpTcpMss                                               types.Int64                                         `tfsdk:"ip_tcp_mss"`
+	IpTcpWindowSize                                        types.Int64                                         `tfsdk:"ip_tcp_window_size"`
 	IpFtpPassive                                           types.Bool                                          `tfsdk:"ip_ftp_passive"`
 	TftpSourceInterfaceGigabitEthernet                     types.String                                        `tfsdk:"tftp_source_interface_gigabit_ethernet"`
 	TftpSourceInterfaceLoopback                            types.Int64                                         `tfsdk:"tftp_source_interface_loopback"`
@@ -813,6 +819,17 @@ func (data System) toBody(ctx context.Context) string {
 	}
 	if !data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() && !data.CallHomeCiscoTac1DestinationTransportMethod.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"call-home.Cisco-IOS-XE-call-home:tac-profile.profile.CiscoTAC-1.destination.transport-method", data.CallHomeCiscoTac1DestinationTransportMethod.ValueString())
+	}
+	if !data.IpTcpPathMtuDiscovery.IsNull() && !data.IpTcpPathMtuDiscovery.IsUnknown() {
+		if data.IpTcpPathMtuDiscovery.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.tcp.path-mtu-discovery", map[string]string{})
+		}
+	}
+	if !data.IpTcpMss.IsNull() && !data.IpTcpMss.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.tcp.mss", strconv.FormatInt(data.IpTcpMss.ValueInt64(), 10))
+	}
+	if !data.IpTcpWindowSize.IsNull() && !data.IpTcpWindowSize.IsUnknown() {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.tcp.window-size", strconv.FormatInt(data.IpTcpWindowSize.ValueInt64(), 10))
 	}
 	if !data.IpFtpPassive.IsNull() && !data.IpFtpPassive.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"ip.ftp.passive-enable", data.IpFtpPassive.ValueBool())
@@ -1695,6 +1712,19 @@ func (data System) toBodyXML(ctx context.Context) string {
 	}
 	if !data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() && !data.CallHomeCiscoTac1DestinationTransportMethod.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method", data.CallHomeCiscoTac1DestinationTransportMethod.ValueString())
+	}
+	if !data.IpTcpPathMtuDiscovery.IsNull() && !data.IpTcpPathMtuDiscovery.IsUnknown() {
+		if data.IpTcpPathMtuDiscovery.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/ip/tcp/path-mtu-discovery", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/ip/tcp/path-mtu-discovery")
+		}
+	}
+	if !data.IpTcpMss.IsNull() && !data.IpTcpMss.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/ip/tcp/mss", strconv.FormatInt(data.IpTcpMss.ValueInt64(), 10))
+	}
+	if !data.IpTcpWindowSize.IsNull() && !data.IpTcpWindowSize.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/ip/tcp/window-size", strconv.FormatInt(data.IpTcpWindowSize.ValueInt64(), 10))
 	}
 	if !data.IpFtpPassive.IsNull() && !data.IpFtpPassive.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/ip/ftp/passive-enable", data.IpFtpPassive.ValueBool())
@@ -2901,6 +2931,25 @@ func (data *System) updateFromBody(ctx context.Context, res gjson.Result) {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringValue(value.String())
 	} else {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringNull()
+	}
+	if value := res.Get(prefix + "ip.tcp.path-mtu-discovery"); !data.IpTcpPathMtuDiscovery.IsNull() {
+		if value.Exists() {
+			data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+		} else {
+			data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+		}
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolNull()
+	}
+	if value := res.Get(prefix + "ip.tcp.mss"); value.Exists() && !data.IpTcpMss.IsNull() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	} else {
+		data.IpTcpMss = types.Int64Null()
+	}
+	if value := res.Get(prefix + "ip.tcp.window-size"); value.Exists() && !data.IpTcpWindowSize.IsNull() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
+	} else {
+		data.IpTcpWindowSize = types.Int64Null()
 	}
 	if value := res.Get(prefix + "ip.ftp.passive-enable"); !data.IpFtpPassive.IsNull() {
 		if value.Exists() {
@@ -4247,6 +4296,25 @@ func (data *System) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	} else {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/path-mtu-discovery"); !data.IpTcpPathMtuDiscovery.IsNull() {
+		if value.Exists() {
+			data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+		} else {
+			data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+		}
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/mss"); value.Exists() && !data.IpTcpMss.IsNull() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	} else {
+		data.IpTcpMss = types.Int64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/window-size"); value.Exists() && !data.IpTcpWindowSize.IsNull() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
+	} else {
+		data.IpTcpWindowSize = types.Int64Null()
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/ftp/passive-enable"); !data.IpFtpPassive.IsNull() {
 		if value.Exists() {
 			data.IpFtpPassive = types.BoolValue(value.Bool())
@@ -5146,6 +5214,17 @@ func (data *System) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "call-home.Cisco-IOS-XE-call-home:tac-profile.profile.CiscoTAC-1.destination.transport-method"); value.Exists() {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "ip.tcp.path-mtu-discovery"); value.Exists() {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "ip.tcp.mss"); value.Exists() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ip.tcp.window-size"); value.Exists() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
+	}
 	if value := res.Get(prefix + "ip.ftp.passive-enable"); value.Exists() {
 		data.IpFtpPassive = types.BoolValue(value.Bool())
 	} else {
@@ -5887,6 +5966,17 @@ func (data *SystemData) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get(prefix + "call-home.Cisco-IOS-XE-call-home:tac-profile.profile.CiscoTAC-1.destination.transport-method"); value.Exists() {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "ip.tcp.path-mtu-discovery"); value.Exists() {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "ip.tcp.mss"); value.Exists() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	}
+	if value := res.Get(prefix + "ip.tcp.window-size"); value.Exists() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
+	}
 	if value := res.Get(prefix + "ip.ftp.passive-enable"); value.Exists() {
 		data.IpFtpPassive = types.BoolValue(value.Bool())
 	} else {
@@ -6623,6 +6713,17 @@ func (data *System) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method"); value.Exists() {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/path-mtu-discovery"); value.Exists() {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/mss"); value.Exists() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/window-size"); value.Exists() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/ftp/passive-enable"); value.Exists() {
 		data.IpFtpPassive = types.BoolValue(value.Bool())
@@ -7361,6 +7462,17 @@ func (data *SystemData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method"); value.Exists() {
 		data.CallHomeCiscoTac1DestinationTransportMethod = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/path-mtu-discovery"); value.Exists() {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(true)
+	} else {
+		data.IpTcpPathMtuDiscovery = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/mss"); value.Exists() {
+		data.IpTcpMss = types.Int64Value(value.Int())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/tcp/window-size"); value.Exists() {
+		data.IpTcpWindowSize = types.Int64Value(value.Int())
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/ftp/passive-enable"); value.Exists() {
 		data.IpFtpPassive = types.BoolValue(value.Bool())
 	} else {
@@ -7778,6 +7890,15 @@ func (data *System) getDeletedItems(ctx context.Context, state System) []string 
 	}
 	if !state.IpFtpPassive.IsNull() && data.IpFtpPassive.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/ftp/passive-enable", state.getPath()))
+	}
+	if !state.IpTcpWindowSize.IsNull() && data.IpTcpWindowSize.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/tcp/window-size", state.getPath()))
+	}
+	if !state.IpTcpMss.IsNull() && data.IpTcpMss.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/tcp/mss", state.getPath()))
+	}
+	if !state.IpTcpPathMtuDiscovery.IsNull() && data.IpTcpPathMtuDiscovery.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/tcp/path-mtu-discovery", state.getPath()))
 	}
 	if !state.CallHomeCiscoTac1DestinationTransportMethod.IsNull() && data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method", state.getPath()))
@@ -8706,6 +8827,15 @@ func (data *System) addDeletedItemsXML(ctx context.Context, state System, body s
 	if !state.IpFtpPassive.IsNull() && data.IpFtpPassive.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/ftp/passive-enable")
 	}
+	if !state.IpTcpWindowSize.IsNull() && data.IpTcpWindowSize.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/tcp/window-size")
+	}
+	if !state.IpTcpMss.IsNull() && data.IpTcpMss.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/tcp/mss")
+	}
+	if !state.IpTcpPathMtuDiscovery.IsNull() && data.IpTcpPathMtuDiscovery.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/tcp/path-mtu-discovery")
+	}
 	if !state.CallHomeCiscoTac1DestinationTransportMethod.IsNull() && data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method")
 	}
@@ -9500,6 +9630,9 @@ func (data *System) getEmptyLeafsDelete(ctx context.Context) []string {
 			emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/track/Cisco-IOS-XE-track:tracked-object-v2=%v/ip/sla/reachability", data.getPath(), strings.Join(keyValues[:], ",")))
 		}
 	}
+	if !data.IpTcpPathMtuDiscovery.IsNull() && !data.IpTcpPathMtuDiscovery.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/ip/tcp/path-mtu-discovery", data.getPath()))
+	}
 	if !data.SubscriberTemplating.IsNull() && !data.SubscriberTemplating.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/subscriber/templating", data.getPath()))
 	}
@@ -9716,6 +9849,15 @@ func (data *System) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.IpFtpPassive.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/ftp/passive-enable", data.getPath()))
+	}
+	if !data.IpTcpWindowSize.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/tcp/window-size", data.getPath()))
+	}
+	if !data.IpTcpMss.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/tcp/mss", data.getPath()))
+	}
+	if !data.IpTcpPathMtuDiscovery.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/tcp/path-mtu-discovery", data.getPath()))
 	}
 	if !data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method", data.getPath()))
@@ -10218,6 +10360,15 @@ func (data *System) addDeletePathsXML(ctx context.Context, body string) string {
 	}
 	if !data.IpFtpPassive.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/ftp/passive-enable")
+	}
+	if !data.IpTcpWindowSize.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/tcp/window-size")
+	}
+	if !data.IpTcpMss.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/tcp/mss")
+	}
+	if !data.IpTcpPathMtuDiscovery.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/tcp/path-mtu-discovery")
 	}
 	if !data.CallHomeCiscoTac1DestinationTransportMethod.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/call-home/Cisco-IOS-XE-call-home:tac-profile/profile/CiscoTAC-1/destination/transport-method")

--- a/internal/provider/resource_iosxe_system.go
+++ b/internal/provider/resource_iosxe_system.go
@@ -793,6 +793,24 @@ func (r *SystemResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					stringvalidator.OneOf("email", "http"),
 				},
 			},
+			"ip_tcp_path_mtu_discovery": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable path-MTU discovery on new TCP connections").String,
+				Optional:            true,
+			},
+			"ip_tcp_mss": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("TCP initial maximum segment size").AddIntegerRangeDescription(0, 10000).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 10000),
+				},
+			},
+			"ip_tcp_window_size": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("TCP window size. Note - IOS-XE 17.15.1 and later uses a default of 131072 when not specified. For consistent behavior across mixed-version environments, always specify this value explicitly.").AddIntegerRangeDescription(0, 1073741823).String,
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 1073741823),
+				},
+			},
 			"ip_ftp_passive": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Connect using passive mode").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_system_test.go
+++ b/internal/provider/resource_iosxe_system_test.go
@@ -84,6 +84,9 @@ func TestAccIosxeSystem(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "call_home_contact_email", "email@test.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "call_home_cisco_tac_1_profile_active", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "call_home_cisco_tac_1_destination_transport_method", "email"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_tcp_path_mtu_discovery", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_tcp_mss", "1460"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_tcp_window_size", "65536"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_nbar_classification_dns_classify_by_domain", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "ip_multicast_route_limit", "200000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_system.test", "igmp_snooping_querier", "true"))
@@ -117,7 +120,7 @@ func TestAccIosxeSystem(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeSystemImportStateIdFunc("iosxe_system.test"),
-				ImportStateVerifyIgnore: []string{"ip_routing", "ip_multicast_routing", "multicast_routing_switch", "ip_multicast_routing_distributed", "multicast_routing_vrfs.0.distributed", "ip_http_authentication_aaa", "ip_http_authentication_local", "ip_http_server", "ip_http_secure_server", "cisp_enable", "epm_logging", "access_session_mac_move_deny", "archive_write_memory", "archive_log_config_logging_enable", "redundancy", "transceiver_type_all_monitoring", "ip_forward_protocol_nd", "ip_scp_server_enable", "ip_ssh_version_legacy", "ip_ssh_bulk_mode", "control_plane_service_policy_input", "subscriber_templating", "multilink_ppp_bundle_name", "version", "ip_cef_load_sharing_algorithm_include_ports_source", "ip_cef_load_sharing_algorithm_include_ports_destination", "ipv6_cef_load_sharing_algorithm_include_ports_source", "ipv6_cef_load_sharing_algorithm_include_ports_destination", "authentication_mac_move_permit", "authentication_mac_move_deny_uncontrolled", "device_classifier", "mld_snooping", "mld_snooping_querier"},
+				ImportStateVerifyIgnore: []string{"ip_routing", "ip_multicast_routing", "multicast_routing_switch", "ip_multicast_routing_distributed", "multicast_routing_vrfs.0.distributed", "ip_http_authentication_aaa", "ip_http_authentication_local", "ip_http_server", "ip_http_secure_server", "cisp_enable", "epm_logging", "access_session_mac_move_deny", "archive_write_memory", "archive_log_config_logging_enable", "redundancy", "transceiver_type_all_monitoring", "ip_forward_protocol_nd", "ip_scp_server_enable", "ip_ssh_version_legacy", "ip_ssh_bulk_mode", "control_plane_service_policy_input", "subscriber_templating", "ip_tcp_window_size", "multilink_ppp_bundle_name", "version", "ip_cef_load_sharing_algorithm_include_ports_source", "ip_cef_load_sharing_algorithm_include_ports_destination", "ipv6_cef_load_sharing_algorithm_include_ports_source", "ipv6_cef_load_sharing_algorithm_include_ports_destination", "authentication_mac_move_permit", "authentication_mac_move_deny_uncontrolled", "device_classifier", "mld_snooping", "mld_snooping_querier"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -224,6 +227,9 @@ func testAccIosxeSystemConfig_all() string {
 	config += `	call_home_contact_email = "email@test.com"` + "\n"
 	config += `	call_home_cisco_tac_1_profile_active = true` + "\n"
 	config += `	call_home_cisco_tac_1_destination_transport_method = "email"` + "\n"
+	config += `	ip_tcp_path_mtu_discovery = true` + "\n"
+	config += `	ip_tcp_mss = 1460` + "\n"
+	config += `	ip_tcp_window_size = 65536` + "\n"
 	config += `	ip_nbar_classification_dns_classify_by_domain = true` + "\n"
 	config += `	ip_multicast_route_limit = 200000` + "\n"
 	config += `	igmp_snooping_querier = true` + "\n"


### PR DESCRIPTION
# Add Global TCP Performance Tuning Parameters

## Overview

This PR adds support for global TCP performance tuning parameters to the `iosxe_system` resource, enabling configuration of TCP behavior optimization for high-throughput and high-latency networks.

## Changes Made

### New Terraform Attributes

| Attribute | CLI Command | Type | Range | Description |
|-----------|-------------|------|-------|-------------|
| `ip_tcp_path_mtu_discovery` | `ip tcp path-mtu-discovery` | Boolean | - | Enable path-MTU discovery on new TCP connections |
| `ip_tcp_mss` | `ip tcp mss <value>` | Integer | 0-10000 | TCP initial maximum segment size |
| `ip_tcp_window_size` | `ip tcp window-size <value>` | Integer | 0-1073741823 | TCP window size |

### Files Modified

- `gen/definitions/system.yaml` - Added TCP attribute definitions
- `internal/provider/resource_iosxe_system.go` - Generated resource schema
- `internal/provider/data_source_iosxe_system.go` - Generated data source schema
- `internal/provider/model_iosxe_system.go` - Generated model with TCP fields
- `internal/provider/resource_iosxe_system_test.go` - Generated acceptance tests
- `internal/provider/data_source_iosxe_system_test.go` - Generated data source tests
- `docs/resources/system.md` - Updated resource documentation
- `docs/data-sources/system.md` - Updated data source documentation
- `examples/resources/iosxe_system/resource.tf` - Updated example usage

## YANG Model Verification

### IOS-XE 17.15.1
- ✅ `ip tcp path-mtu-discovery` - Supported
- ✅ `ip tcp mss` - Supported
- ✅ `ip tcp window-size` - Supported (default: 131072)

### IOS-XE 17.12.1
- ✅ `ip tcp path-mtu-discovery` - Supported
- ✅ `ip tcp mss` - Supported
- ✅ `ip tcp window-size` - Supported (no default value)

## Version Compatibility Note

The `ip_tcp_window_size` attribute has `allow_import_changes: true` because:
- IOS-XE 17.15.1+ uses a default value of `131072` when not specified
- IOS-XE 17.12.1 has no default value
- For consistent behavior across mixed-version environments, users should explicitly specify this value

## Testing

- [x] Code generation completed (`make gen NAME="System"`)
- [x] Go build successful
- [x] Acceptance tests passed

## Checklist

- [x] YANG model support verified for 17.15.1
- [x] YANG model support verified for 17.12.1
- [x] Definition file updated (`gen/definitions/system.yaml`)
- [x] Acceptance tests executed and passed
- [x] Documentation generated