### PR TITLE
fix: prevent NETCONF session exhaustion during acceptance tests

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,7 +78,9 @@ type IosxeProvider struct {
 	// version is set to the provider version on release, "dev" when the
 	// provider is built and ran locally, and "test" when running acceptance
 	// testing.
-	version string
+	version    string
+	lastData   *IosxeProviderData
+	lastDataMu sync.Mutex
 }
 
 // IosxeProviderModel describes the provider data model.
@@ -221,6 +223,19 @@ func (p *IosxeProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 }
 
 func (p *IosxeProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// Close any previously-configured NETCONF connections to prevent session
+	// exhaustion. The terraform-plugin-framework does not provide a shutdown
+	// hook, so connections from prior Configure calls would otherwise leak.
+	p.lastDataMu.Lock()
+	if p.lastData != nil {
+		for _, device := range p.lastData.Devices {
+			if device.NetconfClient != nil {
+				device.NetconfClient.Close()
+			}
+		}
+	}
+	p.lastDataMu.Unlock()
+
 	// Retrieve provider data from configuration
 	var config IosxeProviderModel
 	diags := req.Config.Get(ctx, &config)
@@ -630,6 +645,11 @@ func (p *IosxeProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 	resp.DataSourceData = &data
 	resp.ResourceData = &data
+
+	// Store reference for cleanup on next Configure call
+	p.lastDataMu.Lock()
+	p.lastData = &data
+	p.lastDataMu.Unlock()
 }
 
 func (p *IosxeProvider) Resources(_ context.Context) []func() resource.Resource {


### PR DESCRIPTION
## Summary

- Close stale NETCONF connections at the start of `Configure` to prevent session accumulation across repeated provider initializations
- Target `./internal/provider/` in Makefile test targets so `go test` streams per-test results in real-time

## Problem

The `terraform-plugin-framework` does not provide a provider shutdown hook. When acceptance tests run sequentially in the same process, each test triggers a new `Configure` call that creates a fresh NETCONF client — but the previous client's session is never explicitly closed. Sessions accumulate until the device's `netconf-yang ssh max-sessions` limit (typically 16) is hit, causing all subsequent tests to fail with `errConnectionError`.

This manifests as a "cliff" where the first N tests pass and all remaining tests fail with connection errors, despite the device being reachable.

## Root Cause

The Terraform plugin framework stores provider data (`resp.ResourceData`) per-server but overwrites it on each `Configure` call without any cleanup of the prior value. The framework's `StopProvider` RPC is never called for proto6 providers in the test harness, and even if it were, the framework's implementation only cancels contexts — it doesn't invoke user-defined teardown.

## Fix

Store a reference to the previous `IosxeProviderData` on the provider struct. At the top of each `Configure` call, iterate over the previous data's devices and explicitly close any NETCONF clients before establishing new connections. This bounds session usage to at most one active session per device regardless of how many times `Configure` is called.

## Workaround

If running tests locally and still encountering session exhaustion (e.g., on devices with very low session limits), setting `IOSXE_REUSE_CONNECTION=false` in the environment or `.env` file will cause each NETCONF operation to open and close its own session rather than holding it open. This eliminates session accumulation at the cost of slower test execution:

```bash
IOSXE_REUSE_CONNECTION=false make test-1715-router
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~80%
- **AI Reason**: root cause analysis + implementation
- **Human Oversight**: Code reviewed and tested by Christopher Hart

🤖 Generated with [Claude Code](https://claude.com/claude-code)