### PR TITLE
fix(clock): normalize time strings on read to prevent leading-zero drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 (Unreleased)
+
+- Fix perpetual `terraform plan` drift on `iosxe_clock` summer time attributes where IOS-XE strips leading zeros from time values (e.g., `02:30` becomes `2:30`) in NETCONF get-config responses. The provider now normalizes time strings to always include leading zeros on read.
+
 ## 1.0.0
 
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 1.0.1 (Unreleased)
+
+- Fix perpetual `terraform plan` drift on `iosxe_clock` summer time attributes where IOS-XE strips leading zeros from time values (e.g., `02:30` becomes `2:30`) in NETCONF get-config responses. The provider now normalizes time strings to always include leading zeros on read.
+
 ## 1.0.0
 
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute

--- a/internal/provider/helpers/clock_normalize.go
+++ b/internal/provider/helpers/clock_normalize.go
@@ -1,0 +1,33 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Mozilla Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NormalizeTimeString normalizes a time string like "2:30" to "02:30"
+// by ensuring the hour component always has a leading zero when it is
+// a single digit. IOS-XE strips leading zeros from time values in
+// NETCONF get-config responses, but users typically configure them
+// with leading zeros (e.g., "02:00").
+func NormalizeTimeString(value string) string {
+	parts := strings.SplitN(value, ":", 2)
+	if len(parts) != 2 {
+		return value
+	}
+	hour := parts[0]
+	minute := parts[1]
+	if len(hour) == 1 {
+		hour = "0" + hour
+	}
+	if len(minute) == 1 {
+		minute = "0" + minute
+	}
+	return fmt.Sprintf("%s:%s", hour, minute)
+}

--- a/internal/provider/model_iosxe_clock.go
+++ b/internal/provider/model_iosxe_clock.go
@@ -221,7 +221,9 @@ func (data Clock) toBodyXML(ctx context.Context, config Clock) string {
 
 // End of section. //template:end toBodyXML
 
-// Section below is generated&owned by "gen/generator.go". //template:begin updateFromBodyXML
+// Custom implementation - template markers removed to preserve changes
+// IOS-XE strips leading zeros from time values (e.g., "02:30" -> "2:30") in NETCONF
+// get-config responses. NormalizeTimeString pads single-digit hours/minutes to prevent drift.
 
 func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/calendar-valid"); !data.CalendarValid.IsNull() {
@@ -263,7 +265,7 @@ func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateStartYear = types.Int64Null()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/start-time"); value.Exists() && !data.SummerTimeDateStartTime.IsNull() {
-		data.SummerTimeDateStartTime = types.StringValue(value.String())
+		data.SummerTimeDateStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	} else {
 		data.SummerTimeDateStartTime = types.StringNull()
 	}
@@ -283,7 +285,7 @@ func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateEndYear = types.Int64Null()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/date-end-time"); value.Exists() && !data.SummerTimeDateEndTime.IsNull() {
-		data.SummerTimeDateEndTime = types.StringValue(value.String())
+		data.SummerTimeDateEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	} else {
 		data.SummerTimeDateEndTime = types.StringNull()
 	}
@@ -317,7 +319,7 @@ func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringStartMonth = types.StringNull()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-start-time"); value.Exists() && !data.SummerTimeRecurringStartTime.IsNull() {
-		data.SummerTimeRecurringStartTime = types.StringValue(value.String())
+		data.SummerTimeRecurringStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	} else {
 		data.SummerTimeRecurringStartTime = types.StringNull()
 	}
@@ -337,7 +339,7 @@ func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringEndMonth = types.StringNull()
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-end-time"); value.Exists() && !data.SummerTimeRecurringEndTime.IsNull() {
-		data.SummerTimeRecurringEndTime = types.StringValue(value.String())
+		data.SummerTimeRecurringEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	} else {
 		data.SummerTimeRecurringEndTime = types.StringNull()
 	}
@@ -363,9 +365,10 @@ func (data *Clock) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	}
 }
 
-// End of section. //template:end updateFromBodyXML
+// End of custom updateFromBodyXML implementation.
 
-// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyXML
+// Custom implementation - template markers removed to preserve changes
+// See updateFromBodyXML above for rationale.
 
 func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/calendar-valid"); value.Exists() {
@@ -391,7 +394,7 @@ func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateStartYear = types.Int64Value(value.Int())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/start-time"); value.Exists() {
-		data.SummerTimeDateStartTime = types.StringValue(value.String())
+		data.SummerTimeDateStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/date-end-day"); value.Exists() {
 		data.SummerTimeDateEndDay = types.Int64Value(value.Int())
@@ -403,7 +406,7 @@ func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateEndYear = types.Int64Value(value.Int())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/date-end-time"); value.Exists() {
-		data.SummerTimeDateEndTime = types.StringValue(value.String())
+		data.SummerTimeDateEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/offset"); value.Exists() {
 		data.SummerTimeDateOffset = types.Int64Value(value.Int())
@@ -423,7 +426,7 @@ func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringStartMonth = types.StringValue(value.String())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-start-time"); value.Exists() {
-		data.SummerTimeRecurringStartTime = types.StringValue(value.String())
+		data.SummerTimeRecurringStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-end"); value.Exists() {
 		data.SummerTimeRecurringEndWeek = types.StringValue(value.String())
@@ -435,7 +438,7 @@ func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringEndMonth = types.StringValue(value.String())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-end-time"); value.Exists() {
-		data.SummerTimeRecurringEndTime = types.StringValue(value.String())
+		data.SummerTimeRecurringEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-offset"); value.Exists() {
 		data.SummerTimeRecurringOffset = types.Int64Value(value.Int())
@@ -451,9 +454,10 @@ func (data *Clock) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	}
 }
 
-// End of section. //template:end fromBodyXML
+// End of custom fromBodyXML implementation.
 
-// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyDataXML
+// Custom implementation - template markers removed to preserve changes
+// See updateFromBodyXML above for rationale.
 
 func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/calendar-valid"); value.Exists() {
@@ -479,7 +483,7 @@ func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateStartYear = types.Int64Value(value.Int())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/start-time"); value.Exists() {
-		data.SummerTimeDateStartTime = types.StringValue(value.String())
+		data.SummerTimeDateStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/date-end-day"); value.Exists() {
 		data.SummerTimeDateEndDay = types.Int64Value(value.Int())
@@ -491,7 +495,7 @@ func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeDateEndYear = types.Int64Value(value.Int())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/date-end-time"); value.Exists() {
-		data.SummerTimeDateEndTime = types.StringValue(value.String())
+		data.SummerTimeDateEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/offset"); value.Exists() {
 		data.SummerTimeDateOffset = types.Int64Value(value.Int())
@@ -511,7 +515,7 @@ func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringStartMonth = types.StringValue(value.String())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-start-time"); value.Exists() {
-		data.SummerTimeRecurringStartTime = types.StringValue(value.String())
+		data.SummerTimeRecurringStartTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-end"); value.Exists() {
 		data.SummerTimeRecurringEndWeek = types.StringValue(value.String())
@@ -523,7 +527,7 @@ func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 		data.SummerTimeRecurringEndMonth = types.StringValue(value.String())
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-end-time"); value.Exists() {
-		data.SummerTimeRecurringEndTime = types.StringValue(value.String())
+		data.SummerTimeRecurringEndTime = types.StringValue(helpers.NormalizeTimeString(value.String()))
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/summer-time/recurring-offset"); value.Exists() {
 		data.SummerTimeRecurringOffset = types.Int64Value(value.Int())
@@ -539,7 +543,7 @@ func (data *ClockData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	}
 }
 
-// End of section. //template:end fromBodyDataXML
+// End of custom fromBodyDataXML implementation.
 
 // Section below is generated&owned by "gen/generator.go". //template:begin addDeletedItemsXML
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 1.0.1 (Unreleased)
+
+- Fix perpetual `terraform plan` drift on `iosxe_clock` summer time attributes where IOS-XE strips leading zeros from time values (e.g., `02:30` becomes `2:30`) in NETCONF get-config responses. The provider now normalizes time strings to always include leading zeros on read.
+
 ## 1.0.0
 
 - BREAKING CHANGE: Consolidate `iosxe_device_tracking_policy` into `iosxe_device_tracking` as a `policies` list attribute


### PR DESCRIPTION
## Summary

Fixes perpetual `terraform plan` drift on `iosxe_clock` summer time attributes when using time values with leading zeros (e.g., `"02:00"`, `"02:30"`).

**Root cause:** IOS-XE strips leading zeros from summer-time time values in NETCONF get-config responses. When the user configures `"02:30"`, the device accepts it, but returns `"2:30"` on read. The provider stored `"02:30"` in Terraform state but read back `"2:30"`, causing Terraform to detect drift on every subsequent plan.

**Impact:** Any `iosxe_clock` resource using summer-time with time values like `"02:00"`, `"03:00"`, etc. produced false drift, failing idempotency checks.

**Fix:** Added `NormalizeTimeString()` helper that pads single-digit hour and minute components with a leading zero during the Read operation. This ensures state always stores the padded form (e.g., `"02:30"`) regardless of how the device returns it.

## Affected attributes

- `summer_time_date_start_time`
- `summer_time_date_end_time`
- `summer_time_recurring_start_time`
- `summer_time_recurring_end_time`

## Testing

Verified against IOS-XE 17.15.1a (cat8kv):
1. First apply with `start_time: "02:00"`, `end_time: "02:30"` — succeeds
2. Second apply (idempotency check) — "No changes" (previously showed `"2:00" -> "02:00"` drift)

## Related

Part of provider v1.0.0 idempotency fix series discovered during CI investigation for `nac-iosxe` PR-1574. See also: #613 (ACL port/DSCP normalization).

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~85%
- **AI Reason**: provider bugfix for clock time idempotency drift
- **Human Oversight**: Reviewed and tested by @ChristopherJHart