### PR TITLE
fix(interface_ethernet): delete isis container on destroy instead of tag leaf

### DIFF
--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -571,6 +571,7 @@ attributes:
     example: 3
   - yang_name: ip/router/Cisco-IOS-XE-isis:isis/tag
     tf_name: ip_router_isis
+    delete_parent: true
     example: TEST
     exclude_test: true
 

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -7236,7 +7236,7 @@ func (data *InterfaceEthernetData) fromBodyXML(ctx context.Context, res xmldot.R
 func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state InterfaceEthernet) []string {
 	deletedItems := make([]string, 0)
 	if !state.IpRouterIsis.IsNull() && data.IpRouterIsis.IsNull() {
-		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/router/Cisco-IOS-XE-isis:isis/tag", state.getPath()))
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/router/Cisco-IOS-XE-isis:isis", state.getPath()))
 	}
 	if !state.IpIgmpVersion.IsNull() && data.IpIgmpVersion.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/Cisco-IOS-XE-igmp:igmp/version", state.getPath()))
@@ -7910,7 +7910,7 @@ func (data *InterfaceEthernet) getDeletedItems(ctx context.Context, state Interf
 func (data *InterfaceEthernet) addDeletedItemsXML(ctx context.Context, state InterfaceEthernet, body string) string {
 	b := netconf.NewBody(body)
 	if !state.IpRouterIsis.IsNull() && data.IpRouterIsis.IsNull() {
-		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/router/Cisco-IOS-XE-isis:isis/tag")
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/router/Cisco-IOS-XE-isis:isis")
 	}
 	if !state.IpIgmpVersion.IsNull() && data.IpIgmpVersion.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version")
@@ -8878,7 +8878,7 @@ func (data *InterfaceEthernet) getEmptyLeafsDelete(ctx context.Context) []string
 func (data *InterfaceEthernet) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
 	if !data.IpRouterIsis.IsNull() {
-		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/router/Cisco-IOS-XE-isis:isis/tag", data.getPath()))
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/router/Cisco-IOS-XE-isis:isis", data.getPath()))
 	}
 	if !data.IpIgmpVersion.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/Cisco-IOS-XE-igmp:igmp/version", data.getPath()))
@@ -9316,7 +9316,7 @@ func (data *InterfaceEthernet) getDeletePaths(ctx context.Context) []string {
 func (data *InterfaceEthernet) addDeletePathsXML(ctx context.Context, body string) string {
 	b := netconf.NewBody(body)
 	if !data.IpRouterIsis.IsNull() {
-		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/router/Cisco-IOS-XE-isis:isis/tag")
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/router/Cisco-IOS-XE-isis:isis")
 	}
 	if !data.IpIgmpVersion.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version")


### PR DESCRIPTION
## Summary

Add `delete_parent: true` to the `ip_router_isis` attribute in the `interface_ethernet` definition so that on destroy, the provider deletes the entire `isis` presence container instead of just the `tag` leaf.

## Problem

When an ethernet interface has IS-IS routing enabled (`ip router isis <tag>`), the Terraform provider maps this to:

```
ip/router/Cisco-IOS-XE-isis:isis/tag
```

On destroy, the provider was only deleting the `tag` leaf, leaving an orphaned empty `isis` presence container on the interface. This caused issues on subsequent applies because IOS-XE treats the presence of the empty `isis` container differently than its absence.

## YANG Model Evidence

The relevant YANG structure from `Cisco-IOS-XE-isis.yang` (line 262-276) shows that `isis` is a **presence container** that wraps the `tag` leaf:

```yang
grouping config-interface-ip-router-isis-grouping {
  container isis {
    description "IS-IS Routing for IP";
    presence "true";
    must '../../ios:address/ios:primary/ios:address or ...' {
      error-message "Please configure ip address on the interface";
    }
    must './tag or /ios:native/ios:router/isis' {
      error-message "router isis must be configured first";
    }
    leaf tag {
      type leafref {
        path "/ios:native/ios:router/isis-container/isis/area-tag";
      }
    }
    // ... additional leaves (network, metric, etc.)
  }
}
```

This grouping is augmented into all ethernet interface types:

```yang
augment "/ios:native/ios:interface/ios:GigabitEthernet/ios:ip/ios:router" {
  uses config-interface-ip-router-isis-grouping;
}
```

Since `isis` is a `presence "true"` container, deleting just the `tag` leaf leaves a semantically meaningful empty container. The correct behavior is to delete the entire `isis` container, which is what `delete_parent: true` achieves.

## Changes

- `gen/definitions/interface_ethernet.yaml`: Added `delete_parent: true` to `ip_router_isis`
- `internal/provider/model_iosxe_interface_ethernet.go`: Auto-generated — delete paths changed from `.../isis/tag` to `.../isis`

## Test plan

- [x] Verify `terraform destroy` cleanly removes IS-IS binding from ethernet interface
- [x] Verify no orphaned isis container remains after destroy
- [x] Verify `terraform apply` after destroy correctly re-creates the IS-IS binding