### PR TITLE
fix(netconf): add namespace augmentation to AppendFromXPath for intermediate elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add `lifetime`, `match_address_local_interface_loopback`, and `match_address_local_interface_loopback_legacy` attributes to `iosxe_crypto_ikev2_profile` resource and data source. The `match_address_local_interface_loopback` attribute is a list targeting the 17.18+ `interface-options-local` YANG path. The `match_address_local_interface_loopback_legacy` attribute is a scalar for pre-17.18 compatibility using the deprecated `interface-options` path.
 - Add `set_pfs_group`, `set_security_association_lifetime_seconds`, and `set_security_association_lifetime_seconds_legacy` attributes to `iosxe_crypto_ipsec_profile` resource and data source
 - Add `v3_auth_sha2` attribute to `iosxe_snmp_server` resource and data source for SNMPv3 user SHA-2 authentication (SHA-256, SHA-384, SHA-512)
+- Fix missing NETCONF namespace declaration on intermediate XML elements when `AppendFromXPath` is the first function to create a container with a namespace-prefixed path. This caused `unknown-element` errors for any leaf-list attribute under an augmented container (e.g., `set_communities` in `iosxe_route_map` under `Cisco-IOS-XE-bgp:bgp-route-map-set`) when no sibling scalar attribute was also configured.
 - Fix panic in route-map (and other list-entry resources) when adding a new entry before an existing one that contains list-type match/set attributes. The `getDeletedItems` (RESTCONF) and `addDeletedItemsXML` (NETCONF) functions had swapped loop indices when comparing list element values between state and plan.
 
 ## 0.17.0

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -41,6 +41,7 @@ description: |-
 - Add `lifetime`, `match_address_local_interface_loopback`, and `match_address_local_interface_loopback_legacy` attributes to `iosxe_crypto_ikev2_profile` resource and data source. The `match_address_local_interface_loopback` attribute is a list targeting the 17.18+ `interface-options-local` YANG path. The `match_address_local_interface_loopback_legacy` attribute is a scalar for pre-17.18 compatibility using the deprecated `interface-options` path.
 - Add `set_pfs_group`, `set_security_association_lifetime_seconds`, and `set_security_association_lifetime_seconds_legacy` attributes to `iosxe_crypto_ipsec_profile` resource and data source
 - Add `v3_auth_sha2` attribute to `iosxe_snmp_server` resource and data source for SNMPv3 user SHA-2 authentication (SHA-256, SHA-384, SHA-512)
+- Fix missing NETCONF namespace declaration on intermediate XML elements when `AppendFromXPath` is the first function to create a container with a namespace-prefixed path. This caused `unknown-element` errors for any leaf-list attribute under an augmented container (e.g., `set_communities` in `iosxe_route_map` under `Cisco-IOS-XE-bgp:bgp-route-map-set`) when no sibling scalar attribute was also configured.
 - Fix panic in route-map (and other list-entry resources) when adding a new entry before an existing one that contains list-type match/set attributes. The `getDeletedItems` (RESTCONF) and `addDeletedItemsXML` (NETCONF) functions had swapped loop indices when comparing list element values between state and plan.
 
 ## 0.17.0

--- a/internal/provider/helpers/netconf.go
+++ b/internal/provider/helpers/netconf.go
@@ -1162,6 +1162,12 @@ func AppendFromXPath(body netconf.Body, xPath string, value any) netconf.Body {
 		body = setWithNamespaces(body, fullPath, value)
 	}
 
+	// Augment namespaces for intermediate path elements using the original xPath
+	// which preserves namespace prefixes (e.g. "Cisco-IOS-XE-bgp:bgp-route-map-set").
+	// setWithNamespaces only receives cleaned pathSegments and cannot detect these.
+	dotXPath := strings.ReplaceAll(strings.TrimPrefix(xPath, "/"), "/", ".")
+	body = augmentNamespaces(body, dotXPath)
+
 	return body
 }
 

--- a/internal/provider/helpers/netconf_test.go
+++ b/internal/provider/helpers/netconf_test.go
@@ -1466,6 +1466,54 @@ func TestAppendFromXPath_EmptyValue(t *testing.T) {
 	t.Log("✓ Empty values (presence containers) appended successfully")
 }
 
+// TestAppendFromXPath_IntermediateNamespace verifies that AppendFromXPath adds xmlns
+// declarations to intermediate path elements with namespace prefixes, even when no
+// prior SetFromXPath call has created the container structure.
+// Reproduces issue #1403: route-map set_communities fails when it's the only BGP
+// attribute because bgp-route-map-set is missing its xmlns declaration.
+func TestAppendFromXPath_IntermediateNamespace(t *testing.T) {
+	body := netconf.Body{}
+	body = AppendFromXPath(body, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list", "1:1")
+	body = AppendFromXPath(body, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list", "2:2")
+
+	t.Log("Generated XML:")
+	t.Log(body.Res())
+
+	// Verify values were appended
+	r0 := xmldot.Get(body.Res(), "set.bgp-route-map-set.bgp-community.community-well-known.community-list.0")
+	r1 := xmldot.Get(body.Res(), "set.bgp-route-map-set.bgp-community.community-well-known.community-list.1")
+	if r0.String() != "1:1" {
+		t.Errorf("Expected first community-list to be '1:1', got '%s'", r0.String())
+	}
+	if r1.String() != "2:2" {
+		t.Errorf("Expected second community-list to be '2:2', got '%s'", r1.String())
+	}
+
+	// Verify xmlns is present on the intermediate bgp-route-map-set element
+	if !strings.Contains(body.Res(), `xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-bgp"`) {
+		t.Errorf("Missing Cisco-IOS-XE-bgp namespace declaration on bgp-route-map-set element.\nGot: %s", body.Res())
+	}
+}
+
+// TestAppendFromXPath_IntermediateNamespaceIdempotent verifies that calling
+// AppendFromXPath multiple times does not duplicate xmlns declarations.
+func TestAppendFromXPath_IntermediateNamespaceIdempotent(t *testing.T) {
+	body := netconf.Body{}
+	body = AppendFromXPath(body, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list", "1:1")
+	body = AppendFromXPath(body, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list", "2:2")
+	body = AppendFromXPath(body, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list", "3:3")
+
+	t.Log("Generated XML:")
+	t.Log(body.Res())
+
+	// Count xmlns occurrences — should appear exactly once
+	xmlStr := body.Res()
+	count := strings.Count(xmlStr, `xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-bgp"`)
+	if count != 1 {
+		t.Errorf("Expected exactly 1 xmlns declaration for Cisco-IOS-XE-bgp, got %d.\nXML: %s", count, xmlStr)
+	}
+}
+
 // TestRemoveFromXPath_DebugCleanup tests the cleanup mechanism in isolation
 func TestRemoveFromXPath_DebugCleanup(t *testing.T) {
 	body := netconf.Body{}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -41,6 +41,7 @@ description: |-
 - Add `lifetime`, `match_address_local_interface_loopback`, and `match_address_local_interface_loopback_legacy` attributes to `iosxe_crypto_ikev2_profile` resource and data source. The `match_address_local_interface_loopback` attribute is a list targeting the 17.18+ `interface-options-local` YANG path. The `match_address_local_interface_loopback_legacy` attribute is a scalar for pre-17.18 compatibility using the deprecated `interface-options` path.
 - Add `set_pfs_group`, `set_security_association_lifetime_seconds`, and `set_security_association_lifetime_seconds_legacy` attributes to `iosxe_crypto_ipsec_profile` resource and data source
 - Add `v3_auth_sha2` attribute to `iosxe_snmp_server` resource and data source for SNMPv3 user SHA-2 authentication (SHA-256, SHA-384, SHA-512)
+- Fix missing NETCONF namespace declaration on intermediate XML elements when `AppendFromXPath` is the first function to create a container with a namespace-prefixed path. This caused `unknown-element` errors for any leaf-list attribute under an augmented container (e.g., `set_communities` in `iosxe_route_map` under `Cisco-IOS-XE-bgp:bgp-route-map-set`) when no sibling scalar attribute was also configured.
 - Fix panic in route-map (and other list-entry resources) when adding a new entry before an existing one that contains list-type match/set attributes. The `getDeletedItems` (RESTCONF) and `addDeletedItemsXML` (NETCONF) functions had swapped loop indices when comparing list element values between state and plan.
 
 ## 0.17.0


### PR DESCRIPTION
## Summary

`AppendFromXPath` was not adding `xmlns` declarations to intermediate XML elements when it was the first function to create a container structure with namespace-prefixed paths (e.g., `Cisco-IOS-XE-bgp:bgp-route-map-set`). This caused IOS-XE to reject NETCONF payloads with `unknown-element` errors for any leaf-list attribute under an augmented YANG container when no sibling scalar attribute was also configured.

**Root cause**: `SetFromXPath` correctly calls `augmentNamespaces` with the original xPath (preserving namespace prefixes), but `AppendFromXPath` only passed the cleaned `pathSegments` (namespace prefixes stripped) to `setWithNamespaces`, so `augmentNamespaces` could never detect intermediate namespaces.

**Example**: A route-map with only `set_communities` configured (leaf-list under `bgp-route-map-set`) would fail because `AppendFromXPath` created `<bgp-route-map-set>` without xmlns. Adding `set_as_path_prepend_as` (scalar via `SetFromXPath`) masked the bug by establishing xmlns on the container first.

## Fix

Add the same `augmentNamespaces` call to `AppendFromXPath` that `SetFromXPath` already uses — converting the original xPath to dot notation and augmenting namespaces for all intermediate elements. The call is idempotent (`augmentNamespaces` checks for existing xmlns before adding), so resources where `SetFromXPath` already established the namespace are unaffected.

## Affected Resources

Any resource using `AppendFromXPath` with a namespace-prefixed intermediate path over NETCONF:

- `iosxe_route_map` — `set_communities`, `set_extcomunity_rt`, `match_community_lists`, `match_extcommunity_lists`, `match_as_paths`, `match_local_preferences`
- `iosxe_cts` — `role_based_enforcement_vlan_lists`, `role_based_permissions_default_acl_name`
- `iosxe_snmp_server` — `enable_traps_bgp_cbgp2_state_changes`

## Validation

Tested on C8000v (IOS-XE 17.15) over NETCONF. The following attributes were deployed as the sole leaf-list under their respective augmented container (the exact scenario that triggered `unknown-element` prior to this fix):

| Attribute | Create | Idempotent | Destroy |
|-----------|--------|------------|--------|
| `set_extcomunity_rt` | ✅ | ✅ | ✅ |
| `match_local_preferences` | ✅ | ✅ | ✅ |
| `match_community_lists` | ✅ | ✅ | ✅ |
| `set_communities` | ✅ | ⚠️ pre-existing drift* | ✅ |

\* `set_communities` shows drift on refresh due to a pre-existing community numeric normalization issue (`"1:1"` → `"65537"`) unrelated to this fix.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~85%
- **AI Reason**: root cause analysis + fix implementation + validation
- **Human Oversight**: Code reviewed and validated by Christopher Hart