### PR TITLE
feat(crypto): add IKEv2 ML-KEM PQC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `pqc_mlkem512`, `pqc_mlkem768`, `pqc_mlkem1024`, and `pqc_optional` attributes to `iosxe_crypto_ikev2_proposal` resource and data source
+- Add `set_pfs` attribute to `iosxe_crypto_ipsec_profile` resource and data source
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute
 - BREAKING CHANGE: Consolidate `iosxe_dhcp_pool` and `iosxe_ipv6_dhcp_pool` into `iosxe_dhcp` as `pools` and `ipv6_pools` list attributes
 - BREAKING CHANGE: Consolidate `iosxe_evpn_profile` into `iosxe_evpn` as a `profiles` list attribute

--- a/docs/data-sources/crypto_ikev2_proposal.md
+++ b/docs/data-sources/crypto_ikev2_proposal.md
@@ -52,6 +52,10 @@ data "iosxe_crypto_ikev2_proposal" "example" {
 - `integrity_sha256` (Boolean) Secure Hash Standard 2 (256 bit)
 - `integrity_sha384` (Boolean) Secure Hash Standard 2 (384 bit)
 - `integrity_sha512` (Boolean) Secure Hash Standard 2 (512 bit)
+- `pqc_mlkem1024` (Boolean) Enable the ML-KEM-1024 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode. IKEv2 fragmentation should be considered because of the larger key size.
+- `pqc_mlkem512` (Boolean) Enable the ML-KEM-512 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+- `pqc_mlkem768` (Boolean) Enable the ML-KEM-768 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+- `pqc_optional` (Boolean) Allow fallback to classical key exchange when the peer does not support ML-KEM. Requires at least one PQC ML-KEM algorithm and IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
 - `prf_md5` (Boolean) Message Digest 5
 - `prf_sha1` (Boolean) Secure Hash Standard
 - `prf_sha256` (Boolean) Secure Hash Standard 2 (256 bit)

--- a/docs/data-sources/crypto_ipsec_profile.md
+++ b/docs/data-sources/crypto_ipsec_profile.md
@@ -34,7 +34,8 @@ data "iosxe_crypto_ipsec_profile" "example" {
 - `id` (String) The path of the retrieved object.
 - `set_ikev2_profile` (String) Specify ikev2 Profile
 - `set_isakmp_profile` (String) Specify isakmp Profile
-- `set_pfs_group` (String) List of supported DH groups
+- `set_pfs` (Boolean) Enable Perfect Forward Secrecy without selecting an explicit classical DH group. Use this form with ML-KEM so that IPsec Child SAs and rekeys inherit the algorithm negotiated by the IKEv2 SA. Do not configure together with `set_pfs_group`.
+- `set_pfs_group` (String) Enable Perfect Forward Secrecy with an explicit classical DH group. Do not configure together with `set_pfs`.
 - `set_security_association_lifetime_seconds` (Number) Time-based key duration in seconds
 - `set_security_association_lifetime_seconds_legacy` (Number) Security association lifetime in seconds. Use this for IOS-XE versions before `17.15.1`.
 - `set_transform_set` (List of String) Specify list of transform sets in priority order

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,8 @@ description: |-
 
 ## Unreleased
 
+- Add `pqc_mlkem512`, `pqc_mlkem768`, `pqc_mlkem1024`, and `pqc_optional` attributes to `iosxe_crypto_ikev2_proposal` resource and data source
+- Add `set_pfs` attribute to `iosxe_crypto_ipsec_profile` resource and data source
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute
 - BREAKING CHANGE: Consolidate `iosxe_dhcp_pool` and `iosxe_ipv6_dhcp_pool` into `iosxe_dhcp` as `pools` and `ipv6_pools` list attributes
 - BREAKING CHANGE: Consolidate `iosxe_evpn_profile` into `iosxe_evpn` as a `profiles` list attribute

--- a/docs/resources/crypto_ikev2_proposal.md
+++ b/docs/resources/crypto_ikev2_proposal.md
@@ -51,6 +51,10 @@ resource "iosxe_crypto_ikev2_proposal" "example" {
 - `integrity_sha256` (Boolean) Secure Hash Standard 2 (256 bit)
 - `integrity_sha384` (Boolean) Secure Hash Standard 2 (384 bit)
 - `integrity_sha512` (Boolean) Secure Hash Standard 2 (512 bit)
+- `pqc_mlkem1024` (Boolean) Enable the ML-KEM-1024 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode. IKEv2 fragmentation should be considered because of the larger key size.
+- `pqc_mlkem512` (Boolean) Enable the ML-KEM-512 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+- `pqc_mlkem768` (Boolean) Enable the ML-KEM-768 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+- `pqc_optional` (Boolean) Allow fallback to classical key exchange when the peer does not support ML-KEM. Requires at least one PQC ML-KEM algorithm and IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
 - `prf_md5` (Boolean) Message Digest 5
 - `prf_sha1` (Boolean) Secure Hash Standard
 - `prf_sha256` (Boolean) Secure Hash Standard 2 (256 bit)

--- a/docs/resources/crypto_ipsec_profile.md
+++ b/docs/resources/crypto_ipsec_profile.md
@@ -33,7 +33,8 @@ resource "iosxe_crypto_ipsec_profile" "example" {
 - `device` (String) A device name from the provider configuration.
 - `set_ikev2_profile` (String) Specify ikev2 Profile
 - `set_isakmp_profile` (String) Specify isakmp Profile
-- `set_pfs_group` (String) List of supported DH groups
+- `set_pfs` (Boolean) Enable Perfect Forward Secrecy without selecting an explicit classical DH group. Use this form with ML-KEM so that IPsec Child SAs and rekeys inherit the algorithm negotiated by the IKEv2 SA. Do not configure together with `set_pfs_group`.
+- `set_pfs_group` (String) Enable Perfect Forward Secrecy with an explicit classical DH group. Do not configure together with `set_pfs`.
   - Choices: `group1`, `group14`, `group15`, `group16`, `group19`, `group2`, `group20`, `group21`, `group24`, `group5`
 - `set_security_association_lifetime_seconds` (Number) Time-based key duration in seconds
   - Range: `120`-`2592000`

--- a/gen/definitions/crypto_ikev2_proposal.yaml
+++ b/gen/definitions/crypto_ikev2_proposal.yaml
@@ -23,6 +23,42 @@ attributes:
   - yang_name: encryption/aes-gcm-256
     example: true
     exclude_test: true
+  - yang_name: pqc/mlkem512
+    xpath: pqc/mlkem512
+    tf_name: pqc_mlkem512
+    type: Bool
+    type_yang_bool: empty
+    no_augment_config: true
+    description: Enable the ML-KEM-512 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+    example: true
+    test_tags: [IOSXE2611_C8000G2]
+  - yang_name: pqc/mlkem768
+    xpath: pqc/mlkem768
+    tf_name: pqc_mlkem768
+    type: Bool
+    type_yang_bool: empty
+    no_augment_config: true
+    description: Enable the ML-KEM-768 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+    example: true
+    test_tags: [IOSXE2611_C8000G2]
+  - yang_name: pqc/mlkem1024
+    xpath: pqc/mlkem1024
+    tf_name: pqc_mlkem1024
+    type: Bool
+    type_yang_bool: empty
+    no_augment_config: true
+    description: Enable the ML-KEM-1024 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode. IKEv2 fragmentation should be considered because of the larger key size.
+    example: true
+    test_tags: [IOSXE2611_C8000G2]
+  - yang_name: pqc/optional
+    xpath: pqc/optional
+    tf_name: pqc_optional
+    type: Bool
+    type_yang_bool: empty
+    no_augment_config: true
+    description: Allow fallback to classical key exchange when the peer does not support ML-KEM. Requires at least one PQC ML-KEM algorithm and IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.
+    example: true
+    test_tags: [IOSXE2611_C8000G2]
   - yang_name: group/one
     example: true
     exclude_test: true

--- a/gen/definitions/crypto_ipsec_profile.yaml
+++ b/gen/definitions/crypto_ipsec_profile.yaml
@@ -15,8 +15,19 @@ attributes:
     xpath: set/isakmp-profile
     example: vpn300
     exclude_test: true
+  - yang_name: set/pfs
+    xpath: set/pfs
+    tf_name: set_pfs
+    type: Bool
+    type_yang_bool: presence
+    no_augment_config: true
+    description: Enable Perfect Forward Secrecy without selecting an explicit classical DH group. Use this form with ML-KEM so that IPsec Child SAs and rekeys inherit the algorithm negotiated by the IKEv2 SA. Do not configure together with `set_pfs_group`.
+    example: true
+    exclude_example: true
+    exclude_test: true
   - yang_name: set/pfs/group
     tf_name: set_pfs_group
+    description: Enable Perfect Forward Secrecy with an explicit classical DH group. Do not configure together with `set_pfs`.
     example: group20
   - yang_name: set/security-association/lifetime/days-seconds/seconds/seconds-case
     xpath: set/security-association/lifetime/seconds-case

--- a/internal/provider/crypto_pqc_model_test.go
+++ b/internal/provider/crypto_pqc_model_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCryptoIKEv2ProposalPQCToBodyXML(t *testing.T) {
+	data := CryptoIKEv2Proposal{
+		Name:         types.StringValue("DMVPN-PQC"),
+		PqcMlkem768:  types.BoolValue(true),
+		PqcMlkem1024: types.BoolValue(true),
+		PqcOptional:  types.BoolValue(true),
+	}
+
+	body := data.toBodyXML(context.Background(), data)
+	for _, element := range []string{"<mlkem768", "<mlkem1024", "<optional"} {
+		if !strings.Contains(body, element) {
+			t.Fatalf("expected %s in NETCONF body: %s", element, body)
+		}
+	}
+}
+
+func TestCryptoIKEv2ProposalWithoutPQCOmitsPQCXML(t *testing.T) {
+	data := CryptoIKEv2Proposal{
+		Name: types.StringValue("CLASSICAL-ONLY"),
+	}
+
+	body := data.toBodyXML(context.Background(), data)
+	if strings.Contains(body, "<pqc") || strings.Contains(body, "<mlkem") {
+		t.Fatalf("did not expect PQC elements when no PQC attribute is configured: %s", body)
+	}
+}
+
+func TestCryptoIPSecProfilePresencePfsToBodyXML(t *testing.T) {
+	data := CryptoIPSecProfile{
+		Name:   types.StringValue("DMVPN_IPSEC_TEST"),
+		SetPfs: types.BoolValue(true),
+	}
+
+	body := data.toBodyXML(context.Background(), data)
+	if !strings.Contains(body, "<pfs") {
+		t.Fatalf("expected presence-only pfs container in NETCONF body: %s", body)
+	}
+	if strings.Contains(body, "<group") {
+		t.Fatalf("did not expect an explicit DH group in NETCONF body: %s", body)
+	}
+}
+
+func TestCryptoIPSecProfileWithoutPfsOmitsPfsXML(t *testing.T) {
+	data := CryptoIPSecProfile{
+		Name: types.StringValue("NO_PFS"),
+	}
+
+	body := data.toBodyXML(context.Background(), data)
+	if strings.Contains(body, "<pfs") {
+		t.Fatalf("did not expect a PFS element when no PFS attribute is configured: %s", body)
+	}
+}

--- a/internal/provider/crypto_pqc_unsupported_test.go
+++ b/internal/provider/crypto_pqc_unsupported_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccIosxeCryptoIKEv2ProposalPQCUnsupported verifies the device-side
+// failure mode on platforms that run IOS XE but do not implement the PQC YANG
+// nodes. It is intentionally separate from the generated positive test because
+// it requires a C8000V running IOS XE 17.18.
+func TestAccIosxeCryptoIKEv2ProposalPQCUnsupported(t *testing.T) {
+	if os.Getenv("IOSXE1718_C8000V") == "" {
+		t.Skip("skipping unsupported-platform test; set IOSXE1718_C8000V=1")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "iosxe_crypto_ikev2_proposal" "unsupported_pqc" {
+  name = "TF_PQC_UNSUPPORTED_TEST"
+
+  pqc_mlkem768 = true
+  pqc_optional = true
+
+  encryption_aes_cbc_256 = true
+  integrity_sha256       = true
+  group_nineteen         = true
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)unknown-element.*pqc`),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_iosxe_crypto_ikev2_proposal.go
+++ b/internal/provider/data_source_iosxe_crypto_ikev2_proposal.go
@@ -96,6 +96,22 @@ func (d *CryptoIKEv2ProposalDataSource) Schema(ctx context.Context, req datasour
 				MarkdownDescription: "Combined-mode,256 bit key,16 byte ICV(Authentication Tag)",
 				Computed:            true,
 			},
+			"pqc_mlkem512": schema.BoolAttribute{
+				MarkdownDescription: "Enable the ML-KEM-512 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.",
+				Computed:            true,
+			},
+			"pqc_mlkem768": schema.BoolAttribute{
+				MarkdownDescription: "Enable the ML-KEM-768 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.",
+				Computed:            true,
+			},
+			"pqc_mlkem1024": schema.BoolAttribute{
+				MarkdownDescription: "Enable the ML-KEM-1024 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode. IKEv2 fragmentation should be considered because of the larger key size.",
+				Computed:            true,
+			},
+			"pqc_optional": schema.BoolAttribute{
+				MarkdownDescription: "Allow fallback to classical key exchange when the peer does not support ML-KEM. Requires at least one PQC ML-KEM algorithm and IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.",
+				Computed:            true,
+			},
 			"group_one": schema.BoolAttribute{
 				MarkdownDescription: "DH 768 MODP",
 				Computed:            true,

--- a/internal/provider/data_source_iosxe_crypto_ikev2_proposal_test.go
+++ b/internal/provider/data_source_iosxe_crypto_ikev2_proposal_test.go
@@ -21,6 +21,7 @@ package provider
 
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -33,6 +34,18 @@ import (
 func TestAccDataSourceIosxeCryptoIKEv2Proposal(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "encryption_aes_cbc_256", "true"))
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "pqc_mlkem512", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "pqc_mlkem768", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "pqc_mlkem1024", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "pqc_optional", "true"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "group_sixteen", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_crypto_ikev2_proposal.test", "integrity_sha256", "true"))
 	resource.Test(t, resource.TestCase{
@@ -58,6 +71,18 @@ func testAccDataSourceIosxeCryptoIKEv2ProposalConfig() string {
 	config := `resource "iosxe_crypto_ikev2_proposal" "test" {` + "\n"
 	config += `	name = "PROPOSAL1"` + "\n"
 	config += `	encryption_aes_cbc_256 = true` + "\n"
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem512 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem768 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem1024 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_optional = true` + "\n"
+	}
 	config += `	group_sixteen = true` + "\n"
 	config += `	integrity_sha256 = true` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_iosxe_crypto_ipsec_profile.go
+++ b/internal/provider/data_source_iosxe_crypto_ipsec_profile.go
@@ -85,8 +85,12 @@ func (d *CryptoIPSecProfileDataSource) Schema(ctx context.Context, req datasourc
 				MarkdownDescription: "Specify isakmp Profile",
 				Computed:            true,
 			},
+			"set_pfs": schema.BoolAttribute{
+				MarkdownDescription: "Enable Perfect Forward Secrecy without selecting an explicit classical DH group. Use this form with ML-KEM so that IPsec Child SAs and rekeys inherit the algorithm negotiated by the IKEv2 SA. Do not configure together with `set_pfs_group`.",
+				Computed:            true,
+			},
 			"set_pfs_group": schema.StringAttribute{
-				MarkdownDescription: "List of supported DH groups",
+				MarkdownDescription: "Enable Perfect Forward Secrecy with an explicit classical DH group. Do not configure together with `set_pfs`.",
 				Computed:            true,
 			},
 			"set_security_association_lifetime_seconds": schema.Int64Attribute{

--- a/internal/provider/model_iosxe_crypto_ikev2_proposal.go
+++ b/internal/provider/model_iosxe_crypto_ikev2_proposal.go
@@ -45,6 +45,10 @@ type CryptoIKEv2Proposal struct {
 	EncryptionAesCbc256 types.Bool   `tfsdk:"encryption_aes_cbc_256"`
 	EncryptionAesGcm128 types.Bool   `tfsdk:"encryption_aes_gcm_128"`
 	EncryptionAesGcm256 types.Bool   `tfsdk:"encryption_aes_gcm_256"`
+	PqcMlkem512         types.Bool   `tfsdk:"pqc_mlkem512"`
+	PqcMlkem768         types.Bool   `tfsdk:"pqc_mlkem768"`
+	PqcMlkem1024        types.Bool   `tfsdk:"pqc_mlkem1024"`
+	PqcOptional         types.Bool   `tfsdk:"pqc_optional"`
 	GroupOne            types.Bool   `tfsdk:"group_one"`
 	GroupTwo            types.Bool   `tfsdk:"group_two"`
 	GroupFourteen       types.Bool   `tfsdk:"group_fourteen"`
@@ -76,6 +80,10 @@ type CryptoIKEv2ProposalData struct {
 	EncryptionAesCbc256 types.Bool   `tfsdk:"encryption_aes_cbc_256"`
 	EncryptionAesGcm128 types.Bool   `tfsdk:"encryption_aes_gcm_128"`
 	EncryptionAesGcm256 types.Bool   `tfsdk:"encryption_aes_gcm_256"`
+	PqcMlkem512         types.Bool   `tfsdk:"pqc_mlkem512"`
+	PqcMlkem768         types.Bool   `tfsdk:"pqc_mlkem768"`
+	PqcMlkem1024        types.Bool   `tfsdk:"pqc_mlkem1024"`
+	PqcOptional         types.Bool   `tfsdk:"pqc_optional"`
 	GroupOne            types.Bool   `tfsdk:"group_one"`
 	GroupTwo            types.Bool   `tfsdk:"group_two"`
 	GroupFourteen       types.Bool   `tfsdk:"group_fourteen"`
@@ -171,6 +179,34 @@ func (data CryptoIKEv2Proposal) toBodyXML(ctx context.Context, config CryptoIKEv
 			body = helpers.SetFromXPath(body, data.getXPath()+"/encryption/aes-gcm-256", "")
 		} else {
 			body = helpers.RemoveFromXPath(body, data.getXPath()+"/encryption/aes-gcm-256")
+		}
+	}
+	if !data.PqcMlkem512.IsNull() && !data.PqcMlkem512.IsUnknown() {
+		if data.PqcMlkem512.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/pqc/mlkem512", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/pqc/mlkem512")
+		}
+	}
+	if !data.PqcMlkem768.IsNull() && !data.PqcMlkem768.IsUnknown() {
+		if data.PqcMlkem768.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/pqc/mlkem768", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/pqc/mlkem768")
+		}
+	}
+	if !data.PqcMlkem1024.IsNull() && !data.PqcMlkem1024.IsUnknown() {
+		if data.PqcMlkem1024.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/pqc/mlkem1024", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/pqc/mlkem1024")
+		}
+	}
+	if !data.PqcOptional.IsNull() && !data.PqcOptional.IsUnknown() {
+		if data.PqcOptional.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/pqc/optional", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/pqc/optional")
 		}
 	}
 	if !data.GroupOne.IsNull() && !data.GroupOne.IsUnknown() {
@@ -376,6 +412,42 @@ func (data *CryptoIKEv2Proposal) updateFromBodyXML(ctx context.Context, res xmld
 		}
 	} else {
 		data.EncryptionAesGcm256 = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem512"); !data.PqcMlkem512.IsNull() {
+		if value.Exists() {
+			data.PqcMlkem512 = types.BoolValue(true)
+		} else {
+			data.PqcMlkem512 = types.BoolValue(false)
+		}
+	} else {
+		data.PqcMlkem512 = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem768"); !data.PqcMlkem768.IsNull() {
+		if value.Exists() {
+			data.PqcMlkem768 = types.BoolValue(true)
+		} else {
+			data.PqcMlkem768 = types.BoolValue(false)
+		}
+	} else {
+		data.PqcMlkem768 = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem1024"); !data.PqcMlkem1024.IsNull() {
+		if value.Exists() {
+			data.PqcMlkem1024 = types.BoolValue(true)
+		} else {
+			data.PqcMlkem1024 = types.BoolValue(false)
+		}
+	} else {
+		data.PqcMlkem1024 = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/optional"); !data.PqcOptional.IsNull() {
+		if value.Exists() {
+			data.PqcOptional = types.BoolValue(true)
+		} else {
+			data.PqcOptional = types.BoolValue(false)
+		}
+	} else {
+		data.PqcOptional = types.BoolNull()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/group/one"); !data.GroupOne.IsNull() {
 		if value.Exists() {
@@ -585,6 +657,26 @@ func (data *CryptoIKEv2Proposal) fromBodyXML(ctx context.Context, res xmldot.Res
 	} else {
 		data.EncryptionAesGcm256 = types.BoolValue(false)
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem512"); value.Exists() {
+		data.PqcMlkem512 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem512 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem768"); value.Exists() {
+		data.PqcMlkem768 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem768 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem1024"); value.Exists() {
+		data.PqcMlkem1024 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem1024 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/optional"); value.Exists() {
+		data.PqcOptional = types.BoolValue(true)
+	} else {
+		data.PqcOptional = types.BoolValue(false)
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/group/one"); value.Exists() {
 		data.GroupOne = types.BoolValue(true)
 	} else {
@@ -716,6 +808,26 @@ func (data *CryptoIKEv2ProposalData) fromBodyXML(ctx context.Context, res xmldot
 		data.EncryptionAesGcm256 = types.BoolValue(true)
 	} else {
 		data.EncryptionAesGcm256 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem512"); value.Exists() {
+		data.PqcMlkem512 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem512 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem768"); value.Exists() {
+		data.PqcMlkem768 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem768 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/mlkem1024"); value.Exists() {
+		data.PqcMlkem1024 = types.BoolValue(true)
+	} else {
+		data.PqcMlkem1024 = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/pqc/optional"); value.Exists() {
+		data.PqcOptional = types.BoolValue(true)
+	} else {
+		data.PqcOptional = types.BoolValue(false)
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/group/one"); value.Exists() {
 		data.GroupOne = types.BoolValue(true)
@@ -877,6 +989,18 @@ func (data *CryptoIKEv2Proposal) addDeletedItemsXML(ctx context.Context, state C
 	if !state.GroupOne.IsNull() && data.GroupOne.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/group/one")
 	}
+	if !state.PqcOptional.IsNull() && data.PqcOptional.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/pqc/optional")
+	}
+	if !state.PqcMlkem1024.IsNull() && data.PqcMlkem1024.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/pqc/mlkem1024")
+	}
+	if !state.PqcMlkem768.IsNull() && data.PqcMlkem768.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/pqc/mlkem768")
+	}
+	if !state.PqcMlkem512.IsNull() && data.PqcMlkem512.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/pqc/mlkem512")
+	}
 	if !state.EncryptionAesGcm256.IsNull() && data.EncryptionAesGcm256.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/encryption/aes-gcm-256")
 	}
@@ -962,6 +1086,18 @@ func (data *CryptoIKEv2Proposal) addDeletePathsXML(ctx context.Context, body str
 	}
 	if !data.GroupOne.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/group/one")
+	}
+	if !data.PqcOptional.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/pqc/optional")
+	}
+	if !data.PqcMlkem1024.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/pqc/mlkem1024")
+	}
+	if !data.PqcMlkem768.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/pqc/mlkem768")
+	}
+	if !data.PqcMlkem512.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/pqc/mlkem512")
 	}
 	if !data.EncryptionAesGcm256.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/encryption/aes-gcm-256")

--- a/internal/provider/model_iosxe_crypto_ipsec_profile.go
+++ b/internal/provider/model_iosxe_crypto_ipsec_profile.go
@@ -43,6 +43,7 @@ type CryptoIPSecProfile struct {
 	SetTransformSet                             types.List   `tfsdk:"set_transform_set"`
 	SetIkev2Profile                             types.String `tfsdk:"set_ikev2_profile"`
 	SetIsakmpProfile                            types.String `tfsdk:"set_isakmp_profile"`
+	SetPfs                                      types.Bool   `tfsdk:"set_pfs"`
 	SetPfsGroup                                 types.String `tfsdk:"set_pfs_group"`
 	SetSecurityAssociationLifetimeSeconds       types.Int64  `tfsdk:"set_security_association_lifetime_seconds"`
 	SetSecurityAssociationLifetimeSecondsLegacy types.Int64  `tfsdk:"set_security_association_lifetime_seconds_legacy"`
@@ -55,6 +56,7 @@ type CryptoIPSecProfileData struct {
 	SetTransformSet                             types.List   `tfsdk:"set_transform_set"`
 	SetIkev2Profile                             types.String `tfsdk:"set_ikev2_profile"`
 	SetIsakmpProfile                            types.String `tfsdk:"set_isakmp_profile"`
+	SetPfs                                      types.Bool   `tfsdk:"set_pfs"`
 	SetPfsGroup                                 types.String `tfsdk:"set_pfs_group"`
 	SetSecurityAssociationLifetimeSeconds       types.Int64  `tfsdk:"set_security_association_lifetime_seconds"`
 	SetSecurityAssociationLifetimeSecondsLegacy types.Int64  `tfsdk:"set_security_association_lifetime_seconds_legacy"`
@@ -107,6 +109,13 @@ func (data CryptoIPSecProfile) toBodyXML(ctx context.Context, config CryptoIPSec
 	if !data.SetIsakmpProfile.IsNull() && !data.SetIsakmpProfile.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/set/isakmp-profile", data.SetIsakmpProfile.ValueString())
 	}
+	if !data.SetPfs.IsNull() && !data.SetPfs.IsUnknown() {
+		if data.SetPfs.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/set/pfs", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/set/pfs")
+		}
+	}
 	if !data.SetPfsGroup.IsNull() && !data.SetPfsGroup.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/set/pfs/group", data.SetPfsGroup.ValueString())
 	}
@@ -148,6 +157,15 @@ func (data *CryptoIPSecProfile) updateFromBodyXML(ctx context.Context, res xmldo
 	} else {
 		data.SetIsakmpProfile = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs"); !data.SetPfs.IsNull() {
+		if value.Exists() {
+			data.SetPfs = types.BoolValue(true)
+		} else {
+			data.SetPfs = types.BoolValue(false)
+		}
+	} else {
+		data.SetPfs = types.BoolNull()
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs/group"); value.Exists() && !data.SetPfsGroup.IsNull() {
 		data.SetPfsGroup = types.StringValue(value.String())
 	} else {
@@ -181,6 +199,11 @@ func (data *CryptoIPSecProfile) fromBodyXML(ctx context.Context, res xmldot.Resu
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/isakmp-profile"); value.Exists() {
 		data.SetIsakmpProfile = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs"); value.Exists() {
+		data.SetPfs = types.BoolValue(true)
+	} else {
+		data.SetPfs = types.BoolValue(false)
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs/group"); value.Exists() {
 		data.SetPfsGroup = types.StringValue(value.String())
 	}
@@ -208,6 +231,11 @@ func (data *CryptoIPSecProfileData) fromBodyXML(ctx context.Context, res xmldot.
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/isakmp-profile"); value.Exists() {
 		data.SetIsakmpProfile = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs"); value.Exists() {
+		data.SetPfs = types.BoolValue(true)
+	} else {
+		data.SetPfs = types.BoolValue(false)
+	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/set/pfs/group"); value.Exists() {
 		data.SetPfsGroup = types.StringValue(value.String())
 	}
@@ -233,6 +261,9 @@ func (data *CryptoIPSecProfile) addDeletedItemsXML(ctx context.Context, state Cr
 	}
 	if !state.SetPfsGroup.IsNull() && data.SetPfsGroup.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/set/pfs/group")
+	}
+	if !state.SetPfs.IsNull() && data.SetPfs.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/set/pfs")
 	}
 	if !state.SetIsakmpProfile.IsNull() && data.SetIsakmpProfile.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/set/isakmp-profile")
@@ -284,6 +315,9 @@ func (data *CryptoIPSecProfile) addDeletePathsXML(ctx context.Context, body stri
 	}
 	if !data.SetPfsGroup.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/set/pfs/group")
+	}
+	if !data.SetPfs.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/set/pfs")
 	}
 	if !data.SetIsakmpProfile.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/set/isakmp-profile")

--- a/internal/provider/resource_iosxe_crypto_ikev2_proposal.go
+++ b/internal/provider/resource_iosxe_crypto_ikev2_proposal.go
@@ -106,6 +106,22 @@ func (r *CryptoIKEv2ProposalResource) Schema(ctx context.Context, req resource.S
 				MarkdownDescription: helpers.NewAttributeDescription("Combined-mode,256 bit key,16 byte ICV(Authentication Tag)").String,
 				Optional:            true,
 			},
+			"pqc_mlkem512": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable the ML-KEM-512 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.").String,
+				Optional:            true,
+			},
+			"pqc_mlkem768": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable the ML-KEM-768 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.").String,
+				Optional:            true,
+			},
+			"pqc_mlkem1024": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable the ML-KEM-1024 post-quantum key exchange algorithm. Requires IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode. IKEv2 fragmentation should be considered because of the larger key size.").String,
+				Optional:            true,
+			},
+			"pqc_optional": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Allow fallback to classical key exchange when the peer does not support ML-KEM. Requires at least one PQC ML-KEM algorithm and IOS XE 26.1.1 or later on a supported Cisco Secure Router G2 platform in autonomous mode.").String,
+				Optional:            true,
+			},
 			"group_one": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("DH 768 MODP").String,
 				Optional:            true,
@@ -195,6 +211,35 @@ func (r *CryptoIKEv2ProposalResource) Configure(_ context.Context, req resource.
 }
 
 // End of section. //template:end model
+
+var _ resource.ResourceWithValidateConfig = &CryptoIKEv2ProposalResource{}
+
+// ValidateConfig enforces relationships that are not represented by the IOS XE
+// YANG model. The device rejects the optional fallback keyword unless at least
+// one ML-KEM algorithm is configured in the same proposal.
+func (r *CryptoIKEv2ProposalResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CryptoIKEv2Proposal
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.PqcOptional.IsNull() || config.PqcOptional.IsUnknown() || !config.PqcOptional.ValueBool() {
+		return
+	}
+
+	algorithms := []types.Bool{config.PqcMlkem512, config.PqcMlkem768, config.PqcMlkem1024}
+	for _, algorithm := range algorithms {
+		if algorithm.IsUnknown() {
+			return
+		}
+		if !algorithm.IsNull() && algorithm.ValueBool() {
+			return
+		}
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("pqc_optional"),
+		"Missing PQC algorithm",
+		"pqc_optional requires at least one of pqc_mlkem512, pqc_mlkem768, or pqc_mlkem1024 to be true.",
+	)
+}
 
 // Section below is generated&owned by "gen/generator.go". //template:begin create
 

--- a/internal/provider/resource_iosxe_crypto_ikev2_proposal_test.go
+++ b/internal/provider/resource_iosxe_crypto_ikev2_proposal_test.go
@@ -22,6 +22,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -36,6 +37,18 @@ func TestAccIosxeCryptoIKEv2Proposal(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "name", "PROPOSAL1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "encryption_aes_cbc_256", "true"))
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "pqc_mlkem512", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "pqc_mlkem768", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "pqc_mlkem1024", "true"))
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "pqc_optional", "true"))
+	}
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "group_sixteen", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_crypto_ikev2_proposal.test", "integrity_sha256", "true"))
 	resource.Test(t, resource.TestCase{
@@ -54,7 +67,7 @@ func TestAccIosxeCryptoIKEv2Proposal(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeCryptoIKEv2ProposalImportStateIdFunc("iosxe_crypto_ikev2_proposal.test"),
-				ImportStateVerifyIgnore: []string{"encryption_en_3des", "encryption_aes_cbc_128", "encryption_aes_cbc_192", "encryption_aes_gcm_128", "encryption_aes_gcm_256", "group_one", "group_two", "group_fourteen", "group_fifteen", "group_nineteen", "group_twenty", "group_twenty_one", "group_twenty_four", "integrity_md5", "integrity_sha1", "integrity_sha384", "integrity_sha512", "prf_md5", "prf_sha1", "prf_sha256", "prf_sha384", "prf_sha512"},
+				ImportStateVerifyIgnore: []string{"encryption_en_3des", "encryption_aes_cbc_128", "encryption_aes_cbc_192", "encryption_aes_gcm_128", "encryption_aes_gcm_256", "pqc_mlkem512", "pqc_mlkem768", "pqc_mlkem1024", "pqc_optional", "group_one", "group_two", "group_fourteen", "group_fifteen", "group_nineteen", "group_twenty", "group_twenty_one", "group_twenty_four", "integrity_md5", "integrity_sha1", "integrity_sha384", "integrity_sha512", "prf_md5", "prf_sha1", "prf_sha256", "prf_sha384", "prf_sha512"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -96,6 +109,18 @@ func testAccIosxeCryptoIKEv2ProposalConfig_all() string {
 	config := `resource "iosxe_crypto_ikev2_proposal" "test" {` + "\n"
 	config += `	name = "PROPOSAL1"` + "\n"
 	config += `	encryption_aes_cbc_256 = true` + "\n"
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem512 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem768 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_mlkem1024 = true` + "\n"
+	}
+	if os.Getenv("IOSXE2611_C8000G2") != "" {
+		config += `	pqc_optional = true` + "\n"
+	}
 	config += `	group_sixteen = true` + "\n"
 	config += `	integrity_sha256 = true` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/resource_iosxe_crypto_ipsec_profile.go
+++ b/internal/provider/resource_iosxe_crypto_ipsec_profile.go
@@ -98,8 +98,12 @@ func (r *CryptoIPSecProfileResource) Schema(ctx context.Context, req resource.Sc
 				MarkdownDescription: helpers.NewAttributeDescription("Specify isakmp Profile").String,
 				Optional:            true,
 			},
+			"set_pfs": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable Perfect Forward Secrecy without selecting an explicit classical DH group. Use this form with ML-KEM so that IPsec Child SAs and rekeys inherit the algorithm negotiated by the IKEv2 SA. Do not configure together with `set_pfs_group`.").String,
+				Optional:            true,
+			},
 			"set_pfs_group": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("List of supported DH groups").AddStringEnumDescription("group1", "group14", "group15", "group16", "group19", "group2", "group20", "group21", "group24", "group5").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Enable Perfect Forward Secrecy with an explicit classical DH group. Do not configure together with `set_pfs`.").AddStringEnumDescription("group1", "group14", "group15", "group16", "group19", "group2", "group20", "group21", "group24", "group5").String,
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("group1", "group14", "group15", "group16", "group19", "group2", "group20", "group21", "group24", "group5"),
@@ -132,6 +136,27 @@ func (r *CryptoIPSecProfileResource) Configure(_ context.Context, req resource.C
 }
 
 // End of section. //template:end model
+
+var _ resource.ResourceWithValidateConfig = &CryptoIPSecProfileResource{}
+
+// ValidateConfig prevents emitting both the presence-only `set pfs` command
+// and the mutually exclusive `set pfs <group>` form in one NETCONF edit.
+func (r *CryptoIPSecProfileResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CryptoIPSecProfile
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.SetPfs.IsUnknown() || config.SetPfsGroup.IsUnknown() {
+		return
+	}
+	if config.SetPfs.IsNull() || !config.SetPfs.ValueBool() || config.SetPfsGroup.IsNull() {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("set_pfs"),
+		"Conflicting PFS settings",
+		"Configure either set_pfs or set_pfs_group, not both.",
+	)
+}
 
 // Section below is generated&owned by "gen/generator.go". //template:begin create
 

--- a/internal/provider/resource_iosxe_crypto_ipsec_profile_test.go
+++ b/internal/provider/resource_iosxe_crypto_ipsec_profile_test.go
@@ -61,7 +61,7 @@ func TestAccIosxeCryptoIPSecProfile(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       iosxeCryptoIPSecProfileImportStateIdFunc("iosxe_crypto_ipsec_profile.test"),
-				ImportStateVerifyIgnore: []string{"set_security_association_lifetime_seconds_legacy"},
+				ImportStateVerifyIgnore: []string{"set_pfs", "set_security_association_lifetime_seconds_legacy"},
 				Check:                   resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,8 @@ description: |-
 
 ## Unreleased
 
+- Add `pqc_mlkem512`, `pqc_mlkem768`, `pqc_mlkem1024`, and `pqc_optional` attributes to `iosxe_crypto_ikev2_proposal` resource and data source
+- Add `set_pfs` attribute to `iosxe_crypto_ipsec_profile` resource and data source
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute
 - BREAKING CHANGE: Consolidate `iosxe_dhcp_pool` and `iosxe_ipv6_dhcp_pool` into `iosxe_dhcp` as `pools` and `ipv6_pools` list attributes
 - BREAKING CHANGE: Consolidate `iosxe_evpn_profile` into `iosxe_evpn` as a `profiles` list attribute


### PR DESCRIPTION
## Summary

- add ML-KEM-512, ML-KEM-768, ML-KEM-1024, and optional fallback attributes to `iosxe_crypto_ikev2_proposal`
- add the presence-only `set pfs` form to `iosxe_crypto_ipsec_profile` while retaining explicit `set_pfs_group` support
- emit PQC and presence-only PFS NETCONF elements only when explicitly configured
- validate that `pqc_optional` has an ML-KEM algorithm and that the two PFS forms are not enabled together
- document the IOS XE 26.1.1 and supported Secure Router G2 requirements for IKEv2 PQC

## Why

IOS XE 26.1.1 adds ML-KEM key exchange for IKEv2 on supported Cisco Secure Router G2 platforms. IPsec Child SAs and rekeys use the presence-only `set pfs` form to inherit ML-KEM negotiated by the IKEv2 SA.

The new attributes are optional. Existing configurations and devices do not receive the new NETCONF elements unless users configure them. Unsupported devices therefore continue to work unchanged; if PQC is explicitly requested on one, IOS XE remains the source of truth and returns its normal `unknown-element` RPC error.

## Validation

- `yamale -s gen/schema/schema.yaml gen/definitions/crypto_ikev2_proposal.yaml gen/definitions/crypto_ipsec_profile.yaml`
- `go test -count=1 -timeout 10m ./...`
- `go build .`
- `git diff --check`
- Cisco C8235-G2 with IOS XE 26.1.1: ML-KEM IKEv2 proposal and presence-only PFS configuration succeeded
- C8000V with IOS XE 17.18.3a: explicitly configured PQC returned `unknown-element: pqc` and left no residual proposal configuration

## Compatibility

- no provider-wide platform or version discovery is introduced
- omitted `pqc_*` and `set_pfs` attributes produce no corresponding NETCONF XML
- the existing explicit `set_pfs_group` behavior and generated acceptance-test configuration remain unchanged
