### PR TITLE
fix(tests): repair nightly acceptance tests for VRRP v2 and Tunnel

### DIFF
--- a/gen/definitions/interface_tunnel.yaml
+++ b/gen/definitions/interface_tunnel.yaml
@@ -304,19 +304,23 @@ attributes:
     tf_name: tunnel_mode_gre_multipoint
     example: true
     test_tags: [C8000V]
+    exclude_test: true
   - yang_name: ip/Cisco-IOS-XE-nhrp:nhrp-v4/nhrp/authentication
     tf_name: ip_nhrp_authentication
     example: SECRET
     write_only: true
     test_tags: [C8000V]
+    exclude_test: true
   - yang_name: ip/Cisco-IOS-XE-nhrp:nhrp-v4/nhrp/network-id
     tf_name: ip_nhrp_network_id
     example: 100
     test_tags: [C8000V]
+    exclude_test: true
   - yang_name: ip/Cisco-IOS-XE-nhrp:nhrp-v4/nhrp/nhs/ipv4
     tf_name: ip_nhrp_nhs
     type: List
     test_tags: [C8000V]
+    exclude_test: true
     attributes:
       - yang_name: ipv4
         tf_name: ipv4
@@ -326,6 +330,7 @@ attributes:
     tf_name: ip_nhrp_maps
     type: List
     test_tags: [C8000V]
+    exclude_test: true
     attributes:
       - yang_name: dest-ipv4
         tf_name: dest_ipv4
@@ -338,14 +343,17 @@ attributes:
     tf_name: ip_nhrp_redirect
     example: true
     test_tags: [C8000V]
+    exclude_test: true
   - yang_name: ip/Cisco-IOS-XE-nhrp:nhrp-v4/nhrp/shortcut
     tf_name: ip_nhrp_shortcut
     example: true
     test_tags: [C8000V]
+    exclude_test: true
   - yang_name: mpls/Cisco-IOS-XE-mpls:nhrp
     tf_name: mpls_nhrp
     example: true
     test_tags: [C8000V]
+    exclude_test: true
 
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/vrf/definition[name=VRF1]

--- a/gen/definitions/vrrp_v2.yaml
+++ b/gen/definitions/vrrp_v2.yaml
@@ -3,6 +3,7 @@ name: Interface VRRP v2
 path: /Cisco-IOS-XE-native:native/interface/%s[name=%v]/Cisco-IOS-XE-vrrp:vrrp/vrrp-group-v2[group-id=%v]
 augment_path: /Cisco-IOS-XE-native:native/interface/GigabitEthernet[name=%v]/Cisco-IOS-XE-vrrp:vrrp/vrrp-group-v2[group-id=%v]
 doc_category: Interface
+test_tags: [C8000V]
 attributes:
   - yang_name: type
     tf_name: type

--- a/internal/provider/data_source_iosxe_interface_tunnel_test.go
+++ b/internal/provider/data_source_iosxe_interface_tunnel_test.go
@@ -88,28 +88,6 @@ func TestAccDataSourceIosxeInterfaceTunnel(t *testing.T) {
 	if os.Getenv("C8000V") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "tunnel_key", "10"))
 	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "tunnel_mode_gre_multipoint", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_network_id", "100"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_nhs.0.ipv4", "192.168.10.1"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_maps.0.dest_ipv4", "10.0.0.1"))
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_maps.0.nbma_ipv4", "172.16.1.1"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_redirect", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "ip_nhrp_shortcut", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_tunnel.test", "mpls_nhrp", "true"))
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -223,35 +201,6 @@ func testAccDataSourceIosxeInterfaceTunnelConfig() string {
 	config += `	tunnel_bandwidth_receive = 1000` + "\n"
 	if os.Getenv("C8000V") != "" {
 		config += `	tunnel_key = 10` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	tunnel_mode_gre_multipoint = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_authentication = "SECRET"` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_network_id = 100` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_nhs = [{` + "\n"
-		config += `		ipv4 = "192.168.10.1"` + "\n"
-		config += `	}]` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_maps = [{` + "\n"
-		config += `		dest_ipv4 = "10.0.0.1"` + "\n"
-		config += `		nbma_ipv4 = "172.16.1.1"` + "\n"
-		config += `	}]` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_redirect = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_shortcut = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	mpls_nhrp = true` + "\n"
 	}
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_iosxe_interface_vrrp_v2_test.go
+++ b/internal/provider/data_source_iosxe_interface_vrrp_v2_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,6 +32,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceIosxeInterfaceVRRPV2(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vrrp_v2.test", "ip_primary_address", "192.0.2.254"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_vrrp_v2.test", "ip_secondary_addresses.0.address", "192.0.2.253"))

--- a/internal/provider/resource_iosxe_interface_tunnel_test.go
+++ b/internal/provider/resource_iosxe_interface_tunnel_test.go
@@ -91,28 +91,6 @@ func TestAccIosxeInterfaceTunnel(t *testing.T) {
 	if os.Getenv("C8000V") != "" {
 		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "tunnel_key", "10"))
 	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "tunnel_mode_gre_multipoint", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_network_id", "100"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_nhs.0.ipv4", "192.168.10.1"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_maps.0.dest_ipv4", "10.0.0.1"))
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_maps.0.nbma_ipv4", "172.16.1.1"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_redirect", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "ip_nhrp_shortcut", "true"))
-	}
-	if os.Getenv("C8000V") != "" {
-		checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_tunnel.test", "mpls_nhrp", "true"))
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -261,35 +239,6 @@ func testAccIosxeInterfaceTunnelConfig_all() string {
 	config += `	tunnel_bandwidth_receive = 1000` + "\n"
 	if os.Getenv("C8000V") != "" {
 		config += `	tunnel_key = 10` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	tunnel_mode_gre_multipoint = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_authentication = "SECRET"` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_network_id = 100` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_nhs = [{` + "\n"
-		config += `		ipv4 = "192.168.10.1"` + "\n"
-		config += `	}]` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_maps = [{` + "\n"
-		config += `		dest_ipv4 = "10.0.0.1"` + "\n"
-		config += `		nbma_ipv4 = "172.16.1.1"` + "\n"
-		config += `	}]` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_redirect = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	ip_nhrp_shortcut = true` + "\n"
-	}
-	if os.Getenv("C8000V") != "" {
-		config += `	mpls_nhrp = true` + "\n"
 	}
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, ]` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_interface_vrrp_v2_test.go
+++ b/internal/provider/resource_iosxe_interface_vrrp_v2_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,9 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccIosxeInterfaceVRRPV2(t *testing.T) {
+	if os.Getenv("C8000V") == "" {
+		t.Skip("skipping test, set environment variable C8000V")
+	}
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vrrp_v2.test", "group_id", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_vrrp_v2.test", "ip_primary_address", "192.0.2.254"))


### PR DESCRIPTION
## Summary

The nightly acceptance run (real C9000v / C8000v devices) started failing after the 17.15 feature batch merged. The pull-request CI does not catch this because it skips device-backed acceptance tests when no device is configured; the nightly is the only gate that runs them. This PR fixes two independent test-configuration issues.

### 1. Interface VRRP v2 — gate to C8000V

The generated test sets `fhrp version vrrp v2` as a prerequisite. Catalyst 9000 (C9000v) rejects this (`"v2" is an invalid value` for `/native/fhrp/version/vrrp`): that platform is VRRPv3-only, and `Cisco-IOS-XE-vrrp-deviation.yang` (present in both 17.15.1 and 17.18.1) restricts the leaf to `enum v3`. Legacy VRRP v2 is a router feature — the same test passes on the C8000v router.

Fix: add `test_tags: [C8000V]` to the definition so the test runs only on the router platform where the feature is supported.

### 2. Interface Tunnel — resolve mutually-exclusive attribute combination

The generated test set `tunnel_mode_gre_multipoint` together with `tunnel_destination_ipv4`. The device rejects this (`tunnel destination and this mode cannot be configured together`) — a multipoint GRE tunnel has no single destination.

Fix: mark the GRE-multipoint mode and the NHRP attributes (`ip_nhrp_*`, `mpls_nhrp`) as `exclude_test: true`, so the combined test builds a valid destination-based tunnel. `tunnel_key` and `tunnel_destination_ipv4` are retained.

Both definitions were regenerated with `make gen`; `go vet ./internal/provider/` passes.

## Scope / follow-ups

- This restores the VRRP v2 apply on the switch (by not running it there) and the Tunnel test on the router.
- It intentionally **removes acceptance coverage for the GRE-multipoint / NHRP (DMVPN) attributes**, which are mutually exclusive with the destination-based tunnel the shared test builds. A dedicated multipoint-GRE test (no destination) would be the right way to restore that coverage — suggested as a follow-up.
- Two related nightly findings are **not** addressed here and are being tracked separately: a VRRP v2 *datasource* teardown failure on the router, and an ISIS test that fails as collateral from leftover state. Those need a closer look (possibly a provider delete-path review) rather than a test-only change.

*P.S. — This comment was drafted using voice-to-text via Claude Code. If the tone comes across as overly direct or terse, please know that's just how it tends to phrase things. No offense or criticism is intended — this is purely an objective technical review of the PR. Thanks for understanding! 🙂*