### PR TITLE
fix(large_community_list_standard): use attribute-level delete

### DIFF
--- a/gen/definitions/large_community_list_standard.yaml
+++ b/gen/definitions/large_community_list_standard.yaml
@@ -2,6 +2,7 @@
 name: Large Community List Standard
 path: /Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-bgp:large-community-list/standard[name=%v]
 no_delete_attributes: true
+default_delete_attributes: true
 skip_minimum_test: true
 doc_category: BGP
 attributes:

--- a/internal/provider/resource_iosxe_large_community_list_standard.go
+++ b/internal/provider/resource_iosxe_large_community_list_standard.go
@@ -311,7 +311,7 @@ func (r *LargeCommunityListStandardResource) Delete(ctx context.Context, req res
 	}
 
 	if device.Managed {
-		deleteMode := "all"
+		deleteMode := "attributes"
 
 		// NETCONF - Serialize write operations
 		locked := helpers.AcquireNetconfLock(&device.NetconfOpMutex, device.ReuseConnection, true)


### PR DESCRIPTION
A standard large-community-list exists only while it has entries — the device auto-removes the list when its last entry is deleted. The default "delete the whole container" behavior then issues a redundant `no ip large-community-list standard <name>`, which the device rejects (`% Specified large community list does not exist`), so `terraform destroy` fails (on both router and switch — `TestAccIosxeLargeCommunityListStandard` create/import pass, only destroy fails).

Set `default_delete_attributes` so the delete removes the individual permit/deny entries and lets the device prune the list — no redundant parent removal. Definition-only change + `make gen` (the resource's delete mode flips to attribute-level; the existing `addDeletePathsXML` already targets the entry leaf-lists). The expanded variant is unaffected — its list structure deletes cleanly.
