### PR TITLE
feat(interface_port_channel): add spanning-tree portfast and bpduguard attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source

--- a/docs/data-sources/interface_port_channel.md
+++ b/docs/data-sources/interface_port_channel.md
@@ -50,6 +50,8 @@ data "iosxe_interface_port_channel" "example" {
 - `bfd_interval_multiplier` (Number) Multiplier value used to compute holddown
 - `bfd_local_address` (String) The Source IP address to be used for BFD sessions over this interface.
 - `bfd_template` (String) BFD template
+- `bpduguard_disable` (Boolean) Disable BPDU guard for this interface
+- `bpduguard_enable` (Boolean) Enable BPDU guard for this interface
 - `description` (String) Interface specific description
 - `device_tracking` (Boolean) Configure device-tracking on the interface
 - `device_tracking_attached_policies` (Attributes List) (see [below for nested schema](#nestedatt--device_tracking_attached_policies))
@@ -92,6 +94,10 @@ data "iosxe_interface_port_channel" "example" {
 - `snmp_trap_link_status` (Boolean) Allow SNMP LINKUP and LINKDOWN traps
 - `spanning_tree_guard` (String) Change an interface's spanning tree guard mode
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use
+- `spanning_tree_portfast` (Boolean) (DEPRECATED) Spanning tree portfast options
+- `spanning_tree_portfast_disable` (Boolean) (DEPRECATED) Disable portfast for this interface
+- `spanning_tree_portfast_edge` (Boolean) (DEPRECATED) Enable portfast edge on the interface
+- `spanning_tree_portfast_trunk` (Boolean) (DEPRECATED) Enable portfast on the interface even in trunk mode
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
 - `vrf_forwarding` (String) Configure forwarding table

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source

--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -99,6 +99,8 @@ resource "iosxe_interface_port_channel" "example" {
   - Range: `3`-`50`
 - `bfd_local_address` (String) The Source IP address to be used for BFD sessions over this interface.
 - `bfd_template` (String) BFD template
+- `bpduguard_disable` (Boolean) Disable BPDU guard for this interface
+- `bpduguard_enable` (Boolean) Enable BPDU guard for this interface
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `description` (String) Interface specific description
@@ -150,6 +152,10 @@ resource "iosxe_interface_port_channel" "example" {
   - Choices: `loop`, `none`, `root`
 - `spanning_tree_link_type` (String) Specify a link type for spanning tree tree protocol use
   - Choices: `point-to-point`, `shared`
+- `spanning_tree_portfast` (Boolean) (DEPRECATED) Spanning tree portfast options
+- `spanning_tree_portfast_disable` (Boolean) (DEPRECATED) Disable portfast for this interface
+- `spanning_tree_portfast_edge` (Boolean) (DEPRECATED) Enable portfast edge on the interface
+- `spanning_tree_portfast_trunk` (Boolean) (DEPRECATED) Enable portfast on the interface even in trunk mode
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
   - Choices: `cisco-phone`, `cts`, `ip-camera`, `media-player`

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -196,6 +196,28 @@ attributes:
   - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/link-type
     example: point-to-point
     exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/bpduguard-choice/enable/enable
+    xpath: Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable
+    tf_name: bpduguard_enable
+    example: false
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/bpduguard-choice/disable/disable
+    xpath: Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable
+    tf_name: bpduguard_disable
+    example: false
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/portfast
+    example: true
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable
+    example: false
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk
+    example: true
+    exclude_test: true
+  - yang_name: Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge
+    example: false
+    exclude_test: true
   - yang_name: ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust
     example: true
     exclude_test: true

--- a/internal/provider/data_source_iosxe_interface_port_channel.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel.go
@@ -320,6 +320,30 @@ func (d *InterfacePortChannelDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "Specify a link type for spanning tree tree protocol use",
 				Computed:            true,
 			},
+			"bpduguard_enable": schema.BoolAttribute{
+				MarkdownDescription: "Enable BPDU guard for this interface",
+				Computed:            true,
+			},
+			"bpduguard_disable": schema.BoolAttribute{
+				MarkdownDescription: "Disable BPDU guard for this interface",
+				Computed:            true,
+			},
+			"spanning_tree_portfast": schema.BoolAttribute{
+				MarkdownDescription: "(DEPRECATED) Spanning tree portfast options",
+				Computed:            true,
+			},
+			"spanning_tree_portfast_disable": schema.BoolAttribute{
+				MarkdownDescription: "(DEPRECATED) Disable portfast for this interface",
+				Computed:            true,
+			},
+			"spanning_tree_portfast_trunk": schema.BoolAttribute{
+				MarkdownDescription: "(DEPRECATED) Enable portfast on the interface even in trunk mode",
+				Computed:            true,
+			},
+			"spanning_tree_portfast_edge": schema.BoolAttribute{
+				MarkdownDescription: "(DEPRECATED) Enable portfast edge on the interface",
+				Computed:            true,
+			},
 			"ip_dhcp_snooping_trust": schema.BoolAttribute{
 				MarkdownDescription: "DHCP Snooping trust config",
 				Computed:            true,

--- a/internal/provider/model_iosxe_interface_port_channel.go
+++ b/internal/provider/model_iosxe_interface_port_channel.go
@@ -95,6 +95,12 @@ type InterfacePortChannel struct {
 	IpArpInspectionTrust           types.Bool                                           `tfsdk:"ip_arp_inspection_trust"`
 	IpArpInspectionLimitRate       types.Int64                                          `tfsdk:"ip_arp_inspection_limit_rate"`
 	SpanningTreeLinkType           types.String                                         `tfsdk:"spanning_tree_link_type"`
+	BpduguardEnable                types.Bool                                           `tfsdk:"bpduguard_enable"`
+	BpduguardDisable               types.Bool                                           `tfsdk:"bpduguard_disable"`
+	SpanningTreePortfast           types.Bool                                           `tfsdk:"spanning_tree_portfast"`
+	SpanningTreePortfastDisable    types.Bool                                           `tfsdk:"spanning_tree_portfast_disable"`
+	SpanningTreePortfastTrunk      types.Bool                                           `tfsdk:"spanning_tree_portfast_trunk"`
+	SpanningTreePortfastEdge       types.Bool                                           `tfsdk:"spanning_tree_portfast_edge"`
 	IpDhcpSnoopingTrust            types.Bool                                           `tfsdk:"ip_dhcp_snooping_trust"`
 	LoadInterval                   types.Int64                                          `tfsdk:"load_interval"`
 	SnmpTrapLinkStatus             types.Bool                                           `tfsdk:"snmp_trap_link_status"`
@@ -195,6 +201,12 @@ type InterfacePortChannelData struct {
 	IpArpInspectionTrust           types.Bool                                               `tfsdk:"ip_arp_inspection_trust"`
 	IpArpInspectionLimitRate       types.Int64                                              `tfsdk:"ip_arp_inspection_limit_rate"`
 	SpanningTreeLinkType           types.String                                             `tfsdk:"spanning_tree_link_type"`
+	BpduguardEnable                types.Bool                                               `tfsdk:"bpduguard_enable"`
+	BpduguardDisable               types.Bool                                               `tfsdk:"bpduguard_disable"`
+	SpanningTreePortfast           types.Bool                                               `tfsdk:"spanning_tree_portfast"`
+	SpanningTreePortfastDisable    types.Bool                                               `tfsdk:"spanning_tree_portfast_disable"`
+	SpanningTreePortfastTrunk      types.Bool                                               `tfsdk:"spanning_tree_portfast_trunk"`
+	SpanningTreePortfastEdge       types.Bool                                               `tfsdk:"spanning_tree_portfast_edge"`
 	IpDhcpSnoopingTrust            types.Bool                                               `tfsdk:"ip_dhcp_snooping_trust"`
 	LoadInterval                   types.Int64                                              `tfsdk:"load_interval"`
 	SnmpTrapLinkStatus             types.Bool                                               `tfsdk:"snmp_trap_link_status"`
@@ -461,6 +473,36 @@ func (data InterfacePortChannel) toBody(ctx context.Context, config InterfacePor
 	}
 	if !data.SpanningTreeLinkType.IsNull() && !data.SpanningTreeLinkType.IsUnknown() {
 		body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.link-type", data.SpanningTreeLinkType.ValueString())
+	}
+	if !data.BpduguardEnable.IsNull() && !data.BpduguardEnable.IsUnknown() {
+		if data.BpduguardEnable.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.enable", map[string]string{})
+		}
+	}
+	if !data.BpduguardDisable.IsNull() && !data.BpduguardDisable.IsUnknown() {
+		if data.BpduguardDisable.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.disable", map[string]string{})
+		}
+	}
+	if !data.SpanningTreePortfast.IsNull() && !data.SpanningTreePortfast.IsUnknown() {
+		if data.SpanningTreePortfast.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.portfast", map[string]string{})
+		}
+	}
+	if !data.SpanningTreePortfastDisable.IsNull() && !data.SpanningTreePortfastDisable.IsUnknown() {
+		if data.SpanningTreePortfastDisable.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.disable", map[string]string{})
+		}
+	}
+	if !data.SpanningTreePortfastTrunk.IsNull() && !data.SpanningTreePortfastTrunk.IsUnknown() {
+		if data.SpanningTreePortfastTrunk.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.trunk", map[string]string{})
+		}
+	}
+	if !data.SpanningTreePortfastEdge.IsNull() && !data.SpanningTreePortfastEdge.IsUnknown() {
+		if data.SpanningTreePortfastEdge.ValueBool() {
+			body, _ = sjson.Set(body, helpers.LastElement(data.getPath())+"."+"Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.edge", map[string]string{})
+		}
 	}
 	if !data.IpDhcpSnoopingTrust.IsNull() && !data.IpDhcpSnoopingTrust.IsUnknown() {
 		if data.IpDhcpSnoopingTrust.ValueBool() {
@@ -880,6 +922,48 @@ func (data InterfacePortChannel) toBodyXML(ctx context.Context, config Interface
 	}
 	if !data.SpanningTreeLinkType.IsNull() && !data.SpanningTreeLinkType.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type", data.SpanningTreeLinkType.ValueString())
+	}
+	if !data.BpduguardEnable.IsNull() && !data.BpduguardEnable.IsUnknown() {
+		if data.BpduguardEnable.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable")
+		}
+	}
+	if !data.BpduguardDisable.IsNull() && !data.BpduguardDisable.IsUnknown() {
+		if data.BpduguardDisable.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable")
+		}
+	}
+	if !data.SpanningTreePortfast.IsNull() && !data.SpanningTreePortfast.IsUnknown() {
+		if data.SpanningTreePortfast.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast")
+		}
+	}
+	if !data.SpanningTreePortfastDisable.IsNull() && !data.SpanningTreePortfastDisable.IsUnknown() {
+		if data.SpanningTreePortfastDisable.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable")
+		}
+	}
+	if !data.SpanningTreePortfastTrunk.IsNull() && !data.SpanningTreePortfastTrunk.IsUnknown() {
+		if data.SpanningTreePortfastTrunk.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk")
+		}
+	}
+	if !data.SpanningTreePortfastEdge.IsNull() && !data.SpanningTreePortfastEdge.IsUnknown() {
+		if data.SpanningTreePortfastEdge.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge")
+		}
 	}
 	if !data.IpDhcpSnoopingTrust.IsNull() && !data.IpDhcpSnoopingTrust.IsUnknown() {
 		if data.IpDhcpSnoopingTrust.ValueBool() {
@@ -1459,6 +1543,60 @@ func (data *InterfacePortChannel) updateFromBody(ctx context.Context, res gjson.
 		data.SpanningTreeLinkType = types.StringValue(value.String())
 	} else {
 		data.SpanningTreeLinkType = types.StringNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.enable"); !data.BpduguardEnable.IsNull() {
+		if value.Exists() {
+			data.BpduguardEnable = types.BoolValue(true)
+		} else {
+			data.BpduguardEnable = types.BoolValue(false)
+		}
+	} else {
+		data.BpduguardEnable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.disable"); !data.BpduguardDisable.IsNull() {
+		if value.Exists() {
+			data.BpduguardDisable = types.BoolValue(true)
+		} else {
+			data.BpduguardDisable = types.BoolValue(false)
+		}
+	} else {
+		data.BpduguardDisable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast"); !data.SpanningTreePortfast.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfast = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfast = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfast = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.disable"); !data.SpanningTreePortfastDisable.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastDisable = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastDisable = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.trunk"); !data.SpanningTreePortfastTrunk.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastTrunk = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastTrunk = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolNull()
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.edge"); !data.SpanningTreePortfastEdge.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastEdge = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastEdge = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolNull()
 	}
 	if value := res.Get(prefix + "ip.dhcp.Cisco-IOS-XE-dhcp:snooping.trust"); !data.IpDhcpSnoopingTrust.IsNull() {
 		if value.Exists() {
@@ -2140,6 +2278,60 @@ func (data *InterfacePortChannel) updateFromBodyXML(ctx context.Context, res xml
 	} else {
 		data.SpanningTreeLinkType = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable"); !data.BpduguardEnable.IsNull() {
+		if value.Exists() {
+			data.BpduguardEnable = types.BoolValue(true)
+		} else {
+			data.BpduguardEnable = types.BoolValue(false)
+		}
+	} else {
+		data.BpduguardEnable = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable"); !data.BpduguardDisable.IsNull() {
+		if value.Exists() {
+			data.BpduguardDisable = types.BoolValue(true)
+		} else {
+			data.BpduguardDisable = types.BoolValue(false)
+		}
+	} else {
+		data.BpduguardDisable = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast"); !data.SpanningTreePortfast.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfast = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfast = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfast = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable"); !data.SpanningTreePortfastDisable.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastDisable = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastDisable = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk"); !data.SpanningTreePortfastTrunk.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastTrunk = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastTrunk = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge"); !data.SpanningTreePortfastEdge.IsNull() {
+		if value.Exists() {
+			data.SpanningTreePortfastEdge = types.BoolValue(true)
+		} else {
+			data.SpanningTreePortfastEdge = types.BoolValue(false)
+		}
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolNull()
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust"); !data.IpDhcpSnoopingTrust.IsNull() {
 		if value.Exists() {
 			data.IpDhcpSnoopingTrust = types.BoolValue(true)
@@ -2601,6 +2793,36 @@ func (data *InterfacePortChannel) fromBody(ctx context.Context, res gjson.Result
 	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.link-type"); value.Exists() {
 		data.SpanningTreeLinkType = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.enable"); value.Exists() {
+		data.BpduguardEnable = types.BoolValue(true)
+	} else {
+		data.BpduguardEnable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.disable"); value.Exists() {
+		data.BpduguardDisable = types.BoolValue(true)
+	} else {
+		data.BpduguardDisable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast"); value.Exists() {
+		data.SpanningTreePortfast = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfast = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.disable"); value.Exists() {
+		data.SpanningTreePortfastDisable = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.trunk"); value.Exists() {
+		data.SpanningTreePortfastTrunk = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.edge"); value.Exists() {
+		data.SpanningTreePortfastEdge = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "ip.dhcp.Cisco-IOS-XE-dhcp:snooping.trust"); value.Exists() {
 		data.IpDhcpSnoopingTrust = types.BoolValue(true)
 	} else {
@@ -2958,6 +3180,36 @@ func (data *InterfacePortChannelData) fromBody(ctx context.Context, res gjson.Re
 	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.link-type"); value.Exists() {
 		data.SpanningTreeLinkType = types.StringValue(value.String())
 	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.enable"); value.Exists() {
+		data.BpduguardEnable = types.BoolValue(true)
+	} else {
+		data.BpduguardEnable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.bpduguard.disable"); value.Exists() {
+		data.BpduguardDisable = types.BoolValue(true)
+	} else {
+		data.BpduguardDisable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast"); value.Exists() {
+		data.SpanningTreePortfast = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfast = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.disable"); value.Exists() {
+		data.SpanningTreePortfastDisable = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.trunk"); value.Exists() {
+		data.SpanningTreePortfastTrunk = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolValue(false)
+	}
+	if value := res.Get(prefix + "Cisco-IOS-XE-spanning-tree:spanning-tree.portfast.edge"); value.Exists() {
+		data.SpanningTreePortfastEdge = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolValue(false)
+	}
 	if value := res.Get(prefix + "ip.dhcp.Cisco-IOS-XE-dhcp:snooping.trust"); value.Exists() {
 		data.IpDhcpSnoopingTrust = types.BoolValue(true)
 	} else {
@@ -3310,6 +3562,36 @@ func (data *InterfacePortChannel) fromBodyXML(ctx context.Context, res xmldot.Re
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type"); value.Exists() {
 		data.SpanningTreeLinkType = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable"); value.Exists() {
+		data.BpduguardEnable = types.BoolValue(true)
+	} else {
+		data.BpduguardEnable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable"); value.Exists() {
+		data.BpduguardDisable = types.BoolValue(true)
+	} else {
+		data.BpduguardDisable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast"); value.Exists() {
+		data.SpanningTreePortfast = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfast = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable"); value.Exists() {
+		data.SpanningTreePortfastDisable = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk"); value.Exists() {
+		data.SpanningTreePortfastTrunk = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge"); value.Exists() {
+		data.SpanningTreePortfastEdge = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolValue(false)
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust"); value.Exists() {
 		data.IpDhcpSnoopingTrust = types.BoolValue(true)
@@ -3664,6 +3946,36 @@ func (data *InterfacePortChannelData) fromBodyXML(ctx context.Context, res xmldo
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type"); value.Exists() {
 		data.SpanningTreeLinkType = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable"); value.Exists() {
+		data.BpduguardEnable = types.BoolValue(true)
+	} else {
+		data.BpduguardEnable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable"); value.Exists() {
+		data.BpduguardDisable = types.BoolValue(true)
+	} else {
+		data.BpduguardDisable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast"); value.Exists() {
+		data.SpanningTreePortfast = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfast = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable"); value.Exists() {
+		data.SpanningTreePortfastDisable = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastDisable = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk"); value.Exists() {
+		data.SpanningTreePortfastTrunk = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastTrunk = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge"); value.Exists() {
+		data.SpanningTreePortfastEdge = types.BoolValue(true)
+	} else {
+		data.SpanningTreePortfastEdge = types.BoolValue(false)
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust"); value.Exists() {
 		data.IpDhcpSnoopingTrust = types.BoolValue(true)
 	} else {
@@ -3904,6 +4216,24 @@ func (data *InterfacePortChannel) getDeletedItems(ctx context.Context, state Int
 	}
 	if !state.IpDhcpSnoopingTrust.IsNull() && data.IpDhcpSnoopingTrust.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust", state.getPath()))
+	}
+	if !state.SpanningTreePortfastEdge.IsNull() && data.SpanningTreePortfastEdge.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge", state.getPath()))
+	}
+	if !state.SpanningTreePortfastTrunk.IsNull() && data.SpanningTreePortfastTrunk.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk", state.getPath()))
+	}
+	if !state.SpanningTreePortfastDisable.IsNull() && data.SpanningTreePortfastDisable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable", state.getPath()))
+	}
+	if !state.SpanningTreePortfast.IsNull() && data.SpanningTreePortfast.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast", state.getPath()))
+	}
+	if !state.BpduguardDisable.IsNull() && data.BpduguardDisable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable", state.getPath()))
+	}
+	if !state.BpduguardEnable.IsNull() && data.BpduguardEnable.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable", state.getPath()))
 	}
 	if !state.SpanningTreeLinkType.IsNull() && data.SpanningTreeLinkType.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type", state.getPath()))
@@ -4324,6 +4654,24 @@ func (data *InterfacePortChannel) addDeletedItemsXML(ctx context.Context, state 
 	if !state.IpDhcpSnoopingTrust.IsNull() && data.IpDhcpSnoopingTrust.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust")
 	}
+	if !state.SpanningTreePortfastEdge.IsNull() && data.SpanningTreePortfastEdge.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge")
+	}
+	if !state.SpanningTreePortfastTrunk.IsNull() && data.SpanningTreePortfastTrunk.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk")
+	}
+	if !state.SpanningTreePortfastDisable.IsNull() && data.SpanningTreePortfastDisable.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable")
+	}
+	if !state.SpanningTreePortfast.IsNull() && data.SpanningTreePortfast.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast")
+	}
+	if !state.BpduguardDisable.IsNull() && data.BpduguardDisable.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable")
+	}
+	if !state.BpduguardEnable.IsNull() && data.BpduguardEnable.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable")
+	}
 	if !state.SpanningTreeLinkType.IsNull() && data.SpanningTreeLinkType.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type")
 	}
@@ -4619,6 +4967,24 @@ func (data *InterfacePortChannel) getEmptyLeafsDelete(ctx context.Context) []str
 	if !data.IpDhcpSnoopingTrust.IsNull() && !data.IpDhcpSnoopingTrust.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust", data.getPath()))
 	}
+	if !data.SpanningTreePortfastEdge.IsNull() && !data.SpanningTreePortfastEdge.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge", data.getPath()))
+	}
+	if !data.SpanningTreePortfastTrunk.IsNull() && !data.SpanningTreePortfastTrunk.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk", data.getPath()))
+	}
+	if !data.SpanningTreePortfastDisable.IsNull() && !data.SpanningTreePortfastDisable.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable", data.getPath()))
+	}
+	if !data.SpanningTreePortfast.IsNull() && !data.SpanningTreePortfast.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast", data.getPath()))
+	}
+	if !data.BpduguardDisable.IsNull() && !data.BpduguardDisable.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable", data.getPath()))
+	}
+	if !data.BpduguardEnable.IsNull() && !data.BpduguardEnable.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable", data.getPath()))
+	}
 	if !data.IpArpInspectionTrust.IsNull() && !data.IpArpInspectionTrust.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/ip/arp/inspection/trust", data.getPath()))
 	}
@@ -4762,6 +5128,24 @@ func (data *InterfacePortChannel) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.IpDhcpSnoopingTrust.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust", data.getPath()))
+	}
+	if !data.SpanningTreePortfastEdge.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge", data.getPath()))
+	}
+	if !data.SpanningTreePortfastTrunk.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk", data.getPath()))
+	}
+	if !data.SpanningTreePortfastDisable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable", data.getPath()))
+	}
+	if !data.SpanningTreePortfast.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast", data.getPath()))
+	}
+	if !data.BpduguardDisable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable", data.getPath()))
+	}
+	if !data.BpduguardEnable.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable", data.getPath()))
 	}
 	if !data.SpanningTreeLinkType.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type", data.getPath()))
@@ -4997,6 +5381,24 @@ func (data *InterfacePortChannel) addDeletePathsXML(ctx context.Context, body st
 	}
 	if !data.IpDhcpSnoopingTrust.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/dhcp/Cisco-IOS-XE-dhcp:snooping/trust")
+	}
+	if !data.SpanningTreePortfastEdge.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge")
+	}
+	if !data.SpanningTreePortfastTrunk.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk")
+	}
+	if !data.SpanningTreePortfastDisable.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable")
+	}
+	if !data.SpanningTreePortfast.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast")
+	}
+	if !data.BpduguardDisable.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable")
+	}
+	if !data.BpduguardEnable.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable")
 	}
 	if !data.SpanningTreeLinkType.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-spanning-tree:spanning-tree/link-type")

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -401,6 +401,30 @@ func (r *InterfacePortChannelResource) Schema(ctx context.Context, req resource.
 					stringvalidator.OneOf("point-to-point", "shared"),
 				},
 			},
+			"bpduguard_enable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable BPDU guard for this interface").String,
+				Optional:            true,
+			},
+			"bpduguard_disable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Disable BPDU guard for this interface").String,
+				Optional:            true,
+			},
+			"spanning_tree_portfast": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("(DEPRECATED) Spanning tree portfast options").String,
+				Optional:            true,
+			},
+			"spanning_tree_portfast_disable": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("(DEPRECATED) Disable portfast for this interface").String,
+				Optional:            true,
+			},
+			"spanning_tree_portfast_trunk": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("(DEPRECATED) Enable portfast on the interface even in trunk mode").String,
+				Optional:            true,
+			},
+			"spanning_tree_portfast_edge": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("(DEPRECATED) Enable portfast edge on the interface").String,
+				Optional:            true,
+			},
 			"ip_dhcp_snooping_trust": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("DHCP Snooping trust config").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -95,7 +95,7 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeInterfacePortChannelImportStateIdFunc("iosxe_interface_port_channel.test"),
-				ImportStateVerifyIgnore: []string{"ipv4_address_dhcp", "auto_qos_classify", "auto_qos_classify_police", "auto_qos_trust", "auto_qos_trust_cos", "auto_qos_trust_dscp", "auto_qos_video_cts", "auto_qos_video_ip_camera", "auto_qos_video_media_player", "auto_qos_voip_cisco_phone", "auto_qos_voip_cisco_softphone", "auto_qos_voip_trust", "ipv6_nd_ra_suppress_all", "ipv6_address_autoconfig_default", "ip_dhcp_snooping_trust", "device_tracking", "ip_nat_inside", "ip_nat_outside"},
+				ImportStateVerifyIgnore: []string{"ipv4_address_dhcp", "auto_qos_classify", "auto_qos_classify_police", "auto_qos_trust", "auto_qos_trust_cos", "auto_qos_trust_dscp", "auto_qos_video_cts", "auto_qos_video_ip_camera", "auto_qos_video_media_player", "auto_qos_voip_cisco_phone", "auto_qos_voip_cisco_softphone", "auto_qos_voip_trust", "ipv6_nd_ra_suppress_all", "ipv6_address_autoconfig_default", "bpduguard_enable", "bpduguard_disable", "spanning_tree_portfast", "spanning_tree_portfast_disable", "spanning_tree_portfast_trunk", "spanning_tree_portfast_edge", "ip_dhcp_snooping_trust", "device_tracking", "ip_nat_inside", "ip_nat_outside"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)
 - Add `match_flow_cts_destination_group_tag` and `match_flow_cts_source_group_tag` to `iosxe_flow_record` resource and data source


### PR DESCRIPTION
## ✔️ Type of Change

- [X] 🚀 New feature (new resource/data source, new attributes to existing resource)
- [ ] 🐛 Bug fix
- [ ] ⚠️ Breaking change
- [ ] 📄 Documentation update
- [ ] 🛠️ Refactoring / tech debt
- [ ] ⚙️ Other

## 🔗 Related Issue(s)

n/a

## 📝 Proposed Changes

`Cisco-IOS-XE-spanning-tree.yang` augments the `Port-channel` interface container with the same `config-interface-spanning-tree` grouping that is used on `GigabitEthernet`, `TenGigabitEthernet`, etc. The `iosxe_interface_ethernet` resource already exposes the full set of spanning-tree leaves; `iosxe_interface_port_channel` only exposed `spanning_tree_guard` and `spanning_tree_link_type`. This PR closes that parity gap by adding the remaining six attributes.

### YANG paths

- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable`
- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable`
- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast`
- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable`
- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk`
- `/Cisco-IOS-XE-native:native/interface/Port-channel/Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge`

### New attributes

| Terraform attribute | YANG xpath |
|---|---|
| `bpduguard_enable` | `Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/enable` |
| `bpduguard_disable` | `Cisco-IOS-XE-spanning-tree:spanning-tree/bpduguard/disable` |
| `spanning_tree_portfast` | `Cisco-IOS-XE-spanning-tree:spanning-tree/portfast` |
| `spanning_tree_portfast_disable` | `Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/disable` |
| `spanning_tree_portfast_trunk` | `Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/trunk` |
| `spanning_tree_portfast_edge` | `Cisco-IOS-XE-spanning-tree:spanning-tree/portfast/edge` |

The CLI commands (`spanning-tree portfast`, `spanning-tree portfast disable`, `spanning-tree portfast trunk`, `spanning-tree portfast edge`, `spanning-tree bpduguard enable`, `spanning-tree bpduguard disable`) are accepted directly on `interface Port-channel <id>` on IOS-XE.

### Files changed

Hand-edited:
- `gen/definitions/interface_port_channel.yaml` — added six `yang_name` entries (mirroring the ethernet definition)
- `CHANGELOG.md` and `templates/guides/changelog.md.tmpl` — Unreleased entry

Auto-generated by `make gen NAME="Interface Port Channel"`:
- `internal/provider/{model,resource,data_source,resource_test}_iosxe_interface_port_channel.go`
- `docs/{resources,data-sources,guides}/...`

`exclude_test: true` is set on the new entries to match the existing port-channel `guard` and `link_type` entries — auto-generated acceptance tests would set mutually-exclusive choice cases at the same time, so live testing for these is left to higher-level integration coverage.

### Validation

- `go build ./...` — clean
- `go vet ./internal/provider/` — clean