### PR TITLE
docs: mention env var credentials in Getting Started guide

### DIFF
--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -45,6 +45,11 @@ provider "iosxe" {
 }
 ```
 
+~> The example above hardcodes credentials for simplicity. In practice, use the
+`IOSXE_USERNAME` and `IOSXE_PASSWORD` environment variables to keep credentials
+out of version control. When these variables are set, the `username` and
+`password` attributes can be omitted from the provider block entirely.
+
 ## System Hostname
 
 Next, configure the device hostname with the `iosxe_system` resource:

--- a/templates/guides/getting_started.md.tmpl
+++ b/templates/guides/getting_started.md.tmpl
@@ -45,6 +45,11 @@ provider "iosxe" {
 }
 ```
 
+~> The example above hardcodes credentials for simplicity. In practice, use the
+`IOSXE_USERNAME` and `IOSXE_PASSWORD` environment variables to keep credentials
+out of version control. When these variables are set, the `username` and
+`password` attributes can be omitted from the provider block entirely.
+
 ## System Hostname
 
 Next, configure the device hostname with the `iosxe_system` resource:


### PR DESCRIPTION
## Summary

- Adds a note to the Getting Started guide's "Provider Configuration" section indicating that `IOSXE_USERNAME` and `IOSXE_PASSWORD` environment variables can be used instead of hardcoding credentials in the provider block.

## Test plan

- [ ] Verify the `~>` callout renders correctly on the Terraform Registry documentation page.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~100%
- **AI Reason**: docs improvement

🤖 Generated with [Claude Code](https://claude.ai/claude-code)