### PR TITLE
fix(interface_port_channel): use attribute-level deletes to clear EVPN bindings

### DIFF
--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -2,6 +2,7 @@
 name: Interface Port Channel
 path: /Cisco-IOS-XE-native:native/interface/Port-channel[name=%v]
 doc_category: Interface
+default_delete_attributes: true
 test_tags: [C9000V]
 attributes:
   - yang_name: name

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -182,7 +182,6 @@ resource "iosxe_yang" "PreReq8" {
 
 func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 	config := `resource "iosxe_interface_port_channel" "test" {` + "\n"
-	config += `	delete_mode = "attributes"` + "\n"
 	config += `	name = 10` + "\n"
 	config += `	description = "My Interface Description"` + "\n"
 	config += `	shutdown = false` + "\n"

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -853,7 +853,7 @@ func (r *InterfacePortChannelResource) Delete(ctx context.Context, req resource.
 	}
 
 	if device.Managed {
-		deleteMode := "all"
+		deleteMode := "attributes"
 		if state.DeleteMode.ValueString() == "all" {
 			deleteMode = "all"
 		} else if state.DeleteMode.ValueString() == "attributes" {

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -221,6 +221,7 @@ func testAccIosxeInterfacePortChannelConfig_minimum() string {
 
 func testAccIosxeInterfacePortChannelConfig_all() string {
 	config := `resource "iosxe_interface_port_channel" "test" {` + "\n"
+	config += `	delete_mode = "all"` + "\n"
 	config += `	name = 10` + "\n"
 	config += `	description = "My Interface Description"` + "\n"
 	config += `	shutdown = false` + "\n"


### PR DESCRIPTION
## Summary

- Switch `iosxe_interface_port_channel` default delete mode from `"all"` to `"attributes"` so `terraform destroy` issues individual DELETEs via `getDeletePaths()`, correctly removing L2VPN-augmented EVPN ethernet-segment bindings before the interface is removed.

Fixes #553

## Test plan

- [x] `make gen` passes (generates expected test adjustments)
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Acceptance test `TestAccIosxeInterfacePortChannel` passes with attribute-level destroy
- [ ] Legacy EVPN ethernet-segment fixture destroy no longer returns 404/error