### PR TITLE
fix(interface_ospfv3): include list-key 'id' in router-level test prereq body

### DIFF
--- a/gen/definitions/interface_ospfv3.yaml
+++ b/gen/definitions/interface_ospfv3.yaml
@@ -92,6 +92,8 @@ test_prerequisites:
         value: ""
   - path: /Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3[id=1]
     attributes:
+      - name: id
+        value: 1
       - name: address-family/ipv4/unicast
         value: ""
       - name: address-family/ipv6/unicast

--- a/internal/provider/data_source_iosxe_interface_ospfv3_test.go
+++ b/internal/provider/data_source_iosxe_interface_ospfv3_test.go
@@ -74,6 +74,7 @@ resource "iosxe_yang" "PreReq0" {
 resource "iosxe_yang" "PreReq1" {
 	path = "/Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3[id=1]"
 	attributes = {
+		"id" = "1"
 		"address-family/ipv4/unicast" = ""
 		"address-family/ipv6/unicast" = ""
 	}

--- a/internal/provider/resource_iosxe_interface_ospfv3_test.go
+++ b/internal/provider/resource_iosxe_interface_ospfv3_test.go
@@ -101,6 +101,7 @@ resource "iosxe_yang" "PreReq0" {
 resource "iosxe_yang" "PreReq1" {
 	path = "/Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3[id=1]"
 	attributes = {
+		"id" = "1"
 		"address-family/ipv4/unicast" = ""
 		"address-family/ipv6/unicast" = ""
 	}


### PR DESCRIPTION
## ✔️ Type of Change

- [x] 🐛 Bug fix (corrects an issue in resource behavior, RESTCONF/NETCONF handling)

## 🔗 Related

- Introduced by #527 (the prereq was added there).
- Side note: #543 introduces a new top-level \`iosxe_ospfv3\` resource. Once merged, a follow-up could simplify these prereqs to use the typed resource instead of \`iosxe_yang\`, but that is out of scope for this fix.

## 📝 Proposed Changes

The `main` pipeline has been failing on every nightly since build #1189 (2026-05-18) — the first run after #527 merged on 2026-05-17. Two tests fail deterministically with the same error:

```terraform
TestAccDataSourceIosxeInterfaceOSPFv3 — data_source_iosxe_interface_ospfv3_test.go:50
TestAccIosxeInterfaceOSPFv3           — resource_iosxe_interface_ospfv3_test.go:52

StatusCode 400, RESTCONF errors:
  ErrorTag:     malformed-message
  ErrorPath:    /Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3
  ErrorMessage: missing element: id in /ios:native/ios:router/ios-ospfv3:ospfv3
```

### Root cause

The new test prerequisite added by #527 in `gen/definitions/interface_ospfv3.yaml` puts the list-key `[id=1]` only in the URL predicate. The generator emits whatever is listed under `attributes:` as the JSON body, and nothing else — it does not auto-inject the predicate value. RESTCONF requires the list key to appear in the body too when PATCHing a list entry, so the device rejects the request with `malformed-message: missing element: id`, and both downstream interface_ospfv3 tests fail at the prereq stage before their own apply runs.

Every other list-keyed prereq in this repo follows the convention of including the key in `attributes:` — e.g. `gen/definitions/bgp_address_family_ipv4.yaml`:

```yaml
- path: /Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-bgp:bgp[id=65000]
  attributes:
    - name: id
      value: 65000
```

### Fix

Add the missing \`id: 1\` body attribute to the OSPFv3 router-level prereq in \`gen/definitions/interface_ospfv3.yaml\` and regenerate (\`make gen NAME=\"Interface OSPFv3\"\`). The generated tests pick up the change automatically.

### Diff

Two YAML lines plus the two regenerated test files (1 line each):

```yaml
- path: /Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3[id=1]
  attributes:
    - name: id          # added
      value: 1          # added
    - name: address-family/ipv4/unicast
      value: \"\"
    - name: address-family/ipv6/unicast
      value: \"\"
  dependencies: [0]
```

## 🧪 Testing Evidence

- [x] Verified `id` is the documented list key for `/Cisco-IOS-XE-native:native/router/Cisco-IOS-XE-ospfv3:ospfv3` (see #543's own `gen/definitions/ospfv3.yaml`, which uses `yang_name: id` as the keyed attribute).
- [x] Workflow followed per contributor guide: edited only YAML, regenerated via \`make gen NAME=\"Interface OSPFv3\"\` — no hand-edits to generated files.
- [ ] CI — left to the `main` pipeline to confirm green on next nightly.