### PR TITLE
fix: gate C9000v-incompatible test attributes behind C8000V

### DIFF
--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -17,7 +17,6 @@ resource "iosxe_interface_port_channel" "example" {
   name                           = 10
   description                    = "My Interface Description"
   shutdown                       = false
-  mtu                            = 1500
   switchport                     = false
   ip_proxy_arp                   = false
   ip_redirects                   = false

--- a/examples/resources/iosxe_interface_port_channel/resource.tf
+++ b/examples/resources/iosxe_interface_port_channel/resource.tf
@@ -2,7 +2,6 @@ resource "iosxe_interface_port_channel" "example" {
   name                           = 10
   description                    = "My Interface Description"
   shutdown                       = false
-  mtu                            = 1500
   switchport                     = false
   ip_proxy_arp                   = false
   ip_redirects                   = false

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -11,6 +11,7 @@ attributes:
   - yang_name: shutdown
     example: false
   - yang_name: mtu
+    test_tags: [C8000V]
     example: 1500
   - yang_name: switchport-conf/switchport
     tf_name: switchport

--- a/gen/definitions/interface_tunnel.yaml
+++ b/gen/definitions/interface_tunnel.yaml
@@ -2,6 +2,7 @@
 name: Interface Tunnel
 path: /Cisco-IOS-XE-native:native/interface/Tunnel[name=%s]
 doc_category: Interface
+test_tags: [C8000V]
 no_delete:
 attributes:
   - yang_name: name

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -38,7 +38,9 @@ func TestAccDataSourceIosxeInterfacePortChannel(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "description", "My Interface Description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "shutdown", "false"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "mtu", "1500"))
+	if os.Getenv("C8000V") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "mtu", "1500"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "switchport", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_proxy_arp", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_redirects", "false"))
@@ -187,7 +189,9 @@ func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 	config += `	name = 10` + "\n"
 	config += `	description = "My Interface Description"` + "\n"
 	config += `	shutdown = false` + "\n"
-	config += `	mtu = 1500` + "\n"
+	if os.Getenv("C8000V") != "" {
+		config += `	mtu = 1500` + "\n"
+	}
 	config += `	switchport = false` + "\n"
 	config += `	ip_proxy_arp = false` + "\n"
 	config += `	ip_redirects = false` + "\n"

--- a/internal/provider/data_source_iosxe_interface_tunnel_test.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel_test.go
@@ -32,6 +32,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeInterfaceTunnel(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "description", "My Interface Description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "shutdown", "false"))

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -41,7 +41,9 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "name", "10"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "description", "My Interface Description"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "shutdown", "false"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "mtu", "1500"))
+	if os.Getenv("C8000V") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "mtu", "1500"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "switchport", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_proxy_arp", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_redirects", "false"))
@@ -225,7 +227,9 @@ func testAccIosxeInterfacePortChannelConfig_all() string {
 	config += `	name = 10` + "\n"
 	config += `	description = "My Interface Description"` + "\n"
 	config += `	shutdown = false` + "\n"
-	config += `	mtu = 1500` + "\n"
+	if os.Getenv("C8000V") != "" {
+		config += `	mtu = 1500` + "\n"
+	}
 	config += `	switchport = false` + "\n"
 	config += `	ip_proxy_arp = false` + "\n"
 	config += `	ip_redirects = false` + "\n"

--- a/internal/provider/resource_iosxe_interface_tunnel_test.go
+++ b/internal/provider/resource_iosxe_interface_tunnel_test.go
@@ -34,6 +34,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeInterfaceTunnel(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "name", "90"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "description", "My Interface Description"))


### PR DESCRIPTION
## Summary

- Gate `TestAccIosxeInterfaceTunnel` behind `C8000V` — `tunnel bandwidth receive/transmit` is not supported on C9000v
- Gate `mtu` attribute in `TestAccIosxeInterfacePortChannel` behind `C8000V` — the YANG-to-CLI translator applies `mtu` before `no switchport`, and MTU is invalid on switchport-mode interfaces

## Context

The C9000v 17.15.1 CI stage was failing on 6 tests, with 2 root causes and 4 cascading failures:

| Root cause | Cascading failures |
|---|---|
| `mtu 1500` rejected on Port-channel (applied before `no switchport` in CLI) | FlowMonitor, EVPNEthernetSegment (dangling Port-channel10 with MON1 reference) |
| `tunnel bandwidth receive/transmit` unsupported on C9000v | DataSource variants of both tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)