### PR TITLE
Revert "fix(large_community_list_standard): delete entries, not the parent list (#585)"

### DIFF
--- a/gen/definitions/large_community_list_standard.yaml
+++ b/gen/definitions/large_community_list_standard.yaml
@@ -2,7 +2,6 @@
 name: Large Community List Standard
 path: /Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-bgp:large-community-list/standard[name=%v]
 no_delete_attributes: true
-default_delete_attributes: true
 skip_minimum_test: true
 doc_category: BGP
 attributes:

--- a/internal/provider/resource_iosxe_large_community_list_standard.go
+++ b/internal/provider/resource_iosxe_large_community_list_standard.go
@@ -311,7 +311,7 @@ func (r *LargeCommunityListStandardResource) Delete(ctx context.Context, req res
 	}
 
 	if device.Managed {
-		deleteMode := "attributes"
+		deleteMode := "all"
 
 		// NETCONF - Serialize write operations
 		locked := helpers.AcquireNetconfLock(&device.NetconfOpMutex, device.ReuseConnection, true)


### PR DESCRIPTION
Reverts #585.

#585 switched `iosxe_large_community_list_standard` to attribute-level deletes to avoid the `% DEL? Specified large community list does not exist` failure. On the device that only **changed** the failure mode — destroy now leaves an empty container and the device rejects it with `large-community-list must be configured with permit or deny`. It still fails on **both** C8000v and C9000v, so #585 doesn't resolve the bug.

Reverting to the original (#575) state so the rest of `main` is cleanly testable on the internal nightly. The underlying delete defect is tracked in #589 and needs a code-level fix (delete-error tolerance), not a definition flag.

Pure revert of #585; no other changes.
