### PR TITLE
fix(netconf): prevent leaf-list sibling overwrite in RemoveFromXPath

### DIFF
--- a/internal/provider/helpers/netconf.go
+++ b/internal/provider/helpers/netconf.go
@@ -539,10 +539,16 @@ func buildXPathStructure(body netconf.Body, xPath string, ensureStructure bool) 
 
 				// Set all key values using normal Set
 				for _, kv := range keys {
-					keyPath := fullPath + "." + kv.Key
-					originalKeyPath := originalFullPath + "." + kv.Key
-					body = body.Set(dotPath(keyPath), kv.Value)
-					body = augmentNamespaces(body, originalKeyPath)
+					if kv.Key == "." {
+						// Leaf-list: set the text content of the element directly
+						body = body.Set(dotPath(fullPath), kv.Value)
+						body = augmentNamespaces(body, originalFullPath)
+					} else {
+						keyPath := fullPath + "." + kv.Key
+						originalKeyPath := originalFullPath + "." + kv.Key
+						body = body.Set(dotPath(keyPath), kv.Value)
+						body = augmentNamespaces(body, originalKeyPath)
+					}
 				}
 
 			case SiblingActionUpdate:
@@ -594,16 +600,31 @@ func findSiblingInfo(body netconf.Body, parentPath, elementName string, keys []K
 	countPath := basePath + ".#"
 	count := xmldot.Get(body.Res(), countPath).Int()
 
+	// For leaf-list predicates ([.=value]), the "." key refers to the text content
+	// of the element itself. xmldot accesses text content via the element path directly
+	// (not with a ".key" suffix).
+	isLeafList := len(keys) == 1 && keys[0].Key == "."
+
 	// If count is 0 but element might exist as single (non-array), check directly
 	if count == 0 {
 		// Check if a single element exists by looking for any key
 		if len(keys) > 0 {
-			keyPath := basePath + "." + keys[0].Key
-			if xmldot.Get(body.Res(), keyPath).Exists() {
+			var checkExists string
+			if isLeafList {
+				checkExists = basePath
+			} else {
+				checkExists = basePath + "." + keys[0].Key
+			}
+			if xmldot.Get(body.Res(), checkExists).Exists() {
 				// Single element exists - check if keys match
 				allMatch := true
 				for _, kv := range keys {
-					checkPath := basePath + "." + kv.Key
+					var checkPath string
+					if kv.Key == "." {
+						checkPath = basePath
+					} else {
+						checkPath = basePath + "." + kv.Key
+					}
 					if xmldot.Get(body.Res(), checkPath).String() != kv.Value {
 						allMatch = false
 						break
@@ -625,7 +646,12 @@ func findSiblingInfo(body netconf.Body, parentPath, elementName string, keys []K
 	for i := 0; i < int(count); i++ {
 		allKeysMatch := true
 		for _, kv := range keys {
-			keyPath := fmt.Sprintf("%s.%d.%s", basePath, i, kv.Key)
+			var keyPath string
+			if kv.Key == "." {
+				keyPath = fmt.Sprintf("%s.%d", basePath, i)
+			} else {
+				keyPath = fmt.Sprintf("%s.%d.%s", basePath, i, kv.Key)
+			}
 			existingValue := xmldot.Get(body.Res(), keyPath).String()
 			if existingValue != kv.Value {
 				allKeysMatch = false
@@ -663,7 +689,13 @@ func appendSiblingElement(body netconf.Body, parentPathSegments []string, remain
 
 	// Add keys to the inner XML
 	for _, kv := range keys {
-		innerXML.WriteString(fmt.Sprintf("<%s>%s</%s>", kv.Key, html.EscapeString(kv.Value), kv.Key))
+		if kv.Key == "." {
+			// Leaf-list: the "." key means "self" in XPath — the value is the
+			// text content of the element itself, not a child element.
+			innerXML.WriteString(html.EscapeString(kv.Value))
+		} else {
+			innerXML.WriteString(fmt.Sprintf("<%s>%s</%s>", kv.Key, html.EscapeString(kv.Value), kv.Key))
+		}
 	}
 
 	// Process any nested segments after the first one

--- a/internal/provider/helpers/netconf_leaflist_test.go
+++ b/internal/provider/helpers/netconf_leaflist_test.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/netascode/go-netconf"
+)
+
+func TestRemoveFromXPath_LeafListSiblingConflict(t *testing.T) {
+	// Reproduces the bug where RemoveFromXPath with a leaf-list content predicate
+	// ([.=value]) overwrites an existing element with the same name, destroying
+	// the merge values set by AppendFromXPath (toBodyXML).
+	basePath := "/Cisco-IOS-XE-native:native/ipv6/dhcp/Cisco-IOS-XE-dhcp:pool[name='DHCPv6-PD']"
+
+	// Step 1: Simulate toBodyXML — append a leaf-list value
+	body := netconf.Body{}
+	body = SetFromXPath(body, basePath+"/name", "DHCPv6-PD")
+	body = AppendFromXPath(body, basePath+"/dns-server", "2001:4860:4860::8888")
+
+	t.Logf("After AppendFromXPath:\n%s", body.Res())
+
+	if !strings.Contains(body.Res(), "2001:4860:4860::8888") {
+		t.Fatal("Setup failed: 8888 not in body after AppendFromXPath")
+	}
+
+	// Step 2: Simulate addDeletedItemsXML — remove a different leaf-list value
+	body = RemoveFromXPath(body, basePath+"/dns-server[.=2001:4860:4860::4444]")
+
+	result := body.Res()
+	t.Logf("After RemoveFromXPath:\n%s", result)
+
+	// The merge value (8888) must still be present
+	if !strings.Contains(result, "2001:4860:4860::8888") {
+		t.Error("Merge value 8888 was destroyed by RemoveFromXPath")
+	}
+
+	// The remove element (4444 with operation="remove") must be present
+	if !strings.Contains(result, "2001:4860:4860::4444") {
+		t.Error("Remove value 4444 is not present in the XML")
+	}
+	if !strings.Contains(result, `operation="remove"`) {
+		t.Error("operation=\"remove\" attribute is not present")
+	}
+
+	// Both should coexist as sibling <dns-server> elements
+	count := strings.Count(result, "<dns-server")
+	if count < 2 {
+		t.Errorf("Expected at least 2 <dns-server> elements, got %d", count)
+	}
+}
+
+func TestRemoveFromXPath_LeafListNewElement(t *testing.T) {
+	// Test that RemoveFromXPath creates correct XML when no existing element
+	// with the same name exists (the "new" case).
+	body := netconf.Body{}
+
+	body = RemoveFromXPath(body, "/Cisco-IOS-XE-native:native/ipv6/dhcp/Cisco-IOS-XE-dhcp:pool[name='TEST']/dns-server[.=2001:db8::1]")
+
+	result := body.Res()
+	t.Logf("Result:\n%s", result)
+
+	// Should produce <dns-server operation="remove">2001:db8::1</dns-server>
+	if !strings.Contains(result, ">2001:db8::1<") {
+		t.Errorf("Expected text content '2001:db8::1', got: %s", result)
+	}
+	if !strings.Contains(result, `operation="remove"`) {
+		t.Error("Missing operation=\"remove\" attribute")
+	}
+	// Must NOT contain <.> tags
+	if strings.Contains(result, "<.>") || strings.Contains(result, "</.>") {
+		t.Error("Invalid <.> element generated — leaf-list content should be text, not a child element")
+	}
+}
+
+func TestRemoveFromXPath_MultipleLeafListDeletions(t *testing.T) {
+	// Test deleting multiple leaf-list values creates proper siblings
+	basePath := "/Cisco-IOS-XE-native:native/ipv6/dhcp/Cisco-IOS-XE-dhcp:pool[name='TEST']"
+
+	body := netconf.Body{}
+	body = SetFromXPath(body, basePath+"/name", "TEST")
+	body = AppendFromXPath(body, basePath+"/dns-server", "2001:db8::1")
+	body = RemoveFromXPath(body, basePath+"/dns-server[.=2001:db8::2]")
+	body = RemoveFromXPath(body, basePath+"/dns-server[.=2001:db8::3]")
+
+	result := body.Res()
+	t.Logf("Result:\n%s", result)
+
+	// Should have 3 dns-server elements: one merge + two removes
+	count := strings.Count(result, "<dns-server")
+	if count != 3 {
+		t.Errorf("Expected 3 <dns-server> elements, got %d", count)
+	}
+
+	if !strings.Contains(result, "2001:db8::1") {
+		t.Error("Merge value 2001:db8::1 missing")
+	}
+	if !strings.Contains(result, "2001:db8::2") {
+		t.Error("Remove value 2001:db8::2 missing")
+	}
+	if !strings.Contains(result, "2001:db8::3") {
+		t.Error("Remove value 2001:db8::3 missing")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `RemoveFromXPath` destroying existing sibling elements when called with a leaf-list content predicate (`[.=value]`)
- Affects all `StringList` type attributes using NETCONF where values are removed (e.g., `dns-server`, `domain-names`, `ip name-server`, `ip domain list`)

## Problem

When Terraform removes a value from a leaf-list attribute (e.g., removing a DNS server from `dns_servers`), the NETCONF edit-config body needs both:
- The remaining values (from `toBodyXML` / `AppendFromXPath`)
- The deleted values with `operation="remove"` (from `addDeletedItemsXML` / `RemoveFromXPath`)

The bug: `RemoveFromXPath` with `[.=value]` treated the `.` XPath self-reference as a literal child element name, generating invalid XML (`<.>value</.>`) that corrupted the entire body. The merge values were destroyed, causing perpetual drift on every plan.

## Root Cause

`buildXPathStructure` and its helpers (`findSiblingInfo`, `appendSiblingElement`) didn't handle the XPath `.` (self) key for leaf-list content predicates. Three locations needed the fix:
1. `findSiblingInfo`: check text content via element path directly (not `path + "." + "."`)
2. `buildXPathStructure` (SiblingActionNew): set value as text content of the element
3. `appendSiblingElement`: emit value as text content, not as a `<.>` child element

## Test plan

- [x] New unit tests pass (`TestRemoveFromXPath_LeafListSiblingConflict`, `TestRemoveFromXPath_LeafListNewElement`, `TestRemoveFromXPath_MultipleLeafListDeletions`)
- [x] Existing `TestRemoveFromXPath_MultipleSiblings` and `TestRemoveFromXPath_DisabledVlansScenario` still pass (no regressions)
- [x] Full build compiles
- [x] Real device validation

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: fix NETCONF leaf-list sibling handling bug discovered during IPv6 DHCP feature development
- **Human Oversight**: Code reviewed by Christopher Hart