### PR TITLE
fix(aaa): mark new_model as no_delete to prevent removal attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `iosxe_aaa` resource attempting to delete the `new_model` attribute on update or destroy. IOS-XE does not permit removal of `aaa new-model` once configured (`no aaa new-model` is rejected by the device with active AAA dependents); the leaf is now marked `no_delete: true`
 - Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix `iosxe_aaa` resource attempting to delete the `new_model` attribute on update or destroy. IOS-XE does not permit removal of `aaa new-model` once configured (`no aaa new-model` is rejected by the device with active AAA dependents); the leaf is now marked `no_delete: true`
 - Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)

--- a/gen/definitions/aaa.yaml
+++ b/gen/definitions/aaa.yaml
@@ -7,6 +7,7 @@ test_tags: [AAA]
 attributes:
   - yang_name: Cisco-IOS-XE-aaa:new-model
     example: true
+    no_delete: true
   - yang_name: Cisco-IOS-XE-aaa:server/radius/dynamic-author
     example: true
   - yang_name: Cisco-IOS-XE-aaa:session-id

--- a/internal/provider/model_iosxe_aaa.go
+++ b/internal/provider/model_iosxe_aaa.go
@@ -1897,9 +1897,6 @@ func (data *AAA) getDeletedItems(ctx context.Context, state AAA) []string {
 	if !state.ServerRadiusDynamicAuthor.IsNull() && data.ServerRadiusDynamicAuthor.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:server/radius/dynamic-author", state.getPath()))
 	}
-	if !state.NewModel.IsNull() && data.NewModel.IsNull() {
-		deletedItems = append(deletedItems, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:new-model", state.getPath()))
-	}
 
 	return deletedItems
 }
@@ -2141,9 +2138,6 @@ func (data *AAA) addDeletedItemsXML(ctx context.Context, state AAA, body string)
 	if !state.ServerRadiusDynamicAuthor.IsNull() && data.ServerRadiusDynamicAuthor.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-aaa:server/radius/dynamic-author")
 	}
-	if !state.NewModel.IsNull() && data.NewModel.IsNull() {
-		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-aaa:new-model")
-	}
 
 	b = helpers.CleanupRedundantRemoveOperations(b)
 	return b.Res()
@@ -2202,9 +2196,6 @@ func (data *AAA) getDeletePaths(ctx context.Context) []string {
 	if !data.ServerRadiusDynamicAuthor.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:server/radius/dynamic-author", data.getPath()))
 	}
-	if !data.NewModel.IsNull() {
-		deletePaths = append(deletePaths, fmt.Sprintf("%v/Cisco-IOS-XE-aaa:new-model", data.getPath()))
-	}
 
 	return deletePaths
 }
@@ -2259,9 +2250,6 @@ func (data *AAA) addDeletePathsXML(ctx context.Context, body string) string {
 	}
 	if !data.ServerRadiusDynamicAuthor.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-aaa:server/radius/dynamic-author")
-	}
-	if !data.NewModel.IsNull() {
-		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-aaa:new-model")
 	}
 
 	b = helpers.CleanupRedundantRemoveOperations(b)

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## Unreleased
 
+- Fix `iosxe_aaa` resource attempting to delete the `new_model` attribute on update or destroy. IOS-XE does not permit removal of `aaa new-model` once configured (`no aaa new-model` is rejected by the device with active AAA dependents); the leaf is now marked `no_delete: true`
 - Add `bpduguard_enable`, `bpduguard_disable`, `spanning_tree_portfast`, `spanning_tree_portfast_disable`, `spanning_tree_portfast_trunk`, and `spanning_tree_portfast_edge` attributes to `iosxe_interface_port_channel` resource and data source
 - Fix perpetual `terraform plan` drift on `iosxe_route_map` `set_communities` where IOS-XE returns decimal integers instead of the configured `AA:NN` notation by normalizing community values on read
 - Fix `iosxe_banner` "Provider produced invalid plan" error when recovering from device drift (out-of-band configuration changes)


### PR DESCRIPTION
## Summary

IOS-XE does not permit removal of `aaa new-model` once configured. The device rejects `no aaa new-model` when AAA-dependent commands (TACACS/RADIUS server groups, method lists, etc.) are present, and operationally it should not be flipped off via IaC even when the device would accept it.

This PR marks the `Cisco-IOS-XE-aaa:new-model` leaf as `no_delete: true` so the generated `iosxe_aaa` resource never emits a delete for it on update or destroy. Confirmed by inspecting the regenerated `model_iosxe_aaa.go` — the four delete/destroy code paths (\`getDeletedItems\`, \`addDeletedItemsXML\`, \`getDeletePaths\`, \`addDeletePathsXML\`) no longer reference \`NewModel\`.

Pattern matches existing protection for similarly dangerous flags:
- \`gen/definitions/service.yaml:12\` → \`password-recovery\`
- \`gen/definitions/vtp.yaml:9\`, \`:33\` → \`version\`, \`domain\`

## Changes

- \`gen/definitions/aaa.yaml\` — added \`no_delete: true\` on the \`new-model\` attribute
- \`internal/provider/model_iosxe_aaa.go\` — regenerated via \`go generate\`; removed four code paths that would have emitted delete operations on \`new-model\`
- \`CHANGELOG.md\` and \`templates/guides/changelog.md.tmpl\` — added \`Unreleased\` entry

## Test plan

- [x] \`go build ./...\` — clean
- [x] Manual diff inspection confirms only AAA delete-path code is affected
- [ ] Acceptance tests on a 17.15 device (happy to run locally if requested)

Closes #546