### PR TITLE
fix: correct acceptance tests for route_map, privilege, object_group, switch

### DIFF
--- a/docs/data-sources/switch.md
+++ b/docs/data-sources/switch.md
@@ -14,7 +14,7 @@ This data source can read the Switch configuration.
 
 ```terraform
 data "iosxe_switch" "example" {
-  number = 1
+  number = 2
 }
 ```
 

--- a/docs/resources/object_group.md
+++ b/docs/resources/object_group.md
@@ -52,7 +52,7 @@ resource "iosxe_object_group" "example" {
     {
       name                      = "SERVICE_GROUP_1"
       description               = "My service object group"
-      protocol_numbers          = []
+      protocol_numbers          = [47]
       ahp                       = true
       eigrp                     = false
       esp                       = false

--- a/docs/resources/privilege.md
+++ b/docs/resources/privilege.md
@@ -20,7 +20,7 @@ resource "iosxe_privilege" "example" {
       level = 7
       commands = [
         {
-          command = "show running-config"
+          command = "configure"
         }
       ]
     }

--- a/docs/resources/switch.md
+++ b/docs/resources/switch.md
@@ -14,7 +14,7 @@ This resource can manage the Switch configuration.
 
 ```terraform
 resource "iosxe_switch" "example" {
-  number    = 1
+  number    = 2
   provision = "c9300-24p"
 }
 ```

--- a/examples/data-sources/iosxe_switch/data-source.tf
+++ b/examples/data-sources/iosxe_switch/data-source.tf
@@ -1,3 +1,3 @@
 data "iosxe_switch" "example" {
-  number = 1
+  number = 2
 }

--- a/examples/resources/iosxe_object_group/resource.tf
+++ b/examples/resources/iosxe_object_group/resource.tf
@@ -37,7 +37,7 @@ resource "iosxe_object_group" "example" {
     {
       name                      = "SERVICE_GROUP_1"
       description               = "My service object group"
-      protocol_numbers          = []
+      protocol_numbers          = [47]
       ahp                       = true
       eigrp                     = false
       esp                       = false

--- a/examples/resources/iosxe_privilege/resource.tf
+++ b/examples/resources/iosxe_privilege/resource.tf
@@ -5,7 +5,7 @@ resource "iosxe_privilege" "example" {
       level = 7
       commands = [
         {
-          command = "show running-config"
+          command = "configure"
         }
       ]
     }

--- a/examples/resources/iosxe_switch/resource.tf
+++ b/examples/resources/iosxe_switch/resource.tf
@@ -1,4 +1,4 @@
 resource "iosxe_switch" "example" {
-  number    = 1
+  number    = 2
   provision = "c9300-24p"
 }

--- a/gen/definitions/object_group.yaml
+++ b/gen/definitions/object_group.yaml
@@ -107,6 +107,7 @@ attributes:
       - yang_name: protocal-number
         tf_name: protocol_numbers
         type: Int64Set
+        example: 47
         attributes:
           - yang_name: protocal-number
             tf_name: number

--- a/gen/definitions/privilege.yaml
+++ b/gen/definitions/privilege.yaml
@@ -19,5 +19,5 @@ attributes:
         type: List
         attributes:
           - yang_name: command
-            example: show running-config
+            example: configure
             id: true

--- a/gen/definitions/route_map.yaml
+++ b/gen/definitions/route_map.yaml
@@ -27,6 +27,7 @@ attributes:
       - yang_name: description
         tf_name: description_legacy
         test_tags: [IOSXE1712]
+        allow_import_changes: true
         example: Entry 10
       - yang_name: continue
         example: false

--- a/gen/definitions/switch.yaml
+++ b/gen/definitions/switch.yaml
@@ -5,6 +5,6 @@ doc_category: System
 test_tags: [C9000V]
 attributes:
   - yang_name: number
-    example: 1
+    example: 2
   - yang_name: provision
     example: c9300-24p

--- a/internal/provider/data_source_iosxe_object_group_test.go
+++ b/internal/provider/data_source_iosxe_object_group_test.go
@@ -244,7 +244,7 @@ func testAccDataSourceIosxeObjectGroupConfig() string {
 	config += `	service = [{` + "\n"
 	config += `		name = "SERVICE_GROUP_1"` + "\n"
 	config += `		description = "My service object group"` + "\n"
-	config += `		protocol_numbers = []` + "\n"
+	config += `		protocol_numbers = [47]` + "\n"
 	config += `		ahp = true` + "\n"
 	config += `		eigrp = false` + "\n"
 	config += `		esp = false` + "\n"

--- a/internal/provider/data_source_iosxe_privilege_test.go
+++ b/internal/provider/data_source_iosxe_privilege_test.go
@@ -33,7 +33,7 @@ import (
 func TestAccDataSourceIosxePrivilege(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "levels.0.level", "7"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "levels.0.commands.0.command", "show running-config"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "levels.0.commands.0.command", "configure"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -59,7 +59,7 @@ func testAccDataSourceIosxePrivilegeConfig() string {
 	config += `	levels = [{` + "\n"
 	config += `		level = 7` + "\n"
 	config += `		commands = [{` + "\n"
-	config += `			command = "show running-config"` + "\n"
+	config += `			command = "configure"` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_iosxe_switch_test.go
+++ b/internal/provider/data_source_iosxe_switch_test.go
@@ -59,13 +59,13 @@ func TestAccDataSourceIosxeSwitch(t *testing.T) {
 func testAccDataSourceIosxeSwitchConfig() string {
 	config := `resource "iosxe_switch" "test" {` + "\n"
 	config += `	delete_mode = "attributes"` + "\n"
-	config += `	number = 1` + "\n"
+	config += `	number = 2` + "\n"
 	config += `	provision = "c9300-24p"` + "\n"
 	config += `}` + "\n"
 
 	config += `
 		data "iosxe_switch" "test" {
-			number = 1
+			number = 2
 			depends_on = [iosxe_switch.test]
 		}
 	`

--- a/internal/provider/resource_iosxe_object_group_test.go
+++ b/internal/provider/resource_iosxe_object_group_test.go
@@ -278,7 +278,7 @@ func testAccIosxeObjectGroupConfig_all() string {
 	config += `	service = [{` + "\n"
 	config += `		name = "SERVICE_GROUP_1"` + "\n"
 	config += `		description = "My service object group"` + "\n"
-	config += `		protocol_numbers = []` + "\n"
+	config += `		protocol_numbers = [47]` + "\n"
 	config += `		ahp = true` + "\n"
 	config += `		eigrp = false` + "\n"
 	config += `		esp = false` + "\n"

--- a/internal/provider/resource_iosxe_privilege_test.go
+++ b/internal/provider/resource_iosxe_privilege_test.go
@@ -36,7 +36,7 @@ func TestAccIosxePrivilege(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "name", "exec"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "levels.0.level", "7"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "levels.0.commands.0.command", "show running-config"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "levels.0.commands.0.command", "configure"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -97,7 +97,7 @@ func testAccIosxePrivilegeConfig_all() string {
 	config += `	levels = [{` + "\n"
 	config += `		level = 7` + "\n"
 	config += `		commands = [{` + "\n"
-	config += `			command = "show running-config"` + "\n"
+	config += `			command = "configure"` + "\n"
 	config += `		}]` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_route_map_test.go
+++ b/internal/provider/resource_iosxe_route_map_test.go
@@ -171,7 +171,7 @@ func TestAccIosxeRouteMap(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeRouteMapImportStateIdFunc("iosxe_route_map.test"),
-				ImportStateVerifyIgnore: []string{"entries.0.match_route_type_local_legacy", "entries.0.match_route_type_local", "entries.0.match_community_list_exact_match", "entries.0.set_ip_next_hop_self", "entries.0.set_ip_next_hop_unchanged", "entries.0.set_level_1_2", "entries.0.set_level_2", "entries.0.set_as_path_tag_legacy", "entries.0.set_community_none_legacy", "entries.0.set_communities_additive_legacy", "entries.0.set_community_list_delete_legacy", "entries.0.set_as_path_tag", "entries.0.set_as_path_replace_any", "entries.0.set_community_none", "entries.0.set_communities_additive", "entries.0.set_community_list_delete", "entries.0.set_extcomunity_vpn_distinguisher_additive"},
+				ImportStateVerifyIgnore: []string{"entries.0.description_legacy", "entries.0.match_route_type_local_legacy", "entries.0.match_route_type_local", "entries.0.match_community_list_exact_match", "entries.0.set_ip_next_hop_self", "entries.0.set_ip_next_hop_unchanged", "entries.0.set_level_1_2", "entries.0.set_level_2", "entries.0.set_as_path_tag_legacy", "entries.0.set_community_none_legacy", "entries.0.set_communities_additive_legacy", "entries.0.set_community_list_delete_legacy", "entries.0.set_as_path_tag", "entries.0.set_as_path_replace_any", "entries.0.set_community_none", "entries.0.set_communities_additive", "entries.0.set_community_list_delete", "entries.0.set_extcomunity_vpn_distinguisher_additive"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/internal/provider/resource_iosxe_switch_test.go
+++ b/internal/provider/resource_iosxe_switch_test.go
@@ -38,7 +38,7 @@ func TestAccIosxeSwitch(t *testing.T) {
 		t.Skip("skipping test, set environment variable C9000V")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_switch.test", "number", "1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_switch.test", "number", "2"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_switch.test", "provision", "c9300-24p"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -85,7 +85,7 @@ func iosxeSwitchImportStateIdFunc(resourceName string) resource.ImportStateIdFun
 
 func testAccIosxeSwitchConfig_minimum() string {
 	config := `resource "iosxe_switch" "test" {` + "\n"
-	config += `	number = 1` + "\n"
+	config += `	number = 2` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -96,7 +96,7 @@ func testAccIosxeSwitchConfig_minimum() string {
 
 func testAccIosxeSwitchConfig_all() string {
 	config := `resource "iosxe_switch" "test" {` + "\n"
-	config += `	number = 1` + "\n"
+	config += `	number = 2` + "\n"
 	config += `	provision = "c9300-24p"` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
Acceptance-test fixes for the latest feature batch. All are definition-only (`gen/definitions/*.yaml`) changes regenerated with `make gen` — no hand-edited Go.

- **route_map**: `allow_import_changes` on `description_legacy` — the device mirrors the new `descriptions` list onto the obsolete legacy leaf, so it reappears on import.
- **privilege**: single-token command example (`configure`) — a multi-word command makes the device auto-create a parent entry, so the command list never round-trips.
- **object_group**: add a Set-node `example` to `protocol_numbers` — without it the generated test set was `[]` while the read returns null, causing a perpetual plan.
- **switch**: provision an absent stack member (`number = 2`) — the device rejects provisioning member 1 because it is the active unit.
