### PR TITLE
fix(switch): gate acceptance tests to physical stack hardware

### DIFF
--- a/gen/definitions/switch.yaml
+++ b/gen/definitions/switch.yaml
@@ -2,7 +2,7 @@
 name: Switch
 path: /Cisco-IOS-XE-native:native/Cisco-IOS-XE-switch:switch[number=%v]
 doc_category: System
-test_tags: [C9000V]
+test_tags: [C9500]
 attributes:
   - yang_name: number
     example: 2

--- a/internal/provider/data_source_iosxe_switch_test.go
+++ b/internal/provider/data_source_iosxe_switch_test.go
@@ -32,8 +32,8 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeSwitch(t *testing.T) {
-	if os.Getenv("C9000V") == "" {
-		t.Skip("skipping test, set environment variable C9000V")
+	if os.Getenv("C9500") == "" {
+		t.Skip("skipping test, set environment variable C9500")
 	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_switch.test", "provision", "c9300-24p"))

--- a/internal/provider/resource_iosxe_switch_test.go
+++ b/internal/provider/resource_iosxe_switch_test.go
@@ -34,8 +34,8 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeSwitch(t *testing.T) {
-	if os.Getenv("C9000V") == "" {
-		t.Skip("skipping test, set environment variable C9000V")
+	if os.Getenv("C9500") == "" {
+		t.Skip("skipping test, set environment variable C9500")
 	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_switch.test", "number", "2"))


### PR DESCRIPTION
`switch <n> provision <model>` is offline config for a physically absent stack member. Virtual platforms have no stack backplane and reject the command at apply (`Device refused`), so `TestAccIosxeSwitch` / `TestAccDataSourceIosxeSwitch` can never pass on the virtual test fleet.

Tag the resource `[C9500]` — the existing convention for physical-hardware-only features (already used by `stackwise_virtual` and `interface_stackwise_virtual`) — so the tests skip on the virtual stages and run only on real stack-capable hardware. Definition-only change regenerated with `make gen`; no logic touched.
