### PR TITLE
fix(privilege): skip minimum acceptance test

### DIFF
--- a/gen/definitions/privilege.yaml
+++ b/gen/definitions/privilege.yaml
@@ -2,6 +2,7 @@
 name: Privilege
 path: /Cisco-IOS-XE-native:native/privilege/mode[name=%v]/level[privilege=%v]
 no_delete_attributes: true
+skip_minimum_test: true
 doc_category: System
 attributes:
   - yang_name: name

--- a/internal/provider/resource_iosxe_privilege_test.go
+++ b/internal/provider/resource_iosxe_privilege_test.go
@@ -41,9 +41,6 @@ func TestAccIosxePrivilege(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIosxePrivilegeConfig_minimum(),
-			},
-			{
 				Config: testAccIosxePrivilegeConfig_all(),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},


### PR DESCRIPTION
After keying `iosxe_privilege` by a single level (#586), the minimum acceptance config (`name` + `level`, no commands) renders a bare `privilege exec level N`, which the device rejects as incomplete. A privilege level is only valid with ≥1 command, so there's no meaningful minimum case — add `skip_minimum_test`.

Fixes the resource test on both platforms (it failed at the minimum step on both); the data source and full-config paths already pass. Definition-only + `make gen`.
