### PR TITLE
fix(build): pin provider name in tfplugindocs invocation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,5 +127,5 @@ gen:
 	go run ./gen/generator.go "$(NAME)"
 	go run golang.org/x/tools/cmd/goimports -w internal/provider/
 	terraform fmt -recursive ./examples/
-	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name iosxe --rendered-provider-name terraform-provider-iosxe
 	go run gen/doc_category.go


### PR DESCRIPTION
## Summary

- Add `--provider-name iosxe` and `--rendered-provider-name terraform-provider-iosxe` flags to the `tfplugindocs` invocation in the `gen` Makefile target

## Problem

`tfplugindocs` infers the provider name from the current working directory's basename ([source](https://github.com/hashicorp/terraform-plugin-docs/blob/main/internal/provider/generate.go#L199-L201)):

```go
if g.providerName == "" {
    g.providerName = filepath.Base(g.providerDir)
}
```

When `make gen` runs from a directory named `terraform-provider-iosxe`, this works correctly. But when run from any other directory name — such as a git worktree, a renamed clone, or a CI workspace with a non-standard path — the inferred name is wrong. This silently rewrites the `page_title` frontmatter in every generated doc file, producing a large cosmetic diff unrelated to the actual change.

For example, running from a worktree named `bgp-redistribute-route-map` changes every doc's `page_title` from:

```
page_title: "iosxe_bgp Resource - terraform-provider-iosxe"
```

to:

```
page_title: "iosxe_bgp Resource - bgp-redistribute-route-map"
```

## Fix

Explicitly pass both `--provider-name` and `--rendered-provider-name` so doc generation is deterministic regardless of the working directory name. When run from the standard repo directory, the output is identical — this only prevents incorrect output when the directory name differs.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: identified root cause and applied one-line fix to GNUmakefile
- **Human Oversight**: Code reviewed and approved by Christopher Hart