### PR TITLE
feat: add min_float/max_float and num() example support to schema

### DIFF
--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -36,11 +36,13 @@ attribute:
   exclude_test: bool(required=False)  # Set to true if the attribute should be excluded from the test
   exclude_example: bool(required=False)  # Set to true if the attribute should be excluded from the example
   description: str(required=False)  # Description of the attribute
-  example: any(str(), int(), bool(), required=False)  # Example value for the attribute
+  example: any(str(), int(), num(), bool(), required=False)  # Example value for the attribute
   allow_import_changes: bool(required=False)  # Set to true if the attribute should be allowed to change during import
   enum_values: list(str(), required=False)  # List of possible enum values
   min_int: int(required=False)  # Minimum value for integer attributes
   max_int: int(required=False)  # Maximum value for integer attributes
+  min_float: num(required=False)  # Minimum value for float attributes
+  max_float: num(required=False)  # Maximum value for float attributes
   string_patterns: list(str(),required=False)  # List of string patterns
   string_min_length: int(required=False)  # Minimum length for string attributes
   string_max_length: int(required=False)  # Maximum length for string attributes


### PR DESCRIPTION
## ✔️ Type of Change

- [x] 🚀 New feature (new resource/data source, new attributes to existing resource)
- [ ] 🐛 Bug fix (corrects an issue in resource behavior, RESTCONF/NETCONF handling)
- [ ] ⚠️ Breaking change (modifies existing resource schema or removes attributes)
- [ ] 📄 Documentation update (resource docs, examples, registry docs)
- [ ] 🛠️ Refactoring / tech debt (internal improvements, no user-facing changes)
- [ ] ⚙️ Other (please describe):

## 🔗 Related Issue(s)

Prerequisite for #615 follow-up (port-channel storm-control/access-session attributes)

## 📝 Proposed Changes

`gen/generator.go` already defines `MinFloat`/`MaxFloat` on the attribute struct and derives them automatically from YANG `decimal64` ranges, and `gen/templates/resource.go` already emits `float64validator.Between()` from them — but `gen/schema/schema.yaml`'s Yamale validation never declared `min_float`/`max_float` as accepted keys, so a `gen/definitions/*.yaml` author couldn't set them explicitly (only auto-derivation from YANG worked). This adds the two keys, mirroring the existing `min_int`/`max_int` pattern.

Also adds `num()` to the `example` field validator — `example` only accepted `str()`, `int()`, `bool()`, so a decimal example value (e.g. `10.5`) would fail Yamale validation without this.

No YANG paths added or changed — this is a Yamale schema (`gen/schema/schema.yaml`) change only.

---

## 🧪 Testing Evidence

- [x] N/A — this PR does not touch definitions, generated code, or provider logic (schema-only change to `gen/schema/schema.yaml`; functional validation covered by the companion `interface_port_channel` PR, see below)

### 1. Code Generation

```bash
make gen
git diff --stat -- internal/provider/
# (no output — schema-only change, no generated code affected)
```

- [x] `make gen` completes without errors
- [x] Generated code matches YANG model expectations

### 2. Acceptance Tests

N/A — no acceptance test targets the Yamale schema file itself, since it isn't a resource. The new `min_float`/`max_float` keys are exercised end-to-end by the companion `interface_port_channel` PR: the resulting `float64validator.Between(0, 100)` was confirmed on hardware to correctly reject out-of-range values (e.g. `101.0`) client-side at plan time.

- [ ] Acceptance tests pass against a real device
- [ ] Device type and IOS-XE version: _______

---

## 🔗 Cross-Repo Links

- Module PR: n/a
- Schema PR: n/a

## ✅ Checklist

### Pre-Submission

- [x] I have merged/rebased from `main` and resolved all merge conflicts
- [x] `make gen` runs cleanly for affected resources
- [ ] Acceptance tests pass against a real IOS-XE device
- [x] `go build ./...` compiles without errors

### Code Quality

- [ ] Definition YAML follows existing patterns in `gen/definitions/` — n/a, no `gen/definitions/*.yaml` changed
- [ ] YANG paths are correct and validated against YangSuite — n/a, no YANG paths added
- [ ] Examples in `examples/resources/` are updated for new/changed attributes — n/a
- [ ] Resource documentation in `docs/` is regenerated and accurate — n/a

### Labels & Assignment

- [ ] I have assigned at least one label that aligns with `release.yaml` categories: `feature`, `enhancement`, `bug`, `fix`, `breaking-change`, `documentation`, `refactor`, `tech-debt`, `chore`, or `dependencies`
- [ ] Label(s) match the linked GitHub issue label(s) where applicable
- [ ] PR is assigned to myself
- [ ] One or more reviewers are assigned