### PR TITLE
fix(privilege): key resource by privilege level

### DIFF
--- a/docs/data-sources/privilege.md
+++ b/docs/data-sources/privilege.md
@@ -14,7 +14,8 @@ This data source can read the Privilege configuration.
 
 ```terraform
 data "iosxe_privilege" "example" {
-  name = "exec"
+  name  = "exec"
+  level = 7
 }
 ```
 
@@ -23,6 +24,7 @@ data "iosxe_privilege" "example" {
 
 ### Required
 
+- `level` (Number)
 - `name` (String)
 
 ### Optional
@@ -31,19 +33,11 @@ data "iosxe_privilege" "example" {
 
 ### Read-Only
 
+- `commands` (Attributes List) (see [below for nested schema](#nestedatt--commands))
 - `id` (String) The path of the retrieved object.
-- `levels` (Attributes List) Set privilege level of command (see [below for nested schema](#nestedatt--levels))
 
-<a id="nestedatt--levels"></a>
-### Nested Schema for `levels`
-
-Read-Only:
-
-- `commands` (Attributes List) (see [below for nested schema](#nestedatt--levels--commands))
-- `level` (Number)
-
-<a id="nestedatt--levels--commands"></a>
-### Nested Schema for `levels.commands`
+<a id="nestedatt--commands"></a>
+### Nested Schema for `commands`
 
 Read-Only:
 

--- a/docs/resources/privilege.md
+++ b/docs/resources/privilege.md
@@ -14,15 +14,11 @@ This resource can manage the Privilege configuration.
 
 ```terraform
 resource "iosxe_privilege" "example" {
-  name = "exec"
-  levels = [
+  name  = "exec"
+  level = 7
+  commands = [
     {
-      level = 7
-      commands = [
-        {
-          command = "configure"
-        }
-      ]
+      command = "configure"
     }
   ]
 }
@@ -33,30 +29,20 @@ resource "iosxe_privilege" "example" {
 
 ### Required
 
+- `level` (Number) - Range: `0`-`255`
 - `name` (String) - Choices: `configure`, `crypto-map`, `exec`, `interface`, `ipenacl`, `router`
 
 ### Optional
 
+- `commands` (Attributes List) (see [below for nested schema](#nestedatt--commands))
 - `device` (String) A device name from the provider configuration.
-- `levels` (Attributes List) Set privilege level of command (see [below for nested schema](#nestedatt--levels))
 
 ### Read-Only
 
 - `id` (String) The path of the object.
 
-<a id="nestedatt--levels"></a>
-### Nested Schema for `levels`
-
-Required:
-
-- `level` (Number) - Range: `0`-`255`
-
-Optional:
-
-- `commands` (Attributes List) (see [below for nested schema](#nestedatt--levels--commands))
-
-<a id="nestedatt--levels--commands"></a>
-### Nested Schema for `levels.commands`
+<a id="nestedatt--commands"></a>
+### Nested Schema for `commands`
 
 Required:
 
@@ -69,5 +55,5 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import iosxe_privilege.example "<name>"
+terraform import iosxe_privilege.example "<name>,<level>"
 ```

--- a/examples/data-sources/iosxe_privilege/data-source.tf
+++ b/examples/data-sources/iosxe_privilege/data-source.tf
@@ -1,3 +1,4 @@
 data "iosxe_privilege" "example" {
-  name = "exec"
+  name  = "exec"
+  level = 7
 }

--- a/examples/resources/iosxe_privilege/import.sh
+++ b/examples/resources/iosxe_privilege/import.sh
@@ -1,1 +1,1 @@
-terraform import iosxe_privilege.example "<name>"
+terraform import iosxe_privilege.example "<name>,<level>"

--- a/examples/resources/iosxe_privilege/resource.tf
+++ b/examples/resources/iosxe_privilege/resource.tf
@@ -1,13 +1,9 @@
 resource "iosxe_privilege" "example" {
-  name = "exec"
-  levels = [
+  name  = "exec"
+  level = 7
+  commands = [
     {
-      level = 7
-      commands = [
-        {
-          command = "configure"
-        }
-      ]
+      command = "configure"
     }
   ]
 }

--- a/gen/definitions/privilege.yaml
+++ b/gen/definitions/privilege.yaml
@@ -1,23 +1,18 @@
 ---
 name: Privilege
-path: /Cisco-IOS-XE-native:native/privilege/mode[name=%v]
+path: /Cisco-IOS-XE-native:native/privilege/mode[name=%v]/level[privilege=%v]
 no_delete_attributes: true
 doc_category: System
 attributes:
   - yang_name: name
     example: exec
-  - yang_name: level
-    tf_name: levels
+  - yang_name: privilege
+    tf_name: level
+    example: 7
+  - yang_name: command-list
+    tf_name: commands
     type: List
     attributes:
-      - yang_name: privilege
-        tf_name: level
-        example: 7
+      - yang_name: command
+        example: configure
         id: true
-      - yang_name: command-list
-        tf_name: commands
-        type: List
-        attributes:
-          - yang_name: command
-            example: configure
-            id: true

--- a/internal/provider/data_source_iosxe_privilege.go
+++ b/internal/provider/data_source_iosxe_privilege.go
@@ -72,26 +72,18 @@ func (d *PrivilegeDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				MarkdownDescription: "",
 				Required:            true,
 			},
-			"levels": schema.ListNestedAttribute{
-				MarkdownDescription: "Set privilege level of command",
+			"level": schema.Int64Attribute{
+				MarkdownDescription: "",
+				Required:            true,
+			},
+			"commands": schema.ListNestedAttribute{
+				MarkdownDescription: "",
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"level": schema.Int64Attribute{
-							MarkdownDescription: "",
+						"command": schema.StringAttribute{
+							MarkdownDescription: "There are side effects",
 							Computed:            true,
-						},
-						"commands": schema.ListNestedAttribute{
-							MarkdownDescription: "",
-							Computed:            true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"command": schema.StringAttribute{
-										MarkdownDescription: "There are side effects",
-										Computed:            true,
-									},
-								},
-							},
 						},
 					},
 				},

--- a/internal/provider/data_source_iosxe_privilege_test.go
+++ b/internal/provider/data_source_iosxe_privilege_test.go
@@ -32,8 +32,7 @@ import (
 
 func TestAccDataSourceIosxePrivilege(t *testing.T) {
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "levels.0.level", "7"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "levels.0.commands.0.command", "configure"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_privilege.test", "commands.0.command", "configure"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -56,17 +55,16 @@ func TestAccDataSourceIosxePrivilege(t *testing.T) {
 func testAccDataSourceIosxePrivilegeConfig() string {
 	config := `resource "iosxe_privilege" "test" {` + "\n"
 	config += `	name = "exec"` + "\n"
-	config += `	levels = [{` + "\n"
-	config += `		level = 7` + "\n"
-	config += `		commands = [{` + "\n"
-	config += `			command = "configure"` + "\n"
-	config += `		}]` + "\n"
+	config += `	level = 7` + "\n"
+	config += `	commands = [{` + "\n"
+	config += `		command = "configure"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"
 
 	config += `
 		data "iosxe_privilege" "test" {
 			name = "exec"
+			level = 7
 			depends_on = [iosxe_privilege.test]
 		}
 	`

--- a/internal/provider/model_iosxe_privilege.go
+++ b/internal/provider/model_iosxe_privilege.go
@@ -38,30 +38,24 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 type Privilege struct {
-	Device types.String      `tfsdk:"device"`
-	Id     types.String      `tfsdk:"id"`
-	Name   types.String      `tfsdk:"name"`
-	Levels []PrivilegeLevels `tfsdk:"levels"`
+	Device   types.String        `tfsdk:"device"`
+	Id       types.String        `tfsdk:"id"`
+	Name     types.String        `tfsdk:"name"`
+	Level    types.Int64         `tfsdk:"level"`
+	Commands []PrivilegeCommands `tfsdk:"commands"`
 }
-type PrivilegeLevels struct {
-	Level    types.Int64               `tfsdk:"level"`
-	Commands []PrivilegeLevelsCommands `tfsdk:"commands"`
-}
-type PrivilegeLevelsCommands struct {
+type PrivilegeCommands struct {
 	Command types.String `tfsdk:"command"`
 }
 
 type PrivilegeData struct {
-	Device types.String          `tfsdk:"device"`
-	Id     types.String          `tfsdk:"id"`
-	Name   types.String          `tfsdk:"name"`
-	Levels []PrivilegeLevelsData `tfsdk:"levels"`
+	Device   types.String            `tfsdk:"device"`
+	Id       types.String            `tfsdk:"id"`
+	Name     types.String            `tfsdk:"name"`
+	Level    types.Int64             `tfsdk:"level"`
+	Commands []PrivilegeCommandsData `tfsdk:"commands"`
 }
-type PrivilegeLevelsData struct {
-	Level    types.Int64                   `tfsdk:"level"`
-	Commands []PrivilegeLevelsCommandsData `tfsdk:"commands"`
-}
-type PrivilegeLevelsCommandsData struct {
+type PrivilegeCommandsData struct {
 	Command types.String `tfsdk:"command"`
 }
 
@@ -70,23 +64,23 @@ type PrivilegeLevelsCommandsData struct {
 // Section below is generated&owned by "gen/generator.go". //template:begin getPath
 
 func (data Privilege) getPath() string {
-	return fmt.Sprintf("Cisco-IOS-XE-native:native/privilege/mode=%v", url.QueryEscape(fmt.Sprintf("%v", data.Name.ValueString())))
+	return fmt.Sprintf("Cisco-IOS-XE-native:native/privilege/mode=%v/level=%v", url.QueryEscape(fmt.Sprintf("%v", data.Name.ValueString())), url.QueryEscape(fmt.Sprintf("%v", data.Level.ValueInt64())))
 }
 
 func (data PrivilegeData) getPath() string {
-	return fmt.Sprintf("Cisco-IOS-XE-native:native/privilege/mode=%v", url.QueryEscape(fmt.Sprintf("%v", data.Name.ValueString())))
+	return fmt.Sprintf("Cisco-IOS-XE-native:native/privilege/mode=%v/level=%v", url.QueryEscape(fmt.Sprintf("%v", data.Name.ValueString())), url.QueryEscape(fmt.Sprintf("%v", data.Level.ValueInt64())))
 }
 
 // getXPath returns the XPath for NETCONF operations
 func (data Privilege) getXPath() string {
-	path := "/Cisco-IOS-XE-native:native/privilege/mode[name=%v]"
-	path = fmt.Sprintf(path, fmt.Sprintf("%v", data.Name.ValueString()))
+	path := "/Cisco-IOS-XE-native:native/privilege/mode[name=%v]/level[privilege=%v]"
+	path = fmt.Sprintf(path, fmt.Sprintf("%v", data.Name.ValueString()), fmt.Sprintf("%v", data.Level.ValueInt64()))
 	return path
 }
 
 func (data PrivilegeData) getXPath() string {
-	path := "/Cisco-IOS-XE-native:native/privilege/mode[name=%v]"
-	path = fmt.Sprintf(path, fmt.Sprintf("%v", data.Name.ValueString()))
+	path := "/Cisco-IOS-XE-native:native/privilege/mode[name=%v]/level[privilege=%v]"
+	path = fmt.Sprintf(path, fmt.Sprintf("%v", data.Name.ValueString()), fmt.Sprintf("%v", data.Level.ValueInt64()))
 	return path
 }
 
@@ -96,25 +90,16 @@ func (data PrivilegeData) getXPath() string {
 
 func (data Privilege) toBodyXML(ctx context.Context, config Privilege) string {
 	body := netconf.Body{}
-	if !data.Name.IsNull() && !data.Name.IsUnknown() {
-		body = helpers.SetFromXPath(body, data.getXPath()+"/name", data.Name.ValueString())
+	if !data.Level.IsNull() && !data.Level.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/privilege", strconv.FormatInt(data.Level.ValueInt64(), 10))
 	}
-	if len(data.Levels) > 0 {
-		for _, item := range data.Levels {
+	if len(data.Commands) > 0 {
+		for _, item := range data.Commands {
 			cBody := netconf.Body{}
-			if !item.Level.IsNull() && !item.Level.IsUnknown() {
-				cBody = helpers.SetFromXPath(cBody, "privilege", strconv.FormatInt(item.Level.ValueInt64(), 10))
+			if !item.Command.IsNull() && !item.Command.IsUnknown() {
+				cBody = helpers.SetFromXPath(cBody, "command", item.Command.ValueString())
 			}
-			if len(item.Commands) > 0 {
-				for _, citem := range item.Commands {
-					ccBody := netconf.Body{}
-					if !citem.Command.IsNull() && !citem.Command.IsUnknown() {
-						ccBody = helpers.SetFromXPath(ccBody, "command", citem.Command.ValueString())
-					}
-					cBody = helpers.SetRawFromXPath(cBody, "command-list", ccBody.Res())
-				}
-			}
-			body = helpers.SetRawFromXPath(body, data.getXPath()+"/level", cBody.Res())
+			body = helpers.SetRawFromXPath(body, data.getXPath()+"/command-list", cBody.Res())
 		}
 	}
 	bodyString, err := body.String()
@@ -129,17 +114,17 @@ func (data Privilege) toBodyXML(ctx context.Context, config Privilege) string {
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBodyXML
 
 func (data *Privilege) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
-	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/name"); value.Exists() && !data.Name.IsNull() {
-		data.Name = types.StringValue(value.String())
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/privilege"); value.Exists() && !data.Level.IsNull() {
+		data.Level = types.Int64Value(value.Int())
 	} else {
-		data.Name = types.StringNull()
+		data.Level = types.Int64Null()
 	}
-	for i := range data.Levels {
-		keys := [...]string{"privilege"}
-		keyValues := [...]string{strconv.FormatInt(data.Levels[i].Level.ValueInt64(), 10)}
+	for i := range data.Commands {
+		keys := [...]string{"command"}
+		keyValues := [...]string{data.Commands[i].Command.ValueString()}
 
 		var r xmldot.Result
-		helpers.GetFromXPath(res, "data"+data.getXPath()+"/level").ForEach(
+		helpers.GetFromXPath(res, "data"+data.getXPath()+"/command-list").ForEach(
 			func(_ int, v xmldot.Result) bool {
 				found := false
 				for ik := range keys {
@@ -157,39 +142,10 @@ func (data *Privilege) updateFromBodyXML(ctx context.Context, res xmldot.Result)
 				return true
 			},
 		)
-		if value := helpers.GetFromXPath(r, "privilege"); value.Exists() && !data.Levels[i].Level.IsNull() {
-			data.Levels[i].Level = types.Int64Value(value.Int())
+		if value := helpers.GetFromXPath(r, "command"); value.Exists() && !data.Commands[i].Command.IsNull() {
+			data.Commands[i].Command = types.StringValue(value.String())
 		} else {
-			data.Levels[i].Level = types.Int64Null()
-		}
-		for ci := range data.Levels[i].Commands {
-			keys := [...]string{"command"}
-			keyValues := [...]string{data.Levels[i].Commands[ci].Command.ValueString()}
-
-			var cr xmldot.Result
-			helpers.GetFromXPath(r, "command-list").ForEach(
-				func(_ int, v xmldot.Result) bool {
-					found := false
-					for ik := range keys {
-						if v.Get(keys[ik]).String() == keyValues[ik] {
-							found = true
-							continue
-						}
-						found = false
-						break
-					}
-					if found {
-						cr = v
-						return false
-					}
-					return true
-				},
-			)
-			if value := helpers.GetFromXPath(cr, "command"); value.Exists() && !data.Levels[i].Commands[ci].Command.IsNull() {
-				data.Levels[i].Commands[ci].Command = types.StringValue(value.String())
-			} else {
-				data.Levels[i].Commands[ci].Command = types.StringNull()
-			}
+			data.Commands[i].Command = types.StringNull()
 		}
 	}
 }
@@ -199,25 +155,14 @@ func (data *Privilege) updateFromBodyXML(ctx context.Context, res xmldot.Result)
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyXML
 
 func (data *Privilege) fromBodyXML(ctx context.Context, res xmldot.Result) {
-	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/level"); value.Exists() {
-		data.Levels = make([]PrivilegeLevels, 0)
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/command-list"); value.Exists() {
+		data.Commands = make([]PrivilegeCommands, 0)
 		value.ForEach(func(_ int, v xmldot.Result) bool {
-			item := PrivilegeLevels{}
-			if cValue := helpers.GetFromXPath(v, "privilege"); cValue.Exists() {
-				item.Level = types.Int64Value(cValue.Int())
+			item := PrivilegeCommands{}
+			if cValue := helpers.GetFromXPath(v, "command"); cValue.Exists() {
+				item.Command = types.StringValue(cValue.String())
 			}
-			if cValue := helpers.GetFromXPath(v, "command-list"); cValue.Exists() {
-				item.Commands = make([]PrivilegeLevelsCommands, 0)
-				cValue.ForEach(func(_ int, cv xmldot.Result) bool {
-					cItem := PrivilegeLevelsCommands{}
-					if ccValue := helpers.GetFromXPath(cv, "command"); ccValue.Exists() {
-						cItem.Command = types.StringValue(ccValue.String())
-					}
-					item.Commands = append(item.Commands, cItem)
-					return true
-				})
-			}
-			data.Levels = append(data.Levels, item)
+			data.Commands = append(data.Commands, item)
 			return true
 		})
 	}
@@ -228,25 +173,14 @@ func (data *Privilege) fromBodyXML(ctx context.Context, res xmldot.Result) {
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyDataXML
 
 func (data *PrivilegeData) fromBodyXML(ctx context.Context, res xmldot.Result) {
-	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/level"); value.Exists() {
-		data.Levels = make([]PrivilegeLevelsData, 0)
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/command-list"); value.Exists() {
+		data.Commands = make([]PrivilegeCommandsData, 0)
 		value.ForEach(func(_ int, v xmldot.Result) bool {
-			item := PrivilegeLevelsData{}
-			if cValue := helpers.GetFromXPath(v, "privilege"); cValue.Exists() {
-				item.Level = types.Int64Value(cValue.Int())
+			item := PrivilegeCommandsData{}
+			if cValue := helpers.GetFromXPath(v, "command"); cValue.Exists() {
+				item.Command = types.StringValue(cValue.String())
 			}
-			if cValue := helpers.GetFromXPath(v, "command-list"); cValue.Exists() {
-				item.Commands = make([]PrivilegeLevelsCommandsData, 0)
-				cValue.ForEach(func(_ int, cv xmldot.Result) bool {
-					cItem := PrivilegeLevelsCommandsData{}
-					if ccValue := helpers.GetFromXPath(cv, "command"); ccValue.Exists() {
-						cItem.Command = types.StringValue(ccValue.String())
-					}
-					item.Commands = append(item.Commands, cItem)
-					return true
-				})
-			}
-			data.Levels = append(data.Levels, item)
+			data.Commands = append(data.Commands, item)
 			return true
 		})
 	}
@@ -258,16 +192,16 @@ func (data *PrivilegeData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *Privilege) addDeletedItemsXML(ctx context.Context, state Privilege, body string) string {
 	b := netconf.NewBody(body)
-	for i := range state.Levels {
-		stateKeys := [...]string{"privilege"}
-		stateKeyValues := [...]string{strconv.FormatInt(state.Levels[i].Level.ValueInt64(), 10)}
+	for i := range state.Commands {
+		stateKeys := [...]string{"command"}
+		stateKeyValues := [...]string{state.Commands[i].Command.ValueString()}
 		predicates := ""
 		for i := range stateKeys {
 			predicates += fmt.Sprintf("[%s='%s']", stateKeys[i], stateKeyValues[i])
 		}
 
 		emptyKeys := true
-		if !reflect.ValueOf(state.Levels[i].Level.ValueInt64()).IsZero() {
+		if !reflect.ValueOf(state.Commands[i].Command.ValueString()).IsZero() {
 			emptyKeys = false
 		}
 		if emptyKeys {
@@ -275,47 +209,17 @@ func (data *Privilege) addDeletedItemsXML(ctx context.Context, state Privilege, 
 		}
 
 		found := false
-		for j := range data.Levels {
+		for j := range data.Commands {
 			found = true
-			if state.Levels[i].Level.ValueInt64() != data.Levels[j].Level.ValueInt64() {
+			if state.Commands[i].Command.ValueString() != data.Commands[j].Command.ValueString() {
 				found = false
 			}
 			if found {
-				for ci := range state.Levels[i].Commands {
-					cstateKeys := [...]string{"command"}
-					cstateKeyValues := [...]string{state.Levels[i].Commands[ci].Command.ValueString()}
-					cpredicates := ""
-					for i := range cstateKeys {
-						cpredicates += fmt.Sprintf("[%s='%s']", cstateKeys[i], cstateKeyValues[i])
-					}
-
-					cemptyKeys := true
-					if !reflect.ValueOf(state.Levels[i].Commands[ci].Command.ValueString()).IsZero() {
-						cemptyKeys = false
-					}
-					if cemptyKeys {
-						continue
-					}
-
-					found := false
-					for cj := range data.Levels[j].Commands {
-						found = true
-						if state.Levels[i].Commands[ci].Command.ValueString() != data.Levels[j].Commands[cj].Command.ValueString() {
-							found = false
-						}
-						if found {
-							break
-						}
-					}
-					if !found {
-						b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/level%v/command-list%v", predicates, cpredicates))
-					}
-				}
 				break
 			}
 		}
 		if !found {
-			b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/level%v", predicates))
+			b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/command-list%v", predicates))
 		}
 	}
 
@@ -329,15 +233,15 @@ func (data *Privilege) addDeletedItemsXML(ctx context.Context, state Privilege, 
 
 func (data *Privilege) addDeletePathsXML(ctx context.Context, body string) string {
 	b := netconf.NewBody(body)
-	for i := range data.Levels {
-		keys := [...]string{"privilege"}
-		keyValues := [...]string{strconv.FormatInt(data.Levels[i].Level.ValueInt64(), 10)}
+	for i := range data.Commands {
+		keys := [...]string{"command"}
+		keyValues := [...]string{data.Commands[i].Command.ValueString()}
 		predicates := ""
 		for i := range keys {
 			predicates += fmt.Sprintf("[%s='%s']", keys[i], keyValues[i])
 		}
 
-		b = helpers.RemoveFromXPath(b, fmt.Sprintf(data.getXPath()+"/level%v", predicates))
+		b = helpers.RemoveFromXPath(b, fmt.Sprintf(data.getXPath()+"/command-list%v", predicates))
 	}
 
 	b = helpers.CleanupRedundantRemoveOperations(b)

--- a/internal/provider/resource_iosxe_privilege.go
+++ b/internal/provider/resource_iosxe_privilege.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
@@ -31,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -88,29 +90,24 @@ func (r *PrivilegeResource) Schema(ctx context.Context, req resource.SchemaReque
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"levels": schema.ListNestedAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Set privilege level of command").String,
+			"level": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(0, 255).String,
+				Required:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 255),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"commands": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("").String,
 				Optional:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"level": schema.Int64Attribute{
-							MarkdownDescription: helpers.NewAttributeDescription("").AddIntegerRangeDescription(0, 255).String,
+						"command": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("There are side effects").String,
 							Required:            true,
-							Validators: []validator.Int64{
-								int64validator.Between(0, 255),
-							},
-						},
-						"commands": schema.ListNestedAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("").String,
-							Optional:            true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"command": schema.StringAttribute{
-										MarkdownDescription: helpers.NewAttributeDescription("There are side effects").String,
-										Required:            true,
-									},
-								},
-							},
 						},
 					},
 				},
@@ -368,9 +365,9 @@ func (r *PrivilegeResource) ImportState(ctx context.Context, req resource.Import
 	idParts := strings.Split(req.ID, ",")
 	idParts = helpers.RemoveEmptyStrings(idParts)
 
-	if len(idParts) != 1 && len(idParts) != 2 {
-		expectedIdentifier := "Expected import identifier with format: '<name>'"
-		expectedIdentifier += " or '<name>,<device>'"
+	if len(idParts) != 2 && len(idParts) != 3 {
+		expectedIdentifier := "Expected import identifier with format: '<name>,<level>'"
+		expectedIdentifier += " or '<name>,<level>,<device>'"
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
 			fmt.Sprintf("%s. Got: %q", expectedIdentifier, req.ID),
@@ -378,7 +375,8 @@ func (r *PrivilegeResource) ImportState(ctx context.Context, req resource.Import
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), idParts[0])...)
-	if len(idParts) == 2 {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("level"), helpers.Must(strconv.ParseInt(idParts[1], 10, 64)))...)
+	if len(idParts) == 3 {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("device"), idParts[len(idParts)-1])...)
 	}
 

--- a/internal/provider/resource_iosxe_privilege_test.go
+++ b/internal/provider/resource_iosxe_privilege_test.go
@@ -34,9 +34,8 @@ import (
 
 func TestAccIosxePrivilege(t *testing.T) {
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "name", "exec"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "levels.0.level", "7"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "levels.0.commands.0.command", "configure"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "level", "7"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_privilege.test", "commands.0.command", "configure"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -68,8 +67,9 @@ func iosxePrivilegeImportStateIdFunc(resourceName string) resource.ImportStateId
 	return func(s *terraform.State) (string, error) {
 		primary := s.RootModule().Resources[resourceName].Primary
 		Name := primary.Attributes["name"]
+		Level := primary.Attributes["level"]
 
-		return fmt.Sprintf("%s", Name), nil
+		return fmt.Sprintf("%s,%s", Name, Level), nil
 	}
 }
 
@@ -83,6 +83,7 @@ func iosxePrivilegeImportStateIdFunc(resourceName string) resource.ImportStateId
 func testAccIosxePrivilegeConfig_minimum() string {
 	config := `resource "iosxe_privilege" "test" {` + "\n"
 	config += `	name = "exec"` + "\n"
+	config += `	level = 7` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -94,11 +95,9 @@ func testAccIosxePrivilegeConfig_minimum() string {
 func testAccIosxePrivilegeConfig_all() string {
 	config := `resource "iosxe_privilege" "test" {` + "\n"
 	config += `	name = "exec"` + "\n"
-	config += `	levels = [{` + "\n"
-	config += `		level = 7` + "\n"
-	config += `		commands = [{` + "\n"
-	config += `			command = "configure"` + "\n"
-	config += `		}]` + "\n"
+	config += `	level = 7` + "\n"
+	config += `	commands = [{` + "\n"
+	config += `		command = "configure"` + "\n"
 	config += `	}]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
`iosxe_privilege` was keyed at `privilege/mode[name]`, so it managed the entire exec mode and its read returned *every* privilege level on the device. On any device with pre-existing exec levels (the test fleet carries level 1 and 15), the data source and import surfaced those extra levels — `levels.0` wasn't the configured level and ImportStateVerify saw extra entries. It failed on both router and switch, so it's not platform-specific.

Re-key to `privilege/mode[name]/level[privilege]` so each resource manages a single privilege level, with the read scoped to it (mirrors `policy_map_event`'s `parent[key]/child[key]` structure). Definition-only change + `make gen`.

Schema change: the `levels` list becomes top-level `name`/`level`/`commands`, and import takes `<name>,<level>`. Done now while the resource is unreleased (added in #564) so 1.0.0 ships the correct shape.
