### PR TITLE
fix(interface_port_channel): ignore delete_mode in import verification

### DIFF
--- a/gen/templates/resource_test.go
+++ b/gen/templates/resource_test.go
@@ -111,7 +111,7 @@ func TestAccIosxe{{camelCase .Name}}(t *testing.T) {
 				ImportState:   true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: iosxe{{camelCase .Name}}ImportStateIdFunc("iosxe_{{snakeCase $name}}.test"),
-				ImportStateVerifyIgnore: []string{ {{range getImportExcludes .Attributes}}"{{.}}",{{end}} },
+				ImportStateVerifyIgnore: []string{ {{range getImportExcludes .Attributes}}"{{.}}",{{end}}{{if and (not .NoDelete) (not .NoDeleteAttributes) .DefaultDeleteAttributes}}"delete_mode",{{end}} },
 				Check: resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -95,7 +95,7 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeInterfacePortChannelImportStateIdFunc("iosxe_interface_port_channel.test"),
-				ImportStateVerifyIgnore: []string{"ipv4_address_dhcp", "auto_qos_classify", "auto_qos_classify_police", "auto_qos_trust", "auto_qos_trust_cos", "auto_qos_trust_dscp", "auto_qos_video_cts", "auto_qos_video_ip_camera", "auto_qos_video_media_player", "auto_qos_voip_cisco_phone", "auto_qos_voip_cisco_softphone", "auto_qos_voip_trust", "ipv6_nd_ra_suppress_all", "ipv6_address_autoconfig_default", "bpduguard_enable", "bpduguard_disable", "spanning_tree_portfast", "spanning_tree_portfast_disable", "spanning_tree_portfast_trunk", "spanning_tree_portfast_edge", "ip_dhcp_snooping_trust", "device_tracking", "ip_nat_inside", "ip_nat_outside"},
+				ImportStateVerifyIgnore: []string{"ipv4_address_dhcp", "auto_qos_classify", "auto_qos_classify_police", "auto_qos_trust", "auto_qos_trust_cos", "auto_qos_trust_dscp", "auto_qos_video_cts", "auto_qos_video_ip_camera", "auto_qos_video_media_player", "auto_qos_voip_cisco_phone", "auto_qos_voip_cisco_softphone", "auto_qos_voip_trust", "ipv6_nd_ra_suppress_all", "ipv6_address_autoconfig_default", "bpduguard_enable", "bpduguard_disable", "spanning_tree_portfast", "spanning_tree_portfast_disable", "spanning_tree_portfast_trunk", "spanning_tree_portfast_edge", "ip_dhcp_snooping_trust", "device_tracking", "ip_nat_inside", "ip_nat_outside", "delete_mode"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},


### PR DESCRIPTION
Resources that set `default_delete_attributes` get `delete_mode = "all"` injected into their generated `_all` test configuration, but `delete_mode` was never added to that test step's `ImportStateVerifyIgnore`. Since `delete_mode` is a client-side-only attribute that the device does not return on read, `ImportStateVerify` reports it as missing after import and `TestAccIosxeInterfacePortChannel` fails.

Emit `delete_mode` into `ImportStateVerifyIgnore` in the resource test template under the same condition that injects it into the config, and regenerate. `interface_port_channel` is the only resource that sets `default_delete_attributes` today.
