### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS
+#
+# The default owners are automatically requested for review on every pull
+# request. Order is not significant; all listed owners are default owners
+# for the entire repository.
+#
+# Reference: https://docs.github.com/articles/about-code-owners
+
+* @danischm @ChristopherJHart @aitestino


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file at `.github/CODEOWNERS` designating the default reviewers for the repository. With this in place, the listed owners are automatically requested for review on every pull request (and can back a required-review branch protection rule if desired).

## Owners

```
* @danischm @ChristopherJHart @aitestino
```

Usernames were verified against the GitHub API (canonical login and account id) and against recent merged commit history.

*P.S. — This comment was drafted using voice-to-text via Claude Code. If the tone comes across as overly direct or terse, please know that's just how it tends to phrase things. No offense or criticism is intended — this is purely an objective technical review of the PR. Thanks for understanding! 🙂*