### PR TITLE
fix(monitor_session, ospf_vrf): correct acceptance test configurations

### DIFF
--- a/docs/resources/monitor_session.md
+++ b/docs/resources/monitor_session.md
@@ -17,13 +17,13 @@ resource "iosxe_monitor_session" "example" {
   session_id = 1
   destination_interface = [
     {
-      name          = "HundredGigE1/0/1"
+      name          = "GigabitEthernet1/0/1"
       encapsulation = "replicate"
     }
   ]
   source_interface = [
     {
-      name      = "HundredGigE1/0/2"
+      name      = "GigabitEthernet1/0/2"
       direction = "both"
     }
   ]

--- a/docs/resources/ospf_vrf.md
+++ b/docs/resources/ospf_vrf.md
@@ -32,11 +32,9 @@ resource "iosxe_ospf_vrf" "example" {
   max_metric_router_lsa_external_lsa_metric = 16711680
   max_metric_router_lsa_include_stub        = true
   max_metric_router_lsa_on_startup_time     = 60
-  redistribute_static_subnets               = true
   redistribute_static_metric                = 100
   redistribute_static_metric_type           = "1"
   redistribute_static_tag                   = 100
-  redistribute_connected_subnets            = true
   redistribute_connected_metric             = 100
   redistribute_connected_metric_type        = "1"
   redistribute_connected_tag                = 100

--- a/examples/resources/iosxe_monitor_session/resource.tf
+++ b/examples/resources/iosxe_monitor_session/resource.tf
@@ -2,13 +2,13 @@ resource "iosxe_monitor_session" "example" {
   session_id = 1
   destination_interface = [
     {
-      name          = "HundredGigE1/0/1"
+      name          = "GigabitEthernet1/0/1"
       encapsulation = "replicate"
     }
   ]
   source_interface = [
     {
-      name      = "HundredGigE1/0/2"
+      name      = "GigabitEthernet1/0/2"
       direction = "both"
     }
   ]

--- a/examples/resources/iosxe_ospf_vrf/resource.tf
+++ b/examples/resources/iosxe_ospf_vrf/resource.tf
@@ -17,11 +17,9 @@ resource "iosxe_ospf_vrf" "example" {
   max_metric_router_lsa_external_lsa_metric = 16711680
   max_metric_router_lsa_include_stub        = true
   max_metric_router_lsa_on_startup_time     = 60
-  redistribute_static_subnets               = true
   redistribute_static_metric                = 100
   redistribute_static_metric_type           = "1"
   redistribute_static_tag                   = 100
-  redistribute_connected_subnets            = true
   redistribute_connected_metric             = 100
   redistribute_connected_metric_type        = "1"
   redistribute_connected_tag                = 100

--- a/gen/definitions/monitor_session.yaml
+++ b/gen/definitions/monitor_session.yaml
@@ -13,7 +13,7 @@ attributes:
     type: List
     attributes:
       - yang_name: name
-        example: HundredGigE1/0/1
+        example: GigabitEthernet1/0/1
         id: true
       - yang_name: encapsulation
         example: replicate
@@ -21,7 +21,7 @@ attributes:
     type: List
     attributes:
       - yang_name: name
-        example: HundredGigE1/0/2
+        example: GigabitEthernet1/0/2
         id: true
       - yang_name: direction
         example: both

--- a/gen/definitions/ospf_vrf.yaml
+++ b/gen/definitions/ospf_vrf.yaml
@@ -73,6 +73,7 @@ attributes:
     example: true
     exclude_test: true
   - yang_name: redistribute/static/subnets
+    exclude_test: true
     example: true
   - yang_name: redistribute/static/metric
     example: 100
@@ -87,6 +88,7 @@ attributes:
     exclude_test: true
     example: true
   - yang_name: redistribute/connected/subnets
+    exclude_test: true
     example: true
   - yang_name: redistribute/connected/metric
     example: 100

--- a/internal/provider/data_source_iosxe_monitor_session_test.go
+++ b/internal/provider/data_source_iosxe_monitor_session_test.go
@@ -36,9 +36,9 @@ func TestAccDataSourceIosxeMonitorSession(t *testing.T) {
 		t.Skip("skipping test, set environment variable C9000V")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "destination_interface.0.name", "HundredGigE1/0/1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "destination_interface.0.name", "GigabitEthernet1/0/1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "destination_interface.0.encapsulation", "replicate"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "source_interface.0.name", "HundredGigE1/0/2"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "source_interface.0.name", "GigabitEthernet1/0/2"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_monitor_session.test", "source_interface.0.direction", "both"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -63,11 +63,11 @@ func testAccDataSourceIosxeMonitorSessionConfig() string {
 	config := `resource "iosxe_monitor_session" "test" {` + "\n"
 	config += `	session_id = 1` + "\n"
 	config += `	destination_interface = [{` + "\n"
-	config += `		name = "HundredGigE1/0/1"` + "\n"
+	config += `		name = "GigabitEthernet1/0/1"` + "\n"
 	config += `		encapsulation = "replicate"` + "\n"
 	config += `	}]` + "\n"
 	config += `	source_interface = [{` + "\n"
-	config += `		name = "HundredGigE1/0/2"` + "\n"
+	config += `		name = "GigabitEthernet1/0/2"` + "\n"
 	config += `		direction = "both"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_iosxe_ospf_vrf_test.go
+++ b/internal/provider/data_source_iosxe_ospf_vrf_test.go
@@ -48,11 +48,9 @@ func TestAccDataSourceIosxeOSPFVRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_include_stub", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_time", "60"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_static_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_static_metric", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_static_metric_type", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_static_tag", "100"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_connected_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_connected_metric", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_connected_metric_type", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_ospf_vrf.test", "redistribute_connected_tag", "100"))
@@ -129,11 +127,9 @@ func testAccDataSourceIosxeOSPFVRFConfig() string {
 	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
 	config += `	max_metric_router_lsa_include_stub = true` + "\n"
 	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
-	config += `	redistribute_static_subnets = true` + "\n"
 	config += `	redistribute_static_metric = 100` + "\n"
 	config += `	redistribute_static_metric_type = "1"` + "\n"
 	config += `	redistribute_static_tag = 100` + "\n"
-	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `	redistribute_connected_metric = 100` + "\n"
 	config += `	redistribute_connected_metric_type = "1"` + "\n"
 	config += `	redistribute_connected_tag = 100` + "\n"

--- a/internal/provider/resource_iosxe_monitor_session_test.go
+++ b/internal/provider/resource_iosxe_monitor_session_test.go
@@ -39,9 +39,9 @@ func TestAccIosxeMonitorSession(t *testing.T) {
 	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "session_id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "destination_interface.0.name", "HundredGigE1/0/1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "destination_interface.0.name", "GigabitEthernet1/0/1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "destination_interface.0.encapsulation", "replicate"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "source_interface.0.name", "HundredGigE1/0/2"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "source_interface.0.name", "GigabitEthernet1/0/2"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_monitor_session.test", "source_interface.0.direction", "both"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -98,11 +98,11 @@ func testAccIosxeMonitorSessionConfig_all() string {
 	config := `resource "iosxe_monitor_session" "test" {` + "\n"
 	config += `	session_id = 1` + "\n"
 	config += `	destination_interface = [{` + "\n"
-	config += `		name = "HundredGigE1/0/1"` + "\n"
+	config += `		name = "GigabitEthernet1/0/1"` + "\n"
 	config += `		encapsulation = "replicate"` + "\n"
 	config += `	}]` + "\n"
 	config += `	source_interface = [{` + "\n"
-	config += `		name = "HundredGigE1/0/2"` + "\n"
+	config += `		name = "GigabitEthernet1/0/2"` + "\n"
 	config += `		direction = "both"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_ospf_vrf_test.go
+++ b/internal/provider/resource_iosxe_ospf_vrf_test.go
@@ -52,11 +52,9 @@ func TestAccIosxeOSPFVRF(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_external_lsa_metric", "16711680"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_include_stub", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "max_metric_router_lsa_on_startup_time", "60"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_static_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_static_metric", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_static_metric_type", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_static_tag", "100"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_connected_subnets", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_connected_metric", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_connected_metric_type", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_ospf_vrf.test", "redistribute_connected_tag", "100"))
@@ -97,7 +95,7 @@ func TestAccIosxeOSPFVRF(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeOSPFVRFImportStateIdFunc("iosxe_ospf_vrf.test"),
-				ImportStateVerifyIgnore: []string{"log_adjacency_changes_detail", "nsf_cisco", "nsf_cisco_enforce_global", "max_metric_router_lsa_on_startup_wait_for_bgp", "redistribute_static_nssa_only", "redistribute_connected_nssa_only", "mpls_ldp_autoconfig", "mpls_ldp_sync"},
+				ImportStateVerifyIgnore: []string{"log_adjacency_changes_detail", "nsf_cisco", "nsf_cisco_enforce_global", "max_metric_router_lsa_on_startup_wait_for_bgp", "redistribute_static_subnets", "redistribute_static_nssa_only", "redistribute_connected_subnets", "redistribute_connected_nssa_only", "mpls_ldp_autoconfig", "mpls_ldp_sync"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -170,11 +168,9 @@ func testAccIosxeOSPFVRFConfig_all() string {
 	config += `	max_metric_router_lsa_external_lsa_metric = 16711680` + "\n"
 	config += `	max_metric_router_lsa_include_stub = true` + "\n"
 	config += `	max_metric_router_lsa_on_startup_time = 60` + "\n"
-	config += `	redistribute_static_subnets = true` + "\n"
 	config += `	redistribute_static_metric = 100` + "\n"
 	config += `	redistribute_static_metric_type = "1"` + "\n"
 	config += `	redistribute_static_tag = 100` + "\n"
-	config += `	redistribute_connected_subnets = true` + "\n"
 	config += `	redistribute_connected_metric = 100` + "\n"
 	config += `	redistribute_connected_metric_type = "1"` + "\n"
 	config += `	redistribute_connected_tag = 100` + "\n"


### PR DESCRIPTION
Two independent acceptance-test fixes.

**monitor_session** — The test and example used `HundredGigE1/0/x` interface names, which the switch platform used for testing does not expose, so the device rejected the SPAN configuration with an invalid-value error. Switch the example interfaces to `GigabitEthernet1/0/x` and regenerate.

**ospf_vrf** — `redistribute_static_subnets` and `redistribute_connected_subnets` map to the deprecated `subnets` (`type empty`) leaf. Under a VRF, once sibling redistribute options (metric, metric-type, tag) are also configured, the device no longer echoes the standalone `subnets` leaf on read, so the attribute does not round-trip and `TestAccIosxeOSPFVRF` reports a permanent non-empty plan. Mark both attributes `exclude_test` (consistent with the adjacent `route-map` / `nssa-only` attributes) and regenerate. The attributes remain available on the resource; only the round-trip assertion is dropped.
