### PR TITLE
feat(iosxe): add evpn_ethernet_segments_legacy to interface_port_channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `iosxe_object_group` resource and data source with FQDN (`object-group fqdn`) and network (`object-group network`) object group support, including name, description, nested group references, host entries, network addresses, address ranges, and regex FQDN patterns
 - Add `iosxe_ipv6_prefix_list` resource and data source
 - Add `iosxe_parameter_map` resource and data source
+- Add `evpn_ethernet_segments_legacy` attribute to `iosxe_interface_port_channel` resource and data source for IOS-XE 17.12 compatibility. The legacy attribute uses the pre-17.15 YANG path (`evpn/ethernet-segment`) while the existing `evpn_ethernet_segments` attribute targets the 17.15+ path (`evpn/ethernet-segment-choice`).
 
 ## 0.17.0
 

--- a/docs/data-sources/interface_port_channel.md
+++ b/docs/data-sources/interface_port_channel.md
@@ -54,6 +54,7 @@ data "iosxe_interface_port_channel" "example" {
 - `device_tracking` (Boolean) Configure device-tracking on the interface
 - `device_tracking_attached_policies` (Attributes List) (see [below for nested schema](#nestedatt--device_tracking_attached_policies))
 - `evpn_ethernet_segments` (Attributes List) Ethernet segment local discriminator value (see [below for nested schema](#nestedatt--evpn_ethernet_segments))
+- `evpn_ethernet_segments_legacy` (Attributes List) Ethernet segment local discriminator value, DEPRECATED (see [below for nested schema](#nestedatt--evpn_ethernet_segments_legacy))
 - `helper_addresses` (Attributes List) Specify a destination address for UDP broadcasts (see [below for nested schema](#nestedatt--helper_addresses))
 - `id` (String) The path of the retrieved object.
 - `ip_access_group_in` (String)
@@ -109,6 +110,14 @@ Read-Only:
 Read-Only:
 
 - `es_value` (Number) Ethernet segment local discriminator value
+
+
+<a id="nestedatt--evpn_ethernet_segments_legacy"></a>
+### Nested Schema for `evpn_ethernet_segments_legacy`
+
+Read-Only:
+
+- `es_value` (Number) Ethernet segment local discriminator value, DEPRECATED
 
 
 <a id="nestedatt--helper_addresses"></a>

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -20,6 +20,7 @@ description: |-
 - Add `iosxe_object_group` resource and data source with FQDN (`object-group fqdn`) and network (`object-group network`) object group support, including name, description, nested group references, host entries, network addresses, address ranges, and regex FQDN patterns
 - Add `iosxe_ipv6_prefix_list` resource and data source
 - Add `iosxe_parameter_map` resource and data source
+- Add `evpn_ethernet_segments_legacy` attribute to `iosxe_interface_port_channel` resource and data source for IOS-XE 17.12 compatibility. The legacy attribute uses the pre-17.15 YANG path (`evpn/ethernet-segment`) while the existing `evpn_ethernet_segments` attribute targets the 17.15+ path (`evpn/ethernet-segment-choice`).
 
 ## 0.17.0
 

--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -106,6 +106,7 @@ resource "iosxe_interface_port_channel" "example" {
 - `device_tracking` (Boolean) Configure device-tracking on the interface
 - `device_tracking_attached_policies` (Attributes List) (see [below for nested schema](#nestedatt--device_tracking_attached_policies))
 - `evpn_ethernet_segments` (Attributes List) Ethernet segment local discriminator value (see [below for nested schema](#nestedatt--evpn_ethernet_segments))
+- `evpn_ethernet_segments_legacy` (Attributes List) Ethernet segment local discriminator value, DEPRECATED (see [below for nested schema](#nestedatt--evpn_ethernet_segments_legacy))
 - `helper_addresses` (Attributes List) Specify a destination address for UDP broadcasts (see [below for nested schema](#nestedatt--helper_addresses))
 - `ip_access_group_in` (String)
 - `ip_access_group_in_enable` (Boolean) inbound packets
@@ -171,6 +172,15 @@ Required:
 Required:
 
 - `es_value` (Number) Ethernet segment local discriminator value
+  - Range: `1`-`65535`
+
+
+<a id="nestedatt--evpn_ethernet_segments_legacy"></a>
+### Nested Schema for `evpn_ethernet_segments_legacy`
+
+Required:
+
+- `es_value` (Number) Ethernet segment local discriminator value, DEPRECATED
   - Range: `1`-`65535`
 
 

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -225,7 +225,15 @@ attributes:
     xpath: Cisco-IOS-XE-l2vpn:evpn/ethernet-segment-num/ethernet-segment
     tf_name: evpn_ethernet_segments
     type: List
-    exclude_test: true  # For some reason it works with RESTCONF but fails with NETCONF, further investigation needed.
+    test_tags: [IOSXE1715]
+    attributes:
+      - yang_name: es-value
+        id: true
+        example: 1
+  - yang_name: Cisco-IOS-XE-l2vpn:evpn/ethernet-segment
+    tf_name: evpn_ethernet_segments_legacy
+    type: List
+    test_tags: [IOSXE1712]
     attributes:
       - yang_name: es-value
         id: true

--- a/internal/provider/data_source_iosxe_interface_port_channel.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel.go
@@ -364,6 +364,18 @@ func (d *InterfacePortChannelDataSource) Schema(ctx context.Context, req datasou
 					},
 				},
 			},
+			"evpn_ethernet_segments_legacy": schema.ListNestedAttribute{
+				MarkdownDescription: "Ethernet segment local discriminator value, DEPRECATED",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"es_value": schema.Int64Attribute{
+							MarkdownDescription: "Ethernet segment local discriminator value, DEPRECATED",
+							Computed:            true,
+						},
+					},
+				},
+			},
 			"ip_igmp_version": schema.Int64Attribute{
 				MarkdownDescription: "IGMP version",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -67,6 +67,12 @@ func TestAccDataSourceIosxeInterfacePortChannel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "load_interval", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "logging_event_link_status_enable", "false"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "evpn_ethernet_segments.0.es_value", "1"))
+	}
+	if os.Getenv("IOSXE1712") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "evpn_ethernet_segments_legacy.0.es_value", "1"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_igmp_version", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_flow_monitors.0.direction", "input"))
@@ -215,6 +221,16 @@ func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 	config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	config += `	load_interval = 30` + "\n"
 	config += `	logging_event_link_status_enable = false` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `	evpn_ethernet_segments = [{` + "\n"
+		config += `		es_value = 1` + "\n"
+		config += `	}]` + "\n"
+	}
+	if os.Getenv("IOSXE1712") != "" {
+		config += `	evpn_ethernet_segments_legacy = [{` + "\n"
+		config += `		es_value = 1` + "\n"
+		config += `	}]` + "\n"
+	}
 	config += `	ip_igmp_version = 3` + "\n"
 	config += `	ip_flow_monitors = [{` + "\n"
 	config += `		name = "MON1"` + "\n"

--- a/internal/provider/model_iosxe_interface_port_channel.go
+++ b/internal/provider/model_iosxe_interface_port_channel.go
@@ -102,6 +102,7 @@ type InterfacePortChannel struct {
 	DeviceTrackingAttachedPolicies []InterfacePortChannelDeviceTrackingAttachedPolicies `tfsdk:"device_tracking_attached_policies"`
 	NegotiationAuto                types.Bool                                           `tfsdk:"negotiation_auto"`
 	EvpnEthernetSegments           []InterfacePortChannelEvpnEthernetSegments           `tfsdk:"evpn_ethernet_segments"`
+	EvpnEthernetSegmentsLegacy     []InterfacePortChannelEvpnEthernetSegmentsLegacy     `tfsdk:"evpn_ethernet_segments_legacy"`
 	IpIgmpVersion                  types.Int64                                          `tfsdk:"ip_igmp_version"`
 	IpRouterIsis                   types.String                                         `tfsdk:"ip_router_isis"`
 	IpNatInside                    types.Bool                                           `tfsdk:"ip_nat_inside"`
@@ -130,6 +131,9 @@ type InterfacePortChannelDeviceTrackingAttachedPolicies struct {
 	Name types.String `tfsdk:"name"`
 }
 type InterfacePortChannelEvpnEthernetSegments struct {
+	EsValue types.Int64 `tfsdk:"es_value"`
+}
+type InterfacePortChannelEvpnEthernetSegmentsLegacy struct {
 	EsValue types.Int64 `tfsdk:"es_value"`
 }
 type InterfacePortChannelIpFlowMonitors struct {
@@ -197,6 +201,7 @@ type InterfacePortChannelData struct {
 	DeviceTrackingAttachedPolicies []InterfacePortChannelDeviceTrackingAttachedPoliciesData `tfsdk:"device_tracking_attached_policies"`
 	NegotiationAuto                types.Bool                                               `tfsdk:"negotiation_auto"`
 	EvpnEthernetSegments           []InterfacePortChannelEvpnEthernetSegmentsData           `tfsdk:"evpn_ethernet_segments"`
+	EvpnEthernetSegmentsLegacy     []InterfacePortChannelEvpnEthernetSegmentsLegacyData     `tfsdk:"evpn_ethernet_segments_legacy"`
 	IpIgmpVersion                  types.Int64                                              `tfsdk:"ip_igmp_version"`
 	IpRouterIsis                   types.String                                             `tfsdk:"ip_router_isis"`
 	IpNatInside                    types.Bool                                               `tfsdk:"ip_nat_inside"`
@@ -225,6 +230,9 @@ type InterfacePortChannelDeviceTrackingAttachedPoliciesData struct {
 	Name types.String `tfsdk:"name"`
 }
 type InterfacePortChannelEvpnEthernetSegmentsData struct {
+	EsValue types.Int64 `tfsdk:"es_value"`
+}
+type InterfacePortChannelEvpnEthernetSegmentsLegacyData struct {
 	EsValue types.Int64 `tfsdk:"es_value"`
 }
 type InterfacePortChannelIpFlowMonitorsData struct {
@@ -556,6 +564,14 @@ func (data InterfacePortChannel) toBody(ctx context.Context, config InterfacePor
 		for index, item := range data.EvpnEthernetSegments {
 			if !item.EsValue.IsNull() && !item.EsValue.IsUnknown() {
 				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-l2vpn:evpn.ethernet-segment-num.ethernet-segment"+"."+strconv.Itoa(index)+"."+"es-value", strconv.FormatInt(item.EsValue.ValueInt64(), 10))
+			}
+		}
+	}
+	if len(data.EvpnEthernetSegmentsLegacy) > 0 {
+		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-l2vpn:evpn.ethernet-segment", []interface{}{})
+		for index, item := range data.EvpnEthernetSegmentsLegacy {
+			if !item.EsValue.IsNull() && !item.EsValue.IsUnknown() {
+				body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-l2vpn:evpn.ethernet-segment"+"."+strconv.Itoa(index)+"."+"es-value", strconv.FormatInt(item.EsValue.ValueInt64(), 10))
 			}
 		}
 	}
@@ -899,6 +915,15 @@ func (data InterfacePortChannel) toBodyXML(ctx context.Context, config Interface
 				cBody = helpers.SetFromXPath(cBody, "es-value", strconv.FormatInt(item.EsValue.ValueInt64(), 10))
 			}
 			body = helpers.SetRawFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment-num/ethernet-segment", cBody.Res())
+		}
+	}
+	if len(data.EvpnEthernetSegmentsLegacy) > 0 {
+		for _, item := range data.EvpnEthernetSegmentsLegacy {
+			cBody := netconf.Body{}
+			if !item.EsValue.IsNull() && !item.EsValue.IsUnknown() {
+				cBody = helpers.SetFromXPath(cBody, "es-value", strconv.FormatInt(item.EsValue.ValueInt64(), 10))
+			}
+			body = helpers.SetRawFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment", cBody.Res())
 		}
 	}
 	if !data.IpIgmpVersion.IsNull() && !data.IpIgmpVersion.IsUnknown() {
@@ -1522,6 +1547,35 @@ func (data *InterfacePortChannel) updateFromBody(ctx context.Context, res gjson.
 			data.EvpnEthernetSegments[i].EsValue = types.Int64Value(value.Int())
 		} else {
 			data.EvpnEthernetSegments[i].EsValue = types.Int64Null()
+		}
+	}
+	for i := range data.EvpnEthernetSegmentsLegacy {
+		keys := [...]string{"es-value"}
+		keyValues := [...]string{strconv.FormatInt(data.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+
+		var r gjson.Result
+		res.Get(prefix + "Cisco-IOS-XE-l2vpn:evpn.ethernet-segment").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("es-value"); value.Exists() && !data.EvpnEthernetSegmentsLegacy[i].EsValue.IsNull() {
+			data.EvpnEthernetSegmentsLegacy[i].EsValue = types.Int64Value(value.Int())
+		} else {
+			data.EvpnEthernetSegmentsLegacy[i].EsValue = types.Int64Null()
 		}
 	}
 	if value := res.Get(prefix + "ip.Cisco-IOS-XE-igmp:igmp.version"); value.Exists() && !data.IpIgmpVersion.IsNull() {
@@ -2170,6 +2224,35 @@ func (data *InterfacePortChannel) updateFromBodyXML(ctx context.Context, res xml
 			data.EvpnEthernetSegments[i].EsValue = types.Int64Null()
 		}
 	}
+	for i := range data.EvpnEthernetSegmentsLegacy {
+		keys := [...]string{"es-value"}
+		keyValues := [...]string{strconv.FormatInt(data.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+
+		var r xmldot.Result
+		helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment").ForEach(
+			func(_ int, v xmldot.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := helpers.GetFromXPath(r, "es-value"); value.Exists() && !data.EvpnEthernetSegmentsLegacy[i].EsValue.IsNull() {
+			data.EvpnEthernetSegmentsLegacy[i].EsValue = types.Int64Value(value.Int())
+		} else {
+			data.EvpnEthernetSegmentsLegacy[i].EsValue = types.Int64Null()
+		}
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version"); value.Exists() && !data.IpIgmpVersion.IsNull() {
 		data.IpIgmpVersion = types.Int64Value(value.Int())
 	} else {
@@ -2547,6 +2630,17 @@ func (data *InterfacePortChannel) fromBody(ctx context.Context, res gjson.Result
 			return true
 		})
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-l2vpn:evpn.ethernet-segment"); value.Exists() {
+		data.EvpnEthernetSegmentsLegacy = make([]InterfacePortChannelEvpnEthernetSegmentsLegacy, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := InterfacePortChannelEvpnEthernetSegmentsLegacy{}
+			if cValue := v.Get("es-value"); cValue.Exists() {
+				item.EsValue = types.Int64Value(cValue.Int())
+			}
+			data.EvpnEthernetSegmentsLegacy = append(data.EvpnEthernetSegmentsLegacy, item)
+			return true
+		})
+	}
 	if value := res.Get(prefix + "ip.Cisco-IOS-XE-igmp:igmp.version"); value.Exists() {
 		data.IpIgmpVersion = types.Int64Value(value.Int())
 	}
@@ -2890,6 +2984,17 @@ func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Re
 			return true
 		})
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-l2vpn:evpn.ethernet-segment"); value.Exists() {
+		data.EvpnEthernetSegmentsLegacy = make([]InterfacePortChannelEvpnEthernetSegmentsLegacyData, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := InterfacePortChannelEvpnEthernetSegmentsLegacyData{}
+			if cValue := v.Get("es-value"); cValue.Exists() {
+				item.EsValue = types.Int64Value(cValue.Int())
+			}
+			data.EvpnEthernetSegmentsLegacy = append(data.EvpnEthernetSegmentsLegacy, item)
+			return true
+		})
+	}
 	if value := res.Get(prefix + "ip.Cisco-IOS-XE-igmp:igmp.version"); value.Exists() {
 		data.IpIgmpVersion = types.Int64Value(value.Int())
 	}
@@ -3226,6 +3331,17 @@ func (data *InterfacePortChannel) fromBodyXML(ctx context.Context, res xmldot.Re
 				item.EsValue = types.Int64Value(cValue.Int())
 			}
 			data.EvpnEthernetSegments = append(data.EvpnEthernetSegments, item)
+			return true
+		})
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment"); value.Exists() {
+		data.EvpnEthernetSegmentsLegacy = make([]InterfacePortChannelEvpnEthernetSegmentsLegacy, 0)
+		value.ForEach(func(_ int, v xmldot.Result) bool {
+			item := InterfacePortChannelEvpnEthernetSegmentsLegacy{}
+			if cValue := helpers.GetFromXPath(v, "es-value"); cValue.Exists() {
+				item.EsValue = types.Int64Value(cValue.Int())
+			}
+			data.EvpnEthernetSegmentsLegacy = append(data.EvpnEthernetSegmentsLegacy, item)
 			return true
 		})
 	}
@@ -3568,6 +3684,17 @@ func (data *InterfacePortChannelData) fromBodyXML(ctx context.Context, res xmldo
 			return true
 		})
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment"); value.Exists() {
+		data.EvpnEthernetSegmentsLegacy = make([]InterfacePortChannelEvpnEthernetSegmentsLegacyData, 0)
+		value.ForEach(func(_ int, v xmldot.Result) bool {
+			item := InterfacePortChannelEvpnEthernetSegmentsLegacyData{}
+			if cValue := helpers.GetFromXPath(v, "es-value"); cValue.Exists() {
+				item.EsValue = types.Int64Value(cValue.Int())
+			}
+			data.EvpnEthernetSegmentsLegacy = append(data.EvpnEthernetSegmentsLegacy, item)
+			return true
+		})
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version"); value.Exists() {
 		data.IpIgmpVersion = types.Int64Value(value.Int())
 	}
@@ -3654,6 +3781,31 @@ func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state Int
 	}
 	if !state.IpIgmpVersion.IsNull() && data.IpIgmpVersion.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/Cisco-IOS-XE-igmp:igmp/version", state.getPath()))
+	}
+	for i := range state.EvpnEthernetSegmentsLegacy {
+		stateKeyValues := [...]string{strconv.FormatInt(state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.EvpnEthernetSegmentsLegacy {
+			found = true
+			if state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64() != data.EvpnEthernetSegmentsLegacy[j].EsValue.ValueInt64() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment=%v", state.getPath(), strings.Join(stateKeyValues[:], ",")))
+		}
 	}
 	for i := range state.EvpnEthernetSegments {
 		stateKeyValues := [...]string{strconv.FormatInt(state.EvpnEthernetSegments[i].EsValue.ValueInt64(), 10)}
@@ -4030,6 +4182,36 @@ func (data *InterfacePortChannel) addDeletedItemsXML(ctx context.Context, state 
 	}
 	if !state.IpIgmpVersion.IsNull() && data.IpIgmpVersion.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version")
+	}
+	for i := range state.EvpnEthernetSegmentsLegacy {
+		stateKeys := [...]string{"es-value"}
+		stateKeyValues := [...]string{strconv.FormatInt(state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+		predicates := ""
+		for i := range stateKeys {
+			predicates += fmt.Sprintf("[%s='%s']", stateKeys[i], stateKeyValues[i])
+		}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.EvpnEthernetSegmentsLegacy {
+			found = true
+			if state.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64() != data.EvpnEthernetSegmentsLegacy[j].EsValue.ValueInt64() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment%v", predicates))
+		}
 	}
 	for i := range state.EvpnEthernetSegments {
 		stateKeys := [...]string{"es-value"}
@@ -4512,6 +4694,11 @@ func (data *InterfacePortChannel) getDeletePaths(ctx context.Context) []string {
 	if !data.IpIgmpVersion.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/Cisco-IOS-XE-igmp:igmp/version", data.getPath()))
 	}
+	for i := range data.EvpnEthernetSegmentsLegacy {
+		keyValues := [...]string{strconv.FormatInt(data.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment=%v", data.getPath(), strings.Join(keyValues[:], ",")))
+	}
 	for i := range data.EvpnEthernetSegments {
 		keyValues := [...]string{strconv.FormatInt(data.EvpnEthernetSegments[i].EsValue.ValueInt64(), 10)}
 
@@ -4723,6 +4910,16 @@ func (data *InterfacePortChannel) addDeletePathsXML(ctx context.Context, body st
 	}
 	if !data.IpIgmpVersion.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/Cisco-IOS-XE-igmp:igmp/version")
+	}
+	for i := range data.EvpnEthernetSegmentsLegacy {
+		keys := [...]string{"es-value"}
+		keyValues := [...]string{strconv.FormatInt(data.EvpnEthernetSegmentsLegacy[i].EsValue.ValueInt64(), 10)}
+		predicates := ""
+		for i := range keys {
+			predicates += fmt.Sprintf("[%s='%s']", keys[i], keyValues[i])
+		}
+
+		b = helpers.RemoveFromXPath(b, fmt.Sprintf(data.getXPath()+"/Cisco-IOS-XE-l2vpn:evpn/ethernet-segment%v", predicates))
 	}
 	for i := range data.EvpnEthernetSegments {
 		keys := [...]string{"es-value"}

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -448,6 +448,21 @@ func (r *InterfacePortChannelResource) Schema(ctx context.Context, req resource.
 					},
 				},
 			},
+			"evpn_ethernet_segments_legacy": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Ethernet segment local discriminator value, DEPRECATED").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"es_value": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Ethernet segment local discriminator value, DEPRECATED").AddIntegerRangeDescription(1, 65535).String,
+							Required:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 65535),
+							},
+						},
+					},
+				},
+			},
 			"ip_igmp_version": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("IGMP version").AddIntegerRangeDescription(1, 3).String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -70,6 +70,12 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_arp_inspection_limit_rate", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "load_interval", "30"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "logging_event_link_status_enable", "false"))
+	if os.Getenv("IOSXE1715") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "evpn_ethernet_segments.0.es_value", "1"))
+	}
+	if os.Getenv("IOSXE1712") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "evpn_ethernet_segments_legacy.0.es_value", "1"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_igmp_version", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_flow_monitors.0.direction", "input"))
@@ -253,6 +259,16 @@ func testAccIosxeInterfacePortChannelConfig_all() string {
 	config += `	ip_arp_inspection_limit_rate = 1000` + "\n"
 	config += `	load_interval = 30` + "\n"
 	config += `	logging_event_link_status_enable = false` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `	evpn_ethernet_segments = [{` + "\n"
+		config += `		es_value = 1` + "\n"
+		config += `	}]` + "\n"
+	}
+	if os.Getenv("IOSXE1712") != "" {
+		config += `	evpn_ethernet_segments_legacy = [{` + "\n"
+		config += `		es_value = 1` + "\n"
+		config += `	}]` + "\n"
+	}
 	config += `	ip_igmp_version = 3` + "\n"
 	config += `	ip_flow_monitors = [{` + "\n"
 	config += `		name = "MON1"` + "\n"

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -20,6 +20,7 @@ description: |-
 - Add `iosxe_object_group` resource and data source with FQDN (`object-group fqdn`) and network (`object-group network`) object group support, including name, description, nested group references, host entries, network addresses, address ranges, and regex FQDN patterns
 - Add `iosxe_ipv6_prefix_list` resource and data source
 - Add `iosxe_parameter_map` resource and data source
+- Add `evpn_ethernet_segments_legacy` attribute to `iosxe_interface_port_channel` resource and data source for IOS-XE 17.12 compatibility. The legacy attribute uses the pre-17.15 YANG path (`evpn/ethernet-segment`) while the existing `evpn_ethernet_segments` attribute targets the 17.15+ path (`evpn/ethernet-segment-choice`).
 
 ## 0.17.0
 


### PR DESCRIPTION
## Summary
- Add `evpn_ethernet_segments_legacy` attribute to `iosxe_interface_port_channel` resource and data source for IOS-XE 17.12 compatibility
- The legacy attribute uses the pre-17.15 YANG path (`evpn/ethernet-segment`) while `evpn_ethernet_segments` targets the 17.15+ path (`evpn/ethernet-segment-choice`)
- Add `test_tags: [IOSXE1715]` to existing `evpn_ethernet_segments` and `test_tags: [IOSXE1712]` to the new legacy attribute
- Remove `exclude_test: true` workaround from the existing attribute

Fixes https://github.com/CiscoDevNet/terraform-provider-iosxe/issues/356

## Notes
- Follows the established `_legacy` pattern used in `route_map.yaml` and other resources
- RESTCONF fails for this feature on Cat9kv ("inconsistent value") — only NETCONF works. This is a known device limitation.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: definition YAML, code generation, docs, CHANGELOG
- **Human Oversight**: Code reviewed and tested on live devices