### PR TITLE
fix(route_map): normalize decimal community values to AA:NN on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source

--- a/gen/definitions/route_map.yaml
+++ b/gen/definitions/route_map.yaml
@@ -233,6 +233,7 @@ attributes:
       - yang_name: set/community/community-well-known-choice/community-well-known/community-well-known/community-list
         xpath: set/community/community-well-known/community-list
         tf_name: set_communities_legacy
+        read_filter: GetNormalizedCommunityList
         example: "no-export"
         test_tags: [IOSXE1712]
       - yang_name: set/community/community-well-known-choice/community-well-known/community-well-known/additive
@@ -311,6 +312,7 @@ attributes:
       - yang_name: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known-choice/community-well-known/community-well-known/community-list
         xpath: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list
         tf_name: set_communities
+        read_filter: GetNormalizedCommunityList
         example: "no-export"
         description: "BGP community value - can be a number (AA:NN format) or well-known value (internet, local-AS, no-advertise, no-export, gshut)"
       - yang_name: set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known-choice/community-well-known/community-well-known/additive

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -149,6 +149,7 @@ type YamlConfigAttribute struct {
 	NoAugmentConfig    bool                  `yaml:"no_augment_config"`
 	DeleteParent       bool                  `yaml:"delete_parent"`
 	NoDelete           bool                  `yaml:"no_delete"`
+	ReadFilter         string                `yaml:"read_filter"`
 	TestTags           []string              `yaml:"test_tags"`
 	Attributes         []YamlConfigAttribute `yaml:"attributes"`
 }

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -45,6 +45,7 @@ attribute:
   no_augment_config: bool(required=False)  # Set to true if the attribute should not be augmented by the YANG models
   delete_parent: bool(required=False)  # Set to true if the attribute should delete the parent YANG element when the attribute is deleted
   no_delete: bool(required=False)  # Set to true if the attribute should not be deleted
+  read_filter: str(required=False)  # Name of a Go helper function used to normalize values on read (e.g., community AA:NN normalization)
   test_tags: list(str(), required=False)  # List of test tags, tests are only executed if an environment variable for each of these tags is configured
   attributes: list(include('attribute'), required=False)  # List of attributes in case of a list
 

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -590,7 +590,11 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := res.Get(prefix+"{{toDotPath .XPath}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringList(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -677,7 +681,11 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 		}
 		{{- else if eq .Type "StringList"}}
 		if value := r.Get("{{toDotPath .XPath}}"); value.Exists() && !data.{{$list}}[i].{{toGoName .TfName}}.IsNull() {
+			{{- if .ReadFilter}}
+			data.{{$list}}[i].{{toGoName .TfName}} = helpers.{{.ReadFilter}}(value.Array())
+			{{- else}}
 			data.{{$list}}[i].{{toGoName .TfName}} = helpers.GetStringList(value.Array())
+			{{- end}}
 		} else {
 			data.{{$list}}[i].{{toGoName .TfName}} = types.ListNull(types.StringType)
 		}
@@ -764,7 +772,11 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 			}
 			{{- else if eq .Type "StringList"}}
 			if value := cr.Get("{{toDotPath .XPath}}"); value.Exists() && !data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.IsNull() {
+				{{- if .ReadFilter}}
+				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = helpers.{{.ReadFilter}}(value.Array())
+				{{- else}}
 				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = helpers.GetStringList(value.Array())
+				{{- end}}
 			} else {
 				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -842,7 +854,11 @@ func (data *{{camelCase .Name}}) updateFromBodyXML(ctx context.Context, res xmld
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := helpers.GetFromXPath(res, "data" + data.getXPath() + "/{{.XPath}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringListXML(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -928,7 +944,11 @@ func (data *{{camelCase .Name}}) updateFromBodyXML(ctx context.Context, res xmld
 		}
 		{{- else if eq .Type "StringList"}}
 		if value := helpers.GetFromXPath(r, "{{.XPath}}"); value.Exists() && !data.{{$list}}[i].{{toGoName .TfName}}.IsNull() {
+			{{- if .ReadFilter}}
+			data.{{$list}}[i].{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(value.Array())
+			{{- else}}
 			data.{{$list}}[i].{{toGoName .TfName}} = helpers.GetStringListXML(value.Array())
+			{{- end}}
 		} else {
 			data.{{$list}}[i].{{toGoName .TfName}} = types.ListNull(types.StringType)
 		}
@@ -1014,7 +1034,11 @@ func (data *{{camelCase .Name}}) updateFromBodyXML(ctx context.Context, res xmld
 			}
 			{{- else if eq .Type "StringList"}}
 			if value := helpers.GetFromXPath(cr, "{{.XPath}}"); value.Exists() && !data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.IsNull() {
+				{{- if .ReadFilter}}
+				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(value.Array())
+				{{- else}}
 				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = helpers.GetStringListXML(value.Array())
+				{{- end}}
 			} else {
 				data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -1091,7 +1115,11 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := res.Get(prefix+"{{toDotPath .XPath}}"); value.Exists() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringList(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -1147,7 +1175,11 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 			}
 			{{- else if eq .Type "StringList"}}
 			if cValue := v.Get("{{toDotPath .XPath}}"); cValue.Exists() {
+				{{- if .ReadFilter}}
+				item.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(cValue.Array())
+				{{- else}}
 				item.{{toGoName .TfName}} = helpers.GetStringList(cValue.Array())
+				{{- end}}
 			} else {
 				item.{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -1203,7 +1235,11 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 					}
 					{{- else if eq .Type "StringList"}}
 					if ccValue := cv.Get("{{toDotPath .XPath}}"); ccValue.Exists() {
+						{{- if .ReadFilter}}
+						cItem.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(ccValue.Array())
+						{{- else}}
 						cItem.{{toGoName .TfName}} = helpers.GetStringList(ccValue.Array())
+						{{- end}}
 					} else {
 						cItem.{{toGoName .TfName}} = types.ListNull(types.StringType)
 					}
@@ -1286,7 +1322,11 @@ func (data *{{camelCase .Name}}Data) fromBody(ctx context.Context, res gjson.Res
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := res.Get(prefix+"{{toDotPath .XPath}}"); value.Exists() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringList(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -1342,7 +1382,11 @@ func (data *{{camelCase .Name}}Data) fromBody(ctx context.Context, res gjson.Res
 			}
 			{{- else if eq .Type "StringList"}}
 			if cValue := v.Get("{{toDotPath .XPath}}"); cValue.Exists() {
+				{{- if .ReadFilter}}
+				item.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(cValue.Array())
+				{{- else}}
 				item.{{toGoName .TfName}} = helpers.GetStringList(cValue.Array())
+				{{- end}}
 			} else {
 				item.{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -1398,7 +1442,11 @@ func (data *{{camelCase .Name}}Data) fromBody(ctx context.Context, res gjson.Res
 					}
 					{{- else if eq .Type "StringList"}}
 					if ccValue := cv.Get("{{toDotPath .XPath}}"); ccValue.Exists() {
+						{{- if .ReadFilter}}
+						cItem.{{toGoName .TfName}} = helpers.{{.ReadFilter}}(ccValue.Array())
+						{{- else}}
 						cItem.{{toGoName .TfName}} = helpers.GetStringList(ccValue.Array())
+						{{- end}}
 					} else {
 						cItem.{{toGoName .TfName}} = types.ListNull(types.StringType)
 					}
@@ -1477,7 +1525,11 @@ func (data *{{camelCase .Name}}) fromBodyXML(ctx context.Context, res xmldot.Res
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := helpers.GetFromXPath(res, "data" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringListXML(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -1533,7 +1585,11 @@ func (data *{{camelCase .Name}}) fromBodyXML(ctx context.Context, res xmldot.Res
 			}
 			{{- else if eq .Type "StringList"}}
 			if cValue := helpers.GetFromXPath(v, "{{.XPath}}"); cValue.Exists() {
+				{{- if .ReadFilter}}
+				item.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(cValue.Array())
+				{{- else}}
 				item.{{toGoName .TfName}} = helpers.GetStringListXML(cValue.Array())
+				{{- end}}
 			} else {
 				item.{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -1589,7 +1645,11 @@ func (data *{{camelCase .Name}}) fromBodyXML(ctx context.Context, res xmldot.Res
 					}
 					{{- else if eq .Type "StringList"}}
 					if ccValue := helpers.GetFromXPath(cv, "{{.XPath}}"); ccValue.Exists() {
+						{{- if .ReadFilter}}
+						cItem.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(ccValue.Array())
+						{{- else}}
 						cItem.{{toGoName .TfName}} = helpers.GetStringListXML(ccValue.Array())
+						{{- end}}
 					} else {
 						cItem.{{toGoName .TfName}} = types.ListNull(types.StringType)
 					}
@@ -1668,7 +1728,11 @@ func (data *{{camelCase .Name}}Data) fromBodyXML(ctx context.Context, res xmldot
 	}
 	{{- else if eq .Type "StringList"}}
 	if value := helpers.GetFromXPath(res, "data" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
+		{{- if .ReadFilter}}
+		data.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(value.Array())
+		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringListXML(value.Array())
+		{{- end}}
 	} else {
 		data.{{toGoName .TfName}} = types.ListNull(types.StringType)
 	}
@@ -1724,7 +1788,11 @@ func (data *{{camelCase .Name}}Data) fromBodyXML(ctx context.Context, res xmldot
 			}
 			{{- else if eq .Type "StringList"}}
 			if cValue := helpers.GetFromXPath(v, "{{.XPath}}"); cValue.Exists() {
+				{{- if .ReadFilter}}
+				item.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(cValue.Array())
+				{{- else}}
 				item.{{toGoName .TfName}} = helpers.GetStringListXML(cValue.Array())
+				{{- end}}
 			} else {
 				item.{{toGoName .TfName}} = types.ListNull(types.StringType)
 			}
@@ -1780,7 +1848,11 @@ func (data *{{camelCase .Name}}Data) fromBodyXML(ctx context.Context, res xmldot
 					}
 					{{- else if eq .Type "StringList"}}
 					if ccValue := helpers.GetFromXPath(cv, "{{.XPath}}"); ccValue.Exists() {
+						{{- if .ReadFilter}}
+						cItem.{{toGoName .TfName}} = helpers.{{.ReadFilter}}XML(ccValue.Array())
+						{{- else}}
 						cItem.{{toGoName .TfName}} = helpers.GetStringListXML(ccValue.Array())
+						{{- end}}
 					} else {
 						cItem.{{toGoName .TfName}} = types.ListNull(types.StringType)
 					}

--- a/internal/provider/helpers/utils.go
+++ b/internal/provider/helpers/utils.go
@@ -18,6 +18,10 @@
 package helpers
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/netascode/xmldot"
@@ -133,4 +137,38 @@ func RemoveEmptyStrings(s []string) []string {
 		}
 	}
 	return r
+}
+
+// NormalizeCommunityValue converts a decimal BGP community integer to AA:NN notation.
+// Standard communities are 32-bit: upper 16 bits = AS number, lower 16 bits = value.
+// Values already in colon notation or well-known names pass through unchanged.
+func NormalizeCommunityValue(val string) string {
+	if strings.Contains(val, ":") {
+		return val
+	}
+	n, err := strconv.ParseUint(val, 10, 32)
+	if err != nil {
+		return val
+	}
+	return fmt.Sprintf("%d:%d", n/65536, n%65536)
+}
+
+// GetNormalizedCommunityList converts a slice of gjson.Result to a Terraform types.List,
+// normalizing decimal BGP community values to AA:NN notation.
+func GetNormalizedCommunityList(result []gjson.Result) types.List {
+	v := make([]attr.Value, len(result))
+	for r := range result {
+		v[r] = types.StringValue(NormalizeCommunityValue(result[r].String()))
+	}
+	return types.ListValueMust(types.StringType, v)
+}
+
+// GetNormalizedCommunityListXML converts a slice of xmldot.Result to a Terraform types.List,
+// normalizing decimal BGP community values to AA:NN notation.
+func GetNormalizedCommunityListXML(result []xmldot.Result) types.List {
+	v := make([]attr.Value, len(result))
+	for r := range result {
+		v[r] = types.StringValue(NormalizeCommunityValue(result[r].String()))
+	}
+	return types.ListValueMust(types.StringType, v)
 }

--- a/internal/provider/helpers/utils_test.go
+++ b/internal/provider/helpers/utils_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2025 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Mozilla Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://mozilla.org/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"testing"
+)
+
+func TestNormalizeCommunityValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "decimal 1:1",
+			input:    "65537",
+			expected: "1:1",
+		},
+		{
+			name:     "decimal 2:2",
+			input:    "131074",
+			expected: "2:2",
+		},
+		{
+			name:     "decimal max community",
+			input:    "4294967295",
+			expected: "65535:65535",
+		},
+		{
+			name:     "decimal 1:0 boundary",
+			input:    "65536",
+			expected: "1:0",
+		},
+		{
+			name:     "decimal 0:1",
+			input:    "1",
+			expected: "0:1",
+		},
+		{
+			name:     "already colon notation",
+			input:    "1:1",
+			expected: "1:1",
+		},
+		{
+			name:     "4-byte ASN colon notation passthrough",
+			input:    "65540:100",
+			expected: "65540:100",
+		},
+		{
+			name:     "well-known no-export",
+			input:    "no-export",
+			expected: "no-export",
+		},
+		{
+			name:     "well-known no-advertise",
+			input:    "no-advertise",
+			expected: "no-advertise",
+		},
+		{
+			name:     "well-known internet",
+			input:    "internet",
+			expected: "internet",
+		},
+		{
+			name:     "well-known local-AS",
+			input:    "local-AS",
+			expected: "local-AS",
+		},
+		{
+			name:     "well-known gshut",
+			input:    "gshut",
+			expected: "gshut",
+		},
+		{
+			name:     "overflow uint32 passthrough",
+			input:    "4294967296",
+			expected: "4294967296",
+		},
+		{
+			name:     "empty string passthrough",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeCommunityValue(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeCommunityValue(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/provider/model_iosxe_route_map.go
+++ b/internal/provider/model_iosxe_route_map.go
@@ -1834,7 +1834,7 @@ func (data *RouteMap) updateFromBody(ctx context.Context, res gjson.Result) {
 			data.Entries[i].SetCommunityNoneLegacy = types.BoolNull()
 		}
 		if value := r.Get("set.community.community-well-known.community-list"); value.Exists() && !data.Entries[i].SetCommunitiesLegacy.IsNull() {
-			data.Entries[i].SetCommunitiesLegacy = helpers.GetStringList(value.Array())
+			data.Entries[i].SetCommunitiesLegacy = helpers.GetNormalizedCommunityList(value.Array())
 		} else {
 			data.Entries[i].SetCommunitiesLegacy = types.ListNull(types.StringType)
 		}
@@ -1963,7 +1963,7 @@ func (data *RouteMap) updateFromBody(ctx context.Context, res gjson.Result) {
 			data.Entries[i].SetCommunityNone = types.BoolNull()
 		}
 		if value := r.Get("set.Cisco-IOS-XE-bgp:bgp-route-map-set.bgp-community.community-well-known.community-list"); value.Exists() && !data.Entries[i].SetCommunities.IsNull() {
-			data.Entries[i].SetCommunities = helpers.GetStringList(value.Array())
+			data.Entries[i].SetCommunities = helpers.GetNormalizedCommunityList(value.Array())
 		} else {
 			data.Entries[i].SetCommunities = types.ListNull(types.StringType)
 		}
@@ -2528,7 +2528,7 @@ func (data *RouteMap) updateFromBodyXML(ctx context.Context, res xmldot.Result) 
 			data.Entries[i].SetCommunityNoneLegacy = types.BoolNull()
 		}
 		if value := helpers.GetFromXPath(r, "set/community/community-well-known/community-list"); value.Exists() && !data.Entries[i].SetCommunitiesLegacy.IsNull() {
-			data.Entries[i].SetCommunitiesLegacy = helpers.GetStringListXML(value.Array())
+			data.Entries[i].SetCommunitiesLegacy = helpers.GetNormalizedCommunityListXML(value.Array())
 		} else {
 			data.Entries[i].SetCommunitiesLegacy = types.ListNull(types.StringType)
 		}
@@ -2657,7 +2657,7 @@ func (data *RouteMap) updateFromBodyXML(ctx context.Context, res xmldot.Result) 
 			data.Entries[i].SetCommunityNone = types.BoolNull()
 		}
 		if value := helpers.GetFromXPath(r, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list"); value.Exists() && !data.Entries[i].SetCommunities.IsNull() {
-			data.Entries[i].SetCommunities = helpers.GetStringListXML(value.Array())
+			data.Entries[i].SetCommunities = helpers.GetNormalizedCommunityListXML(value.Array())
 		} else {
 			data.Entries[i].SetCommunities = types.ListNull(types.StringType)
 		}
@@ -3064,7 +3064,7 @@ func (data *RouteMap) fromBody(ctx context.Context, res gjson.Result) {
 				item.SetCommunityNoneLegacy = types.BoolValue(false)
 			}
 			if cValue := v.Get("set.community.community-well-known.community-list"); cValue.Exists() {
-				item.SetCommunitiesLegacy = helpers.GetStringList(cValue.Array())
+				item.SetCommunitiesLegacy = helpers.GetNormalizedCommunityList(cValue.Array())
 			} else {
 				item.SetCommunitiesLegacy = types.ListNull(types.StringType)
 			}
@@ -3137,7 +3137,7 @@ func (data *RouteMap) fromBody(ctx context.Context, res gjson.Result) {
 				item.SetCommunityNone = types.BoolValue(false)
 			}
 			if cValue := v.Get("set.Cisco-IOS-XE-bgp:bgp-route-map-set.bgp-community.community-well-known.community-list"); cValue.Exists() {
-				item.SetCommunities = helpers.GetStringList(cValue.Array())
+				item.SetCommunities = helpers.GetNormalizedCommunityList(cValue.Array())
 			} else {
 				item.SetCommunities = types.ListNull(types.StringType)
 			}
@@ -3521,7 +3521,7 @@ func (data *RouteMapData) fromBody(ctx context.Context, res gjson.Result) {
 				item.SetCommunityNoneLegacy = types.BoolValue(false)
 			}
 			if cValue := v.Get("set.community.community-well-known.community-list"); cValue.Exists() {
-				item.SetCommunitiesLegacy = helpers.GetStringList(cValue.Array())
+				item.SetCommunitiesLegacy = helpers.GetNormalizedCommunityList(cValue.Array())
 			} else {
 				item.SetCommunitiesLegacy = types.ListNull(types.StringType)
 			}
@@ -3594,7 +3594,7 @@ func (data *RouteMapData) fromBody(ctx context.Context, res gjson.Result) {
 				item.SetCommunityNone = types.BoolValue(false)
 			}
 			if cValue := v.Get("set.Cisco-IOS-XE-bgp:bgp-route-map-set.bgp-community.community-well-known.community-list"); cValue.Exists() {
-				item.SetCommunities = helpers.GetStringList(cValue.Array())
+				item.SetCommunities = helpers.GetNormalizedCommunityList(cValue.Array())
 			} else {
 				item.SetCommunities = types.ListNull(types.StringType)
 			}
@@ -3974,7 +3974,7 @@ func (data *RouteMap) fromBodyXML(ctx context.Context, res xmldot.Result) {
 				item.SetCommunityNoneLegacy = types.BoolValue(false)
 			}
 			if cValue := helpers.GetFromXPath(v, "set/community/community-well-known/community-list"); cValue.Exists() {
-				item.SetCommunitiesLegacy = helpers.GetStringListXML(cValue.Array())
+				item.SetCommunitiesLegacy = helpers.GetNormalizedCommunityListXML(cValue.Array())
 			} else {
 				item.SetCommunitiesLegacy = types.ListNull(types.StringType)
 			}
@@ -4047,7 +4047,7 @@ func (data *RouteMap) fromBodyXML(ctx context.Context, res xmldot.Result) {
 				item.SetCommunityNone = types.BoolValue(false)
 			}
 			if cValue := helpers.GetFromXPath(v, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list"); cValue.Exists() {
-				item.SetCommunities = helpers.GetStringListXML(cValue.Array())
+				item.SetCommunities = helpers.GetNormalizedCommunityListXML(cValue.Array())
 			} else {
 				item.SetCommunities = types.ListNull(types.StringType)
 			}
@@ -4427,7 +4427,7 @@ func (data *RouteMapData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 				item.SetCommunityNoneLegacy = types.BoolValue(false)
 			}
 			if cValue := helpers.GetFromXPath(v, "set/community/community-well-known/community-list"); cValue.Exists() {
-				item.SetCommunitiesLegacy = helpers.GetStringListXML(cValue.Array())
+				item.SetCommunitiesLegacy = helpers.GetNormalizedCommunityListXML(cValue.Array())
 			} else {
 				item.SetCommunitiesLegacy = types.ListNull(types.StringType)
 			}
@@ -4500,7 +4500,7 @@ func (data *RouteMapData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 				item.SetCommunityNone = types.BoolValue(false)
 			}
 			if cValue := helpers.GetFromXPath(v, "set/Cisco-IOS-XE-bgp:bgp-route-map-set/bgp-community/community-well-known/community-list"); cValue.Exists() {
-				item.SetCommunities = helpers.GetStringListXML(cValue.Array())
+				item.SetCommunities = helpers.GetNormalizedCommunityListXML(cValue.Array())
 			} else {
 				item.SetCommunities = types.ListNull(types.StringType)
 			}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source
 - Add `process_ids` attribute to `iosxe_interface_ospfv3` resource and data source
 - Add `ipv6_unicast_aggregate_addresses`, `ipv6_unicast_admin_distances`, `ipv6_unicast_distance_bgp_external`, `ipv6_unicast_distance_bgp_internal`, `ipv6_unicast_distance_bgp_local`, `ipv6_unicast_maximum_paths_ebgp`, `ipv6_unicast_maximum_paths_ibgp`, `ipv6_unicast_router_id_ip`, `ipv6_unicast_router_id_loopback` attributes to `iosxe_bgp_address_family_ipv6_vrf` resource and data source


### PR DESCRIPTION
## Summary

- Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers (e.g., `65537`) instead of the configured `AA:NN` notation (e.g., `1:1`)
- Extend the code generator with a reusable `read_filter` YAML attribute for read-side normalization of StringList attributes
- Add `NormalizeCommunityValue` helper that safely converts `uint32 → AA:NN` while passing through colon notation, well-known names, and 4-byte ASN values unchanged

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: generator read_filter mechanism + community normalization helpers + unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)