### PR TITLE
fix(banner): return raw config value in plan modifier during drift recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source

--- a/internal/provider/helpers/plan_modifiers.go
+++ b/internal/provider/helpers/plan_modifiers.go
@@ -90,6 +90,8 @@ func (m netconfTrailingWhitespaceTrimModifier) PlanModifyString(ctx context.Cont
 		return
 	}
 
-	// Values are different - use the normalized config value
-	resp.PlanValue = types.StringValue(configNormalized)
+	// Values are genuinely different (real config change or drift recovery).
+	// Return the raw config value so Terraform's plan validation passes —
+	// it requires planned value == config value when changing.
+	resp.PlanValue = req.ConfigValue
 }

--- a/internal/provider/helpers/plan_modifiers_test.go
+++ b/internal/provider/helpers/plan_modifiers_test.go
@@ -85,6 +85,9 @@ func TestNetconfTrailingWhitespaceTrimModifier_UpdateMultilineMatch(t *testing.T
 }
 
 func TestNetconfTrailingWhitespaceTrimModifier_UpdateValuesDiffer(t *testing.T) {
+	// When config and state are genuinely different (drift or intentional change),
+	// the plan modifier must return the raw config value to satisfy Terraform's
+	// plan validation (planned value must == config value when changing).
 	modifier := UseNetconfTrailingWhitespaceTrimming()
 	req := planmodifier.StringRequest{
 		ConfigValue: types.StringValue("New banner text  "),
@@ -97,7 +100,8 @@ func TestNetconfTrailingWhitespaceTrimModifier_UpdateValuesDiffer(t *testing.T) 
 
 	modifier.PlanModifyString(context.Background(), req, resp)
 
-	expected := "New banner text"
+	// Must return raw config value, not normalized, to pass Terraform plan validation
+	expected := "New banner text  "
 	if resp.PlanValue.ValueString() != expected {
 		t.Errorf("UPDATE values differ: got %q, want %q", resp.PlanValue.ValueString(), expected)
 	}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source


### PR DESCRIPTION
## Summary

Fixes "Provider produced invalid plan" error for banner resources when recovering from device drift (e.g. after an offline configuration change).

The banner plan modifier (`UseNetconfTrailingWhitespaceTrimming`) normalizes trailing whitespace to prevent false drift between config and NETCONF/RESTCONF responses (see #686). However, when the device state genuinely differs from the config — such as after an out-of-band change — the modifier was returning a *normalized* config value. This is a third value that matches neither the raw config nor the prior state, which Terraform rejects:

```
Error: Provider produced invalid plan

planned value cty.StringVal("...*") does not match config value
cty.StringVal("...*\n") nor prior value cty.StringVal("OFFLINE CHANGE...").
```

The fix returns the raw config value (`req.ConfigValue`) in the genuine-change case instead of the normalized value. The normalization is still used for the *comparison* that detects false drift, preserving idempotency.

## Reproduction

1. Apply a multi-line banner with a YAML `|` block scalar (which includes a trailing newline)
2. Make an out-of-band change to the banner on the device
3. Run `terraform plan` → "Provider produced invalid plan" error

## Changes

- `internal/provider/helpers/plan_modifiers.go` — Return `req.ConfigValue` instead of `types.StringValue(configNormalized)` when config and state genuinely differ
- `internal/provider/helpers/plan_modifiers_test.go` — Updated "values differ" test to expect raw config value

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~80%
- **AI Reason**: bug diagnosis, fix implementation, and test verification
- **Human Oversight**: Code reviewed and approved by Christopher Hart