### PR TITLE
fix: resolve Jenkins acceptance test failures across C8000V and C9000V

### DIFF
--- a/docs/resources/object_group.md
+++ b/docs/resources/object_group.md
@@ -20,7 +20,7 @@ resource "iosxe_object_group" "example" {
       description = "My FQDN object group"
       patterns = [
         {
-          fqdn_pattern = "test-fqdn-pattern"
+          fqdn_pattern = ".*\\.cisco\\.com"
         }
       ]
     }

--- a/docs/resources/snmp_server.md
+++ b/docs/resources/snmp_server.md
@@ -151,7 +151,6 @@ resource "iosxe_snmp_server" "example" {
       username                         = "USER1"
       grpname                          = "GROUP1"
       v3_auth_algorithm                = "sha"
-      v3_auth_sha2                     = "256"
       v3_auth_password                 = "Cisco123"
       v3_auth_priv_aes_algorithm       = "128"
       v3_auth_priv_aes_password        = "Cisco123"

--- a/examples/resources/iosxe_object_group/resource.tf
+++ b/examples/resources/iosxe_object_group/resource.tf
@@ -5,7 +5,7 @@ resource "iosxe_object_group" "example" {
       description = "My FQDN object group"
       patterns = [
         {
-          fqdn_pattern = "test-fqdn-pattern"
+          fqdn_pattern = ".*\\.cisco\\.com"
         }
       ]
     }

--- a/examples/resources/iosxe_snmp_server/resource.tf
+++ b/examples/resources/iosxe_snmp_server/resource.tf
@@ -136,7 +136,6 @@ resource "iosxe_snmp_server" "example" {
       username                         = "USER1"
       grpname                          = "GROUP1"
       v3_auth_algorithm                = "sha"
-      v3_auth_sha2                     = "256"
       v3_auth_password                 = "Cisco123"
       v3_auth_priv_aes_algorithm       = "128"
       v3_auth_priv_aes_password        = "Cisco123"

--- a/gen/definitions/object_group.yaml
+++ b/gen/definitions/object_group.yaml
@@ -29,7 +29,7 @@ attributes:
           - yang_name: fqdn-pattern
             tf_name: fqdn_pattern
             id: true
-            example: test-fqdn-pattern
+            example: .*\\.cisco\\.com
   - yang_name: Cisco-IOS-XE-object-group:network
     tf_name: network
     type: List

--- a/gen/definitions/snmp_server.yaml
+++ b/gen/definitions/snmp_server.yaml
@@ -935,6 +935,7 @@ attributes:
         tf_name: v3_auth_sha2
         example: 256
         write_only: true
+        test_tags: [IOSXE1715]
       - yang_name: v3/auth-config/password
         tf_name: v3_auth_password
         write_only: true

--- a/gen/definitions/snmp_server.yaml
+++ b/gen/definitions/snmp_server.yaml
@@ -935,7 +935,7 @@ attributes:
         tf_name: v3_auth_sha2
         example: 256
         write_only: true
-        test_tags: [IOSXE1715]
+        exclude_test: true
       - yang_name: v3/auth-config/password
         tf_name: v3_auth_password
         write_only: true

--- a/gen/definitions/zone_pair_security.yaml
+++ b/gen/definitions/zone_pair_security.yaml
@@ -18,3 +18,21 @@ attributes:
   - yang_name: service-policy/type/inspect
     tf_name: service_policy_type_inspect
     example: PM_IN_TO_OUT
+test_prerequisites:
+  - path: /Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=INSIDE]
+    no_delete: true
+    attributes:
+      - name: id
+        value: INSIDE
+  - path: /Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=OUTSIDE]
+    no_delete: true
+    attributes:
+      - name: id
+        value: OUTSIDE
+  - path: /Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map[name=PM_IN_TO_OUT]
+    no_delete: true
+    attributes:
+      - name: name
+        value: PM_IN_TO_OUT
+      - name: type
+        value: inspect

--- a/gen/definitions/zone_pair_security.yaml
+++ b/gen/definitions/zone_pair_security.yaml
@@ -2,6 +2,7 @@
 name: Zone Pair Security
 path: /Cisco-IOS-XE-native:native/zone-pair/Cisco-IOS-XE-zone:security[id=%v]
 no_delete_attributes: true
+test_tags: [C8000V]
 doc_category: Security
 attributes:
   - yang_name: id

--- a/internal/provider/data_source_iosxe_object_group_test.go
+++ b/internal/provider/data_source_iosxe_object_group_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceIosxeObjectGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "fqdn.0.name", "FQDN_GROUP_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "fqdn.0.description", "My FQDN object group"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "fqdn.0.patterns.0.fqdn_pattern", "test-fqdn-pattern"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "fqdn.0.patterns.0.fqdn_pattern", ".*\\.cisco\\.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "network.0.name", "NETWORK_GROUP_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "network.0.description", "My network object group"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_object_group.test", "network.0.hosts.0.ipv4_host", "10.1.1.1"))
@@ -67,7 +67,7 @@ func testAccDataSourceIosxeObjectGroupConfig() string {
 	config += `		name = "FQDN_GROUP_1"` + "\n"
 	config += `		description = "My FQDN object group"` + "\n"
 	config += `		patterns = [{` + "\n"
-	config += `			fqdn_pattern = "test-fqdn-pattern"` + "\n"
+	config += `			fqdn_pattern = ".*\\.cisco\\.com"` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
 	config += `	network = [{` + "\n"

--- a/internal/provider/data_source_iosxe_snmp_server_test.go
+++ b/internal/provider/data_source_iosxe_snmp_server_test.go
@@ -643,7 +643,9 @@ func testAccDataSourceIosxeSNMPServerConfig() string {
 	config += `		username = "USER1"` + "\n"
 	config += `		grpname = "GROUP1"` + "\n"
 	config += `		v3_auth_algorithm = "sha"` + "\n"
-	config += `		v3_auth_sha2 = "256"` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `		v3_auth_sha2 = "256"` + "\n"
+	}
 	config += `		v3_auth_password = "Cisco123"` + "\n"
 	config += `		v3_auth_priv_aes_algorithm = "128"` + "\n"
 	config += `		v3_auth_priv_aes_password = "Cisco123"` + "\n"

--- a/internal/provider/data_source_iosxe_snmp_server_test.go
+++ b/internal/provider/data_source_iosxe_snmp_server_test.go
@@ -643,9 +643,6 @@ func testAccDataSourceIosxeSNMPServerConfig() string {
 	config += `		username = "USER1"` + "\n"
 	config += `		grpname = "GROUP1"` + "\n"
 	config += `		v3_auth_algorithm = "sha"` + "\n"
-	if os.Getenv("IOSXE1715") != "" {
-		config += `		v3_auth_sha2 = "256"` + "\n"
-	}
 	config += `		v3_auth_password = "Cisco123"` + "\n"
 	config += `		v3_auth_priv_aes_algorithm = "128"` + "\n"
 	config += `		v3_auth_priv_aes_password = "Cisco123"` + "\n"

--- a/internal/provider/data_source_iosxe_zone_pair_security_test.go
+++ b/internal/provider/data_source_iosxe_zone_pair_security_test.go
@@ -41,7 +41,7 @@ func TestAccDataSourceIosxeZonePairSecurity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIosxeZonePairSecurityConfig(),
+				Config: testAccDataSourceIosxeZonePairSecurityPrerequisitesConfig + testAccDataSourceIosxeZonePairSecurityConfig(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -51,6 +51,34 @@ func TestAccDataSourceIosxeZonePairSecurity(t *testing.T) {
 // End of section. //template:end testAccDataSource
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccDataSourceIosxeZonePairSecurityPrerequisitesConfig = `
+resource "iosxe_yang" "PreReq0" {
+	path = "/Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=INSIDE]"
+	delete = false
+	attributes = {
+		"id" = "INSIDE"
+	}
+}
+
+resource "iosxe_yang" "PreReq1" {
+	path = "/Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=OUTSIDE]"
+	delete = false
+	attributes = {
+		"id" = "OUTSIDE"
+	}
+}
+
+resource "iosxe_yang" "PreReq2" {
+	path = "/Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map[name=PM_IN_TO_OUT]"
+	delete = false
+	attributes = {
+		"name" = "PM_IN_TO_OUT"
+		"type" = "inspect"
+	}
+}
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSourceConfig
@@ -62,6 +90,7 @@ func testAccDataSourceIosxeZonePairSecurityConfig() string {
 	config += `	destination = "OUTSIDE"` + "\n"
 	config += `	description = "Inside to outside traffic policy"` + "\n"
 	config += `	service_policy_type_inspect = "PM_IN_TO_OUT"` + "\n"
+	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, ]` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/data_source_iosxe_zone_pair_security_test.go
+++ b/internal/provider/data_source_iosxe_zone_pair_security_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,6 +32,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeZonePairSecurity(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_zone_pair_security.test", "source", "INSIDE"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_zone_pair_security.test", "destination", "OUTSIDE"))

--- a/internal/provider/resource_iosxe_object_group_test.go
+++ b/internal/provider/resource_iosxe_object_group_test.go
@@ -36,7 +36,7 @@ func TestAccIosxeObjectGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "fqdn.0.name", "FQDN_GROUP_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "fqdn.0.description", "My FQDN object group"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "fqdn.0.patterns.0.fqdn_pattern", "test-fqdn-pattern"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "fqdn.0.patterns.0.fqdn_pattern", ".*\\.cisco\\.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "network.0.name", "NETWORK_GROUP_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "network.0.description", "My network object group"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_object_group.test", "network.0.hosts.0.ipv4_host", "10.1.1.1"))
@@ -101,7 +101,7 @@ func testAccIosxeObjectGroupConfig_all() string {
 	config += `		name = "FQDN_GROUP_1"` + "\n"
 	config += `		description = "My FQDN object group"` + "\n"
 	config += `		patterns = [{` + "\n"
-	config += `			fqdn_pattern = "test-fqdn-pattern"` + "\n"
+	config += `			fqdn_pattern = ".*\\.cisco\\.com"` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
 	config += `	network = [{` + "\n"

--- a/internal/provider/resource_iosxe_snmp_server_test.go
+++ b/internal/provider/resource_iosxe_snmp_server_test.go
@@ -677,9 +677,6 @@ func testAccIosxeSNMPServerConfig_all() string {
 	config += `		username = "USER1"` + "\n"
 	config += `		grpname = "GROUP1"` + "\n"
 	config += `		v3_auth_algorithm = "sha"` + "\n"
-	if os.Getenv("IOSXE1715") != "" {
-		config += `		v3_auth_sha2 = "256"` + "\n"
-	}
 	config += `		v3_auth_password = "Cisco123"` + "\n"
 	config += `		v3_auth_priv_aes_algorithm = "128"` + "\n"
 	config += `		v3_auth_priv_aes_password = "Cisco123"` + "\n"

--- a/internal/provider/resource_iosxe_snmp_server_test.go
+++ b/internal/provider/resource_iosxe_snmp_server_test.go
@@ -677,7 +677,9 @@ func testAccIosxeSNMPServerConfig_all() string {
 	config += `		username = "USER1"` + "\n"
 	config += `		grpname = "GROUP1"` + "\n"
 	config += `		v3_auth_algorithm = "sha"` + "\n"
-	config += `		v3_auth_sha2 = "256"` + "\n"
+	if os.Getenv("IOSXE1715") != "" {
+		config += `		v3_auth_sha2 = "256"` + "\n"
+	}
 	config += `		v3_auth_password = "Cisco123"` + "\n"
 	config += `		v3_auth_priv_aes_algorithm = "128"` + "\n"
 	config += `		v3_auth_priv_aes_password = "Cisco123"` + "\n"

--- a/internal/provider/resource_iosxe_zone_pair_security_test.go
+++ b/internal/provider/resource_iosxe_zone_pair_security_test.go
@@ -44,10 +44,10 @@ func TestAccIosxeZonePairSecurity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIosxeZonePairSecurityConfig_minimum(),
+				Config: testAccIosxeZonePairSecurityPrerequisitesConfig + testAccIosxeZonePairSecurityConfig_minimum(),
 			},
 			{
-				Config: testAccIosxeZonePairSecurityConfig_all(),
+				Config: testAccIosxeZonePairSecurityPrerequisitesConfig + testAccIosxeZonePairSecurityConfig_all(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 			{
@@ -78,6 +78,34 @@ func iosxeZonePairSecurityImportStateIdFunc(resourceName string) resource.Import
 // End of section. //template:end importStateIdFunc
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testPrerequisites
+const testAccIosxeZonePairSecurityPrerequisitesConfig = `
+resource "iosxe_yang" "PreReq0" {
+	path = "/Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=INSIDE]"
+	delete = false
+	attributes = {
+		"id" = "INSIDE"
+	}
+}
+
+resource "iosxe_yang" "PreReq1" {
+	path = "/Cisco-IOS-XE-native:native/zone/Cisco-IOS-XE-zone:security[id=OUTSIDE]"
+	delete = false
+	attributes = {
+		"id" = "OUTSIDE"
+	}
+}
+
+resource "iosxe_yang" "PreReq2" {
+	path = "/Cisco-IOS-XE-native:native/policy/Cisco-IOS-XE-policy:policy-map[name=PM_IN_TO_OUT]"
+	delete = false
+	attributes = {
+		"name" = "PM_IN_TO_OUT"
+		"type" = "inspect"
+	}
+}
+
+`
+
 // End of section. //template:end testPrerequisites
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigMinimal
@@ -87,6 +115,7 @@ func testAccIosxeZonePairSecurityConfig_minimum() string {
 	config += `	name = "ZP_IN_OUT"` + "\n"
 	config += `	source = "INSIDE"` + "\n"
 	config += `	destination = "OUTSIDE"` + "\n"
+	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, ]` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -102,6 +131,7 @@ func testAccIosxeZonePairSecurityConfig_all() string {
 	config += `	destination = "OUTSIDE"` + "\n"
 	config += `	description = "Inside to outside traffic policy"` + "\n"
 	config += `	service_policy_type_inspect = "PM_IN_TO_OUT"` + "\n"
+	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, ]` + "\n"
 	config += `}` + "\n"
 	return config
 }

--- a/internal/provider/resource_iosxe_zone_pair_security_test.go
+++ b/internal/provider/resource_iosxe_zone_pair_security_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeZonePairSecurity(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_zone_pair_security.test", "name", "ZP_IN_OUT"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_zone_pair_security.test", "source", "INSIDE"))


### PR DESCRIPTION
## Summary

Fixes acceptance test failures in the internal Jenkins CI pipeline caused by recently-merged features that introduced invalid test data, missing prerequisites, platform-incompatible configurations, and test-isolation conflicts.

- **Object Group**: FQDN pattern `test-fqdn-pattern` rejected by device — must use regex with escaped dots (e.g. `.*\.cisco\.com`)
- **SNMP Server**: SNMPv3 SHA-2 256 auth (`v3_auth_sha2`) and `v3_auth_algorithm` are mutually exclusive — excluded SHA-2 from tests since the generator combines all attributes in a single user block
- **Zone Pair Security**: Test missing prerequisites (security zones + inspect policy-map); also skip on C9000V since ZBFW is router-only
- **BGP IPv6 AF/VRF/Neighbor**: Destroy failures caused by `ipv6 unicast-routing` prerequisite being removed while VRF1 (persisted via `no_delete`) still depends on it — fixed by marking the ipv6 prerequisite as `no_delete: true`
- **IPv6 Local Pool / DHCP Pool**: `ipv6/local` YANG path unavailable on all virtual platforms — skipped via `test_tags: [ISR]`

## Verification

All tests verified passing on local lab devices:

| Test | 17.12 C8000V | 17.15 C8000V | 17.15 C9000V |
|------|:---:|:---:|:---:|
| Object Group | ✅ | ✅ | ✅ |
| SNMP Server | ✅ | ✅ | ✅ |
| Zone Pair Security | ✅ | ✅ | ⏭️ SKIP |
| BGP IPv6 AF | ✅ | — | — |
| BGP IPv6 VRF | ✅ | — | — |
| BGP IPv6 Unicast Neighbor | ✅ | — | — |
| IPv6 Local Pool | ⏭️ SKIP | — | ⏭️ SKIP |
| IPv6 DHCP Pool | ⏭️ SKIP | — | ⏭️ SKIP |

## Root Cause Analysis

**BGP IPv6 destroy failures** (the hardest to diagnose): The IPv6 VRF test creates VRF1 with `address-family ipv6` and `no_delete: true`, so VRF1 persists across tests. Later, BGP IPv6 AF tests create `ipv6 unicast-routing` as a prerequisite. On destroy, the test tries to DELETE `/native/ipv6` which removes `ipv6 unicast-routing` — but the device refuses because VRF1 still depends on IPv6 routing being enabled. Fix: mark the `/native/ipv6` prerequisite as `no_delete: true` so it is never torn down.

## Known Remaining Issues

- **NTP and System test failures**: Observed in full local suite run but not yet investigated. May be separate issues unrelated to the BGP/IPv6 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)