### PR TITLE
docs: add Getting Started guide

### DIFF
--- a/docs/guides/destroying_resources.md
+++ b/docs/guides/destroying_resources.md
@@ -27,3 +27,7 @@ This way, only the `log_neighbor_changes` attribute will be removed when the res
 If the `delete_mode` attribute is set to `all`, the entire BGP configuration would have been removed when the resource was destroyed.
 
 For some resources only one mode is supported, for example the `iosxe_access_list_standard` resource only supports the `all` mode and does not expose a `delete_mode` attribute, because it is not possible to manage individual access list entries outside of Terraform.
+
+## See Also
+
+- [NETCONF](netconf) — commit modes (`auto_commit`) and how destroy commits staged changes.

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -1,0 +1,108 @@
+---
+subcategory: "Guides"
+page_title: "Getting Started"
+description: |-
+    Get started with the IOSXE provider by configuring a device end to end.
+---
+
+# Getting Started
+
+This guide walks through a minimal end-to-end example: configuring the system
+hostname, creating a loopback interface, and adding a VRF on a single Cisco
+IOS-XE device. Each resource shown here is documented in full detail in the
+sidebar.
+
+## Prerequisite: Enable NETCONF
+
+The IOSXE provider communicates with devices over **NETCONF** (SSH). Before
+Terraform can manage a device, enable `netconf-yang` on it:
+
+```
+configure terminal
+netconf-yang
+```
+
+Optionally enable the candidate datastore for transactional commits. See the
+[NETCONF guide](netconf) for details.
+
+## Provider Configuration
+
+First, declare the provider and point it at your device:
+
+```terraform
+terraform {
+  required_providers {
+    iosxe = {
+      source = "CiscoDevNet/iosxe"
+    }
+  }
+}
+
+provider "iosxe" {
+  username = "admin"
+  password = "password"
+  host     = "10.1.1.1"
+}
+```
+
+## System Hostname
+
+Next, configure the device hostname with the `iosxe_system` resource:
+
+```terraform
+resource "iosxe_system" "system" {
+  hostname = "ROUTER-1"
+}
+```
+
+## Loopback Interface
+
+Now add a loopback interface with the `iosxe_interface_loopback` resource:
+
+```terraform
+resource "iosxe_interface_loopback" "loopback100" {
+  name              = 100
+  description       = "Managed by Terraform"
+  ipv4_address      = "10.0.0.1"
+  ipv4_address_mask = "255.255.255.255"
+}
+```
+
+## VRF
+
+And finally, create a VRF with the `iosxe_vrf` resource:
+
+```terraform
+resource "iosxe_vrf" "vrf1" {
+  name                = "VRF1"
+  description         = "Managed by Terraform"
+  address_family_ipv4 = true
+}
+```
+
+## Deploy the Configuration
+
+Initialize the working directory to download the provider:
+
+```shell
+terraform init
+```
+
+Review the planned changes:
+
+```shell
+terraform plan
+```
+
+Apply the configuration to the device. Terraform prompts for confirmation;
+type `yes` to proceed:
+
+```shell
+terraform apply
+```
+
+## Next Steps
+
+- [NETCONF](netconf) — transactional commits and the candidate datastore
+- [Manage Multiple Devices](manage_multiple_devices) — drive many devices from a single configuration
+- [Importing Resources](importing_resources) — bring existing device configuration under Terraform management

--- a/docs/guides/manage_multiple_devices.md
+++ b/docs/guides/manage_multiple_devices.md
@@ -31,9 +31,9 @@ resource "iosxe_system" "ROUTER-2" {
 }
 ```
 
-The disadvantages here is that the `provider` attribute of resources cannot be dynamic and therefore cannot be used in combination with `for_each` as an example. The issue is being tracked [here](https://github.com/hashicorp/terraform/issues/24476).
+The disadvantage here is that the `provider` attribute of resources cannot be dynamic and therefore cannot be used in combination with `for_each` as an example. The issue is being tracked [here](https://github.com/hashicorp/terraform/issues/24476).
 
-This provider offers an alternative approach where mutliple devices can be managed by a single provider configuration and the optional `device` attribute, which is available in every resource and data source, can then be used to select the respective device. This assumes that every device uses the same credentials.
+This provider offers an alternative approach where multiple devices can be managed by a single provider configuration and the optional `device` attribute, which is available in every resource and data source, can then be used to select the respective device. This assumes that every device uses the same credentials.
 
 ```terraform
 locals {

--- a/docs/guides/manage_multiple_devices.md
+++ b/docs/guides/manage_multiple_devices.md
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "Manage Multiple Devices"
 description: |-
-    Howto manage multiple devices.
+    How to manage multiple IOS-XE devices.
 ---
 
 # Manage Multiple Devices
@@ -72,7 +72,7 @@ Each device in the `devices` list supports an optional `managed` attribute that 
 
 ### Basic Managed Flag Usage
 
-```hcl
+```terraform
 locals {
   devices = [
     {
@@ -116,7 +116,7 @@ resource "iosxe_banner" "login_banner" {
 - **When `selected_devices` is not specified**: Individual `managed` flags are respected
 
 #### Example: selected_devices Override
-```hcl
+```terraform
 provider "iosxe" {
   selected_devices = ["switch-01", "switch-03"]  # Only these devices managed
   devices = [
@@ -128,3 +128,7 @@ provider "iosxe" {
 ```
 
 **Result**: Only `switch-01` and `switch-03` are managed, regardless of their individual `managed` flags.
+
+## See Also
+
+- [Selective Deploy](selective_deploy) — deploy to only a subset of the `devices` list while keeping the rest frozen.

--- a/docs/guides/netconf.md
+++ b/docs/guides/netconf.md
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "NETCONF"
 description: |-
-    Howto use NETCONF with the IOSXE provider.
+    How to use NETCONF with the IOSXE provider.
 ---
 
 # NETCONF
@@ -146,7 +146,7 @@ provider "iosxe" {
 }
 
 resource "iosxe_interface_loopback" "example" {
-  name = "100"
+  name = 100
   description = "Managed by Terraform"
 }
 # Changes are committed automatically after this resource is created/updated
@@ -168,12 +168,12 @@ provider "iosxe" {
 }
 
 resource "iosxe_interface_loopback" "loopback100" {
-  name = "100"
+  name = 100
   description = "Loopback 100"
 }
 
 resource "iosxe_interface_loopback" "loopback101" {
-  name = "101"
+  name = 101
   description = "Loopback 101"
 }
 
@@ -230,12 +230,12 @@ The `iosxe_commit` resource can optionally save the running configuration to sta
 
 ```terraform
 resource "iosxe_interface_loopback" "loopback100" {
-  name        = "100"
+  name        = 100
   description = "Loopback 100"
 }
 
 resource "iosxe_interface_loopback" "loopback101" {
-  name        = "101"
+  name        = 101
   description = "Loopback 101"
 }
 
@@ -264,3 +264,7 @@ This combines commit and save operations in a single transaction, ensuring your 
 - [RFC 6241 - Network Configuration Protocol (NETCONF)](https://tools.ietf.org/html/rfc6241)
 - [go-netconf Library Documentation](https://github.com/netascode/go-netconf)
 - [IOS-XE Programmability Guide](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/prog/configuration/1715/b_1715_programmability_cg.html)
+
+## See Also
+
+- [Destroying Resources](destroying_resources) — how `delete_mode` and commit behavior interact during destroy.

--- a/docs/guides/selective_deploy.md
+++ b/docs/guides/selective_deploy.md
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "Selective Deploy"
 description: |-
-    Howto selectively deploy to devices.
+    How to selectively deploy to a subset of devices.
 ---
 
 # Selective Deploy
@@ -35,7 +35,7 @@ When using selective deployment, Terraform maintains state for ALL devices but o
 
 Configure selective deployment using the `selected_devices` attribute in your provider block:
 
-```hcl
+```terraform
 provider "iosxe" {
   selected_devices = ["switch-01", "switch-02"]
   devices = [
@@ -56,7 +56,7 @@ Alternatively, use the `IOSXE_SELECTED_DEVICES` environment variable with comma-
 export IOSXE_SELECTED_DEVICES="switch-01,switch-02"
 ```
 
-```hcl
+```terraform
 provider "iosxe" {
   devices = [
     { name = "switch-01", host = "10.1.1.10" },
@@ -71,3 +71,7 @@ provider "iosxe" {
 ### Default Behavior
 
 When `selected_devices` is not specified, all devices in the `devices` list are managed by default.
+
+## See Also
+
+- [Manage Multiple Devices](manage_multiple_devices) — configure the `devices` list this guide selects from.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ All resources and data sources have been tested with the following releases.
 
 The following guides are available to help you get started with the IOSXE provider:
 
+- **[Getting Started](guides/getting_started)** - Configure your first IOS-XE device end to end: provider setup, hostname, loopback interface, and VRF
 - **[NETCONF](guides/netconf)** - Learn how to use NETCONF protocol for transactional configuration management with candidate datastore support
 - **[Manage Multiple Devices](guides/manage_multiple_devices)** - Learn how to manage multiple IOS-XE devices using provider aliases or the single-provider approach with device-level management control
 - **[Selective Deploy](guides/selective_deploy)** - Deploy configurations to a subset of devices while keeping others in a "frozen" state for staged rollouts and maintenance scenarios

--- a/templates/guides/destroying_resources.md.tmpl
+++ b/templates/guides/destroying_resources.md.tmpl
@@ -27,3 +27,7 @@ This way, only the `log_neighbor_changes` attribute will be removed when the res
 If the `delete_mode` attribute is set to `all`, the entire BGP configuration would have been removed when the resource was destroyed.
 
 For some resources only one mode is supported, for example the `iosxe_access_list_standard` resource only supports the `all` mode and does not expose a `delete_mode` attribute, because it is not possible to manage individual access list entries outside of Terraform.
+
+## See Also
+
+- [NETCONF](netconf) — commit modes (`auto_commit`) and how destroy commits staged changes.

--- a/templates/guides/getting_started.md.tmpl
+++ b/templates/guides/getting_started.md.tmpl
@@ -1,0 +1,108 @@
+---
+subcategory: "Guides"
+page_title: "Getting Started"
+description: |-
+    Get started with the IOSXE provider by configuring a device end to end.
+---
+
+# Getting Started
+
+This guide walks through a minimal end-to-end example: configuring the system
+hostname, creating a loopback interface, and adding a VRF on a single Cisco
+IOS-XE device. Each resource shown here is documented in full detail in the
+sidebar.
+
+## Prerequisite: Enable NETCONF
+
+The IOSXE provider communicates with devices over **NETCONF** (SSH). Before
+Terraform can manage a device, enable `netconf-yang` on it:
+
+```
+configure terminal
+netconf-yang
+```
+
+Optionally enable the candidate datastore for transactional commits. See the
+[NETCONF guide](netconf) for details.
+
+## Provider Configuration
+
+First, declare the provider and point it at your device:
+
+```terraform
+terraform {
+  required_providers {
+    iosxe = {
+      source = "CiscoDevNet/iosxe"
+    }
+  }
+}
+
+provider "iosxe" {
+  username = "admin"
+  password = "password"
+  host     = "10.1.1.1"
+}
+```
+
+## System Hostname
+
+Next, configure the device hostname with the `iosxe_system` resource:
+
+```terraform
+resource "iosxe_system" "system" {
+  hostname = "ROUTER-1"
+}
+```
+
+## Loopback Interface
+
+Now add a loopback interface with the `iosxe_interface_loopback` resource:
+
+```terraform
+resource "iosxe_interface_loopback" "loopback100" {
+  name              = 100
+  description       = "Managed by Terraform"
+  ipv4_address      = "10.0.0.1"
+  ipv4_address_mask = "255.255.255.255"
+}
+```
+
+## VRF
+
+And finally, create a VRF with the `iosxe_vrf` resource:
+
+```terraform
+resource "iosxe_vrf" "vrf1" {
+  name                = "VRF1"
+  description         = "Managed by Terraform"
+  address_family_ipv4 = true
+}
+```
+
+## Deploy the Configuration
+
+Initialize the working directory to download the provider:
+
+```shell
+terraform init
+```
+
+Review the planned changes:
+
+```shell
+terraform plan
+```
+
+Apply the configuration to the device. Terraform prompts for confirmation;
+type `yes` to proceed:
+
+```shell
+terraform apply
+```
+
+## Next Steps
+
+- [NETCONF](netconf) — transactional commits and the candidate datastore
+- [Manage Multiple Devices](manage_multiple_devices) — drive many devices from a single configuration
+- [Importing Resources](importing_resources) — bring existing device configuration under Terraform management

--- a/templates/guides/manage_multiple_devices.md.tmpl
+++ b/templates/guides/manage_multiple_devices.md.tmpl
@@ -31,9 +31,9 @@ resource "iosxe_system" "ROUTER-2" {
 }
 ```
 
-The disadvantages here is that the `provider` attribute of resources cannot be dynamic and therefore cannot be used in combination with `for_each` as an example. The issue is being tracked [here](https://github.com/hashicorp/terraform/issues/24476).
+The disadvantage here is that the `provider` attribute of resources cannot be dynamic and therefore cannot be used in combination with `for_each` as an example. The issue is being tracked [here](https://github.com/hashicorp/terraform/issues/24476).
 
-This provider offers an alternative approach where mutliple devices can be managed by a single provider configuration and the optional `device` attribute, which is available in every resource and data source, can then be used to select the respective device. This assumes that every device uses the same credentials.
+This provider offers an alternative approach where multiple devices can be managed by a single provider configuration and the optional `device` attribute, which is available in every resource and data source, can then be used to select the respective device. This assumes that every device uses the same credentials.
 
 ```terraform
 locals {

--- a/templates/guides/manage_multiple_devices.md.tmpl
+++ b/templates/guides/manage_multiple_devices.md.tmpl
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "Manage Multiple Devices"
 description: |-
-    Howto manage multiple devices.
+    How to manage multiple IOS-XE devices.
 ---
 
 # Manage Multiple Devices
@@ -72,7 +72,7 @@ Each device in the `devices` list supports an optional `managed` attribute that 
 
 ### Basic Managed Flag Usage
 
-```hcl
+```terraform
 locals {
   devices = [
     {
@@ -116,7 +116,7 @@ resource "iosxe_banner" "login_banner" {
 - **When `selected_devices` is not specified**: Individual `managed` flags are respected
 
 #### Example: selected_devices Override
-```hcl
+```terraform
 provider "iosxe" {
   selected_devices = ["switch-01", "switch-03"]  # Only these devices managed
   devices = [
@@ -128,3 +128,7 @@ provider "iosxe" {
 ```
 
 **Result**: Only `switch-01` and `switch-03` are managed, regardless of their individual `managed` flags.
+
+## See Also
+
+- [Selective Deploy](selective_deploy) — deploy to only a subset of the `devices` list while keeping the rest frozen.

--- a/templates/guides/netconf.md.tmpl
+++ b/templates/guides/netconf.md.tmpl
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "NETCONF"
 description: |-
-    Howto use NETCONF with the IOSXE provider.
+    How to use NETCONF with the IOSXE provider.
 ---
 
 # NETCONF
@@ -146,7 +146,7 @@ provider "iosxe" {
 }
 
 resource "iosxe_interface_loopback" "example" {
-  name = "100"
+  name = 100
   description = "Managed by Terraform"
 }
 # Changes are committed automatically after this resource is created/updated
@@ -168,12 +168,12 @@ provider "iosxe" {
 }
 
 resource "iosxe_interface_loopback" "loopback100" {
-  name = "100"
+  name = 100
   description = "Loopback 100"
 }
 
 resource "iosxe_interface_loopback" "loopback101" {
-  name = "101"
+  name = 101
   description = "Loopback 101"
 }
 
@@ -230,12 +230,12 @@ The `iosxe_commit` resource can optionally save the running configuration to sta
 
 ```terraform
 resource "iosxe_interface_loopback" "loopback100" {
-  name        = "100"
+  name        = 100
   description = "Loopback 100"
 }
 
 resource "iosxe_interface_loopback" "loopback101" {
-  name        = "101"
+  name        = 101
   description = "Loopback 101"
 }
 
@@ -264,3 +264,7 @@ This combines commit and save operations in a single transaction, ensuring your 
 - [RFC 6241 - Network Configuration Protocol (NETCONF)](https://tools.ietf.org/html/rfc6241)
 - [go-netconf Library Documentation](https://github.com/netascode/go-netconf)
 - [IOS-XE Programmability Guide](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/prog/configuration/1715/b_1715_programmability_cg.html)
+
+## See Also
+
+- [Destroying Resources](destroying_resources) — how `delete_mode` and commit behavior interact during destroy.

--- a/templates/guides/selective_deploy.md.tmpl
+++ b/templates/guides/selective_deploy.md.tmpl
@@ -2,7 +2,7 @@
 subcategory: "Guides"
 page_title: "Selective Deploy"
 description: |-
-    Howto selectively deploy to devices.
+    How to selectively deploy to a subset of devices.
 ---
 
 # Selective Deploy
@@ -35,7 +35,7 @@ When using selective deployment, Terraform maintains state for ALL devices but o
 
 Configure selective deployment using the `selected_devices` attribute in your provider block:
 
-```hcl
+```terraform
 provider "iosxe" {
   selected_devices = ["switch-01", "switch-02"]
   devices = [
@@ -56,7 +56,7 @@ Alternatively, use the `IOSXE_SELECTED_DEVICES` environment variable with comma-
 export IOSXE_SELECTED_DEVICES="switch-01,switch-02"
 ```
 
-```hcl
+```terraform
 provider "iosxe" {
   devices = [
     { name = "switch-01", host = "10.1.1.10" },
@@ -71,3 +71,7 @@ provider "iosxe" {
 ### Default Behavior
 
 When `selected_devices` is not specified, all devices in the `devices` list are managed by default.
+
+## See Also
+
+- [Manage Multiple Devices](manage_multiple_devices) — configure the `devices` list this guide selects from.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -38,6 +38,7 @@ All resources and data sources have been tested with the following releases.
 
 The following guides are available to help you get started with the IOSXE provider:
 
+- **[Getting Started](guides/getting_started)** - Configure your first IOS-XE device end to end: provider setup, hostname, loopback interface, and VRF
 - **[NETCONF](guides/netconf)** - Learn how to use NETCONF protocol for transactional configuration management with candidate datastore support
 - **[Manage Multiple Devices](guides/manage_multiple_devices)** - Learn how to manage multiple IOS-XE devices using provider aliases or the single-provider approach with device-level management control
 - **[Selective Deploy](guides/selective_deploy)** - Deploy configurations to a subset of devices while keeping others in a "frozen" state for staged rollouts and maintenance scenarios


### PR DESCRIPTION
## Summary

Adds a **Getting Started** guide to the provider documentation and folds in a freshness pass over the existing guides. The provider's `templates/guides/` already covered NETCONF, multiple devices, selective deploy, importing, destroying, and the changelog, but lacked a single end-to-end "first config" walkthrough for new users.

The new guide adapts the arc to IOS-XE (NETCONF-based): enable `netconf-yang` → configure the provider → set the hostname → add a loopback → add a VRF → `init`/`plan`/`apply`. It follows the existing guide style (inline `terraform` blocks, `subcategory: "Guides"` frontmatter) and cross-links to the NETCONF, Manage Multiple Devices, and Importing Resources guides.

## Changes

**New guide**
- Add `templates/guides/getting_started.md.tmpl` (+ rendered `docs/guides/getting_started.md`).
- Register the guide, leading the Guides list, in `templates/index.md.tmpl` (+ rendered `docs/index.md`).

**Existing-guide polish**
- Fix loopback `name` examples in the NETCONF guide to use the numeric type (`name = 100`) matching the `iosxe_interface_loopback` schema (`Number`), instead of quoted strings.
- Standardize code fences to ` ```terraform ` (Selective Deploy and Manage Multiple Devices previously used ` ```hcl `).
- Normalize frontmatter descriptions ("Howto …" → "How to …").
- Fix a typo (`mutliple` → `multiple`) and a subject/verb agreement issue in Manage Multiple Devices.
- Add `See Also` cross-links between related guides (Selective Deploy ↔ Manage Multiple Devices, NETCONF ↔ Destroying Resources).

## Notes

- Rendered docs were generated with `tfplugindocs generate`; only the intended files are included (unrelated `subcategory` churn from running the generator without the `gen/doc_category.go` step was discarded).
- Example attributes verified against `examples/resources/*` for `iosxe_system`, `iosxe_interface_loopback`, and `iosxe_vrf`, plus the provider `host` attribute format and the rendered `interface_loopback` schema.