### PR TITLE
fix: correct delete semantics for iosxe_privilege and iosxe_interface_vrrp_v2

### DIFF
--- a/gen/definitions/privilege.yaml
+++ b/gen/definitions/privilege.yaml
@@ -1,7 +1,7 @@
 ---
 name: Privilege
 path: /Cisco-IOS-XE-native:native/privilege/mode[name=%v]/level[privilege=%v]
-no_delete_attributes: true
+no_delete: true
 skip_minimum_test: true
 doc_category: System
 attributes:

--- a/gen/definitions/vrrp_v2.yaml
+++ b/gen/definitions/vrrp_v2.yaml
@@ -33,6 +33,7 @@ attributes:
     description: Virtual IP address
     type: String
     mandatory: true
+    no_delete: true
     example: 192.0.2.254
   - yang_name: ip/secondary
     tf_name: ip_secondary_addresses

--- a/internal/provider/model_iosxe_interface_vrrp_v2.go
+++ b/internal/provider/model_iosxe_interface_vrrp_v2.go
@@ -540,9 +540,6 @@ func (data *InterfaceVRRPV2) addDeletedItemsXML(ctx context.Context, state Inter
 			b = helpers.RemoveFromXPath(b, fmt.Sprintf(state.getXPath()+"/ip/secondary%v", predicates))
 		}
 	}
-	if !state.IpPrimaryAddress.IsNull() && data.IpPrimaryAddress.IsNull() {
-		b = helpers.RemoveFromXPath(b, state.getXPath()+"/ip/primary/address")
-	}
 
 	b = helpers.CleanupRedundantRemoveOperations(b)
 	return b.Res()
@@ -594,9 +591,6 @@ func (data *InterfaceVRRPV2) addDeletePathsXML(ctx context.Context, body string)
 		}
 
 		b = helpers.RemoveFromXPath(b, fmt.Sprintf(data.getXPath()+"/ip/secondary%v", predicates))
-	}
-	if !data.IpPrimaryAddress.IsNull() {
-		b = helpers.RemoveFromXPath(b, data.getXPath()+"/ip/primary/address")
 	}
 
 	b = helpers.CleanupRedundantRemoveOperations(b)

--- a/internal/provider/resource_iosxe_privilege.go
+++ b/internal/provider/resource_iosxe_privilege.go
@@ -325,7 +325,7 @@ func (r *PrivilegeResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	if device.Managed {
-		deleteMode := "all"
+		deleteMode := "attributes"
 
 		// NETCONF - Serialize write operations
 		locked := helpers.AcquireNetconfLock(&device.NetconfOpMutex, device.ReuseConnection, true)


### PR DESCRIPTION
## Summary

Corrects the delete behavior for two resources so teardown maps to a valid IOS-XE negation.

### `iosxe_privilege`
Previously deleted the whole `privilege/mode[name]/level[privilege=N]` node, which emits a bare `no privilege exec level N` — invalid, since a privilege level has no standalone existence and is only valid with a command. Switched the definition to `no_delete`, so delete routes through the per-command path and removes each `privilege exec level N <command>` mapping (the valid negation).

### `iosxe_interface_vrrp_v2`
Marked `ip_primary_address` as `no_delete`. The virtual IP is a mandatory anchor of the VRRP group; removing it while the group remains leaves an invalid address-less group. The group is now removed as a whole instead. This mirrors the existing anchor-leaf pattern (e.g. `iosxe_bgp_neighbor` `remote_as`).

Definitions updated and regenerated via `make gen`; `go vet ./internal/provider/` passes.