### PR TITLE
fix: resolve BGP IPv6 destroy failures and skip IPv6 local pool tests

### DIFF
--- a/gen/definitions/bgp_address_family_ipv6.yaml
+++ b/gen/definitions/bgp_address_family_ipv6.yaml
@@ -40,6 +40,7 @@ attributes:
         example: true
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/ipv6
+    no_delete: true
     attributes:
       - name: unicast-routing
         value: ""

--- a/gen/definitions/bgp_address_family_ipv6_vrf.yaml
+++ b/gen/definitions/bgp_address_family_ipv6_vrf.yaml
@@ -53,6 +53,7 @@ attributes:
             example: false
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/ipv6
+    no_delete: true
     attributes:
       - name: unicast-routing
         value: ""

--- a/gen/definitions/bgp_ipv6_unicast_neighbor.yaml
+++ b/gen/definitions/bgp_ipv6_unicast_neighbor.yaml
@@ -38,6 +38,7 @@ attributes:
         example: RM1
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/ipv6
+    no_delete: true
     attributes:
       - name: unicast-routing
         value: ""

--- a/gen/definitions/ipv6_dhcp_pool.yaml
+++ b/gen/definitions/ipv6_dhcp_pool.yaml
@@ -1,6 +1,7 @@
 ---
 name: IPv6 DHCP Pool
 path: /Cisco-IOS-XE-native:native/ipv6/dhcp/Cisco-IOS-XE-dhcp:pool[name=%s]
+test_tags: [ISR]
 doc_category: System
 attributes:
   - yang_name: name

--- a/gen/definitions/ipv6_local_pool.yaml
+++ b/gen/definitions/ipv6_local_pool.yaml
@@ -1,6 +1,7 @@
 ---
 name: IPv6 Local Pool
 path: /Cisco-IOS-XE-native:native/ipv6/local/pool[id=%s]
+test_tags: [ISR]
 doc_category: System
 attributes:
   - yang_name: id

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv6_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv6_test.go
@@ -59,6 +59,7 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv6(t *testing.T) {
 const testAccDataSourceIosxeBGPAddressFamilyIPv6PrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/data_source_iosxe_bgp_address_family_ipv6_vrf_test.go
+++ b/internal/provider/data_source_iosxe_bgp_address_family_ipv6_vrf_test.go
@@ -62,6 +62,7 @@ func TestAccDataSourceIosxeBGPAddressFamilyIPv6VRF(t *testing.T) {
 const testAccDataSourceIosxeBGPAddressFamilyIPv6VRFPrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/data_source_iosxe_bgp_ipv6_unicast_neighbor_test.go
+++ b/internal/provider/data_source_iosxe_bgp_ipv6_unicast_neighbor_test.go
@@ -58,6 +58,7 @@ func TestAccDataSourceIosxeBGPIPv6UnicastNeighbor(t *testing.T) {
 const testAccDataSourceIosxeBGPIPv6UnicastNeighborPrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/data_source_iosxe_ipv6_dhcp_pool_test.go
+++ b/internal/provider/data_source_iosxe_ipv6_dhcp_pool_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,6 +32,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeIPv6DHCPPool(t *testing.T) {
+	if os.Getenv("ISR") == "" {
+		t.Skip("skipping test, set environment variable ISR")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ipv6_dhcp_pool.test", "prefix_delegation_pool_name", "DHCPv6-PD"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ipv6_dhcp_pool.test", "dns_servers.0", "2001:4860:4860::8888"))

--- a/internal/provider/data_source_iosxe_ipv6_local_pool_test.go
+++ b/internal/provider/data_source_iosxe_ipv6_local_pool_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,6 +32,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeIPv6LocalPool(t *testing.T) {
+	if os.Getenv("ISR") == "" {
+		t.Skip("skipping test, set environment variable ISR")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ipv6_local_pool.test", "start_address", "2001:db8::/48"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ipv6_local_pool.test", "prefix_length", "64"))

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv6_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv6_test.go
@@ -87,6 +87,7 @@ func iosxeBGPAddressFamilyIPv6ImportStateIdFunc(resourceName string) resource.Im
 const testAccIosxeBGPAddressFamilyIPv6PrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/resource_iosxe_bgp_address_family_ipv6_vrf_test.go
+++ b/internal/provider/resource_iosxe_bgp_address_family_ipv6_vrf_test.go
@@ -87,6 +87,7 @@ func iosxeBGPAddressFamilyIPv6VRFImportStateIdFunc(resourceName string) resource
 const testAccIosxeBGPAddressFamilyIPv6VRFPrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/resource_iosxe_bgp_ipv6_unicast_neighbor_test.go
+++ b/internal/provider/resource_iosxe_bgp_ipv6_unicast_neighbor_test.go
@@ -86,6 +86,7 @@ func iosxeBGPIPv6UnicastNeighborImportStateIdFunc(resourceName string) resource.
 const testAccIosxeBGPIPv6UnicastNeighborPrerequisitesConfig = `
 resource "iosxe_yang" "PreReq0" {
 	path = "/Cisco-IOS-XE-native:native/ipv6"
+	delete = false
 	attributes = {
 		"unicast-routing" = ""
 	}

--- a/internal/provider/resource_iosxe_ipv6_dhcp_pool_test.go
+++ b/internal/provider/resource_iosxe_ipv6_dhcp_pool_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeIPv6DHCPPool(t *testing.T) {
+	if os.Getenv("ISR") == "" {
+		t.Skip("skipping test, set environment variable ISR")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ipv6_dhcp_pool.test", "name", "DHCPv6-PD"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ipv6_dhcp_pool.test", "prefix_delegation_pool_name", "DHCPv6-PD"))

--- a/internal/provider/resource_iosxe_ipv6_local_pool_test.go
+++ b/internal/provider/resource_iosxe_ipv6_local_pool_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeIPv6LocalPool(t *testing.T) {
+	if os.Getenv("ISR") == "" {
+		t.Skip("skipping test, set environment variable ISR")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ipv6_local_pool.test", "name", "DHCPv6-PD"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ipv6_local_pool.test", "start_address", "2001:db8::/48"))


### PR DESCRIPTION
## Summary

Fixes BGP IPv6 acceptance test destroy failures and skips IPv6 local pool tests that require physical hardware not available in CI.

- **BGP IPv6 AF/VRF/Neighbor**: Destroy failures caused by `ipv6 unicast-routing` prerequisite being removed while VRF1 (persisted via `no_delete`) still depends on IPv6 routing. Fix: mark the `/native/ipv6` prerequisite as `no_delete: true`.
- **IPv6 Local Pool / DHCP Pool**: `ipv6 local pool` CLI is not available on virtual platforms (C8000V, C9000V). Skip via `test_tags: [ISR]`. Note: the `ISR` environment variable is intentionally not set by any CI stage — this effectively excludes these tests from running until a physical ISR/ASR device is added to the test lab.

## Root Cause (BGP IPv6)

The IPv6 VRF test creates VRF1 with `address-family ipv6` and `no_delete: true`, so VRF1 persists across tests. Later, BGP IPv6 AF tests attempt to DELETE `/native/ipv6` (removing `ipv6 unicast-routing`) during their destroy phase. The device refuses because VRF1 still depends on IPv6 routing being enabled. Adding `no_delete: true` to the ipv6 prerequisite prevents this conflict.

Reproduced locally by running the full test suite against a 17.12 C8000V — the minimal reproduction sequence is:
1. `TestAccDataSourceIosxeBGPAddressFamilyIPv6VRF` (leaves VRF1 with IPv6 AF)
2. `TestAccIosxeBGPAddressFamilyIPv4VRF` (creates/destroys router bgp)
3. `TestAccIosxeBGPAddressFamilyIPv6` (destroy fails on ipv6 prerequisite removal)

## Root Cause (IPv6 Local Pool)

The `ipv6 local pool` CLI command is not implemented on C8000V/C9000V virtual platforms. The YANG model defines the path but the device refuses all configuration attempts. Requires a physical ISR/ASR for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)