### PR TITLE
Fix/port channel storm control access session

### DIFF
--- a/docs/data-sources/interface_port_channel.md
+++ b/docs/data-sources/interface_port_channel.md
@@ -31,6 +31,7 @@ data "iosxe_interface_port_channel" "example" {
 
 ### Read-Only
 
+- `access_session_monitor` (Boolean) Apply interface defined access-session monitor
 - `arp_timeout` (Number) Set ARP cache timeout
 - `auto_qos_classify` (Boolean) Configure classification for untrusted devices
 - `auto_qos_classify_police` (Boolean) Configure QoS policing for untrusted devices
@@ -107,6 +108,32 @@ data "iosxe_interface_port_channel" "example" {
 - `spanning_tree_portfast_disable` (Boolean) (DEPRECATED) Disable portfast for this interface
 - `spanning_tree_portfast_edge` (Boolean) (DEPRECATED) Enable portfast edge on the interface
 - `spanning_tree_portfast_trunk` (Boolean) (DEPRECATED) Enable portfast on the interface even in trunk mode
+- `storm_control_action_shutdown` (Boolean) Shutdown this interface if a storm occurs
+- `storm_control_action_trap` (Boolean) Send SNMP trap if a storm occurs
+- `storm_control_broadcast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_broadcast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_multicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_multicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unknown_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unknown_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_rising_threshold` (Number) Enter rising threshold
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
 - `vrf_forwarding` (String) Configure forwarding table

--- a/docs/resources/interface_port_channel.md
+++ b/docs/resources/interface_port_channel.md
@@ -68,6 +68,33 @@ resource "iosxe_interface_port_channel" "example" {
       direction = "input"
     }
   ]
+  access_session_monitor                                    = true
+  storm_control_broadcast_level_rising_threshold            = 10.5
+  storm_control_broadcast_level_falling_threshold           = 8.5
+  storm_control_broadcast_level_bps_rising_threshold        = "10k"
+  storm_control_broadcast_level_bps_falling_threshold       = "8k"
+  storm_control_broadcast_level_pps_rising_threshold        = "10k"
+  storm_control_broadcast_level_pps_falling_threshold       = "8k"
+  storm_control_multicast_level_rising_threshold            = 10.5
+  storm_control_multicast_level_falling_threshold           = 8.5
+  storm_control_multicast_level_bps_rising_threshold        = "10k"
+  storm_control_multicast_level_bps_falling_threshold       = "8k"
+  storm_control_multicast_level_pps_rising_threshold        = "10k"
+  storm_control_multicast_level_pps_falling_threshold       = "8k"
+  storm_control_unicast_level_rising_threshold              = 10.5
+  storm_control_unicast_level_falling_threshold             = 8.5
+  storm_control_unicast_level_bps_rising_threshold          = "10k"
+  storm_control_unicast_level_bps_falling_threshold         = "8k"
+  storm_control_unicast_level_pps_rising_threshold          = "10k"
+  storm_control_unicast_level_pps_falling_threshold         = "8k"
+  storm_control_unknown_unicast_level_rising_threshold      = 10.5
+  storm_control_unknown_unicast_level_falling_threshold     = 8.5
+  storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+  storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+  storm_control_action_shutdown                             = true
+  storm_control_action_trap                                 = true
 }
 ```
 
@@ -80,6 +107,7 @@ resource "iosxe_interface_port_channel" "example" {
 
 ### Optional
 
+- `access_session_monitor` (Boolean) Apply interface defined access-session monitor
 - `arp_timeout` (Number) Set ARP cache timeout
   - Range: `0`-`2147483`
 - `auto_qos_classify` (Boolean) Configure classification for untrusted devices
@@ -169,6 +197,32 @@ resource "iosxe_interface_port_channel" "example" {
 - `spanning_tree_portfast_disable` (Boolean) (DEPRECATED) Disable portfast for this interface
 - `spanning_tree_portfast_edge` (Boolean) (DEPRECATED) Enable portfast edge on the interface
 - `spanning_tree_portfast_trunk` (Boolean) (DEPRECATED) Enable portfast on the interface even in trunk mode
+- `storm_control_action_shutdown` (Boolean) Shutdown this interface if a storm occurs
+- `storm_control_action_trap` (Boolean) Send SNMP trap if a storm occurs
+- `storm_control_broadcast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_broadcast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_multicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_multicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unknown_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unknown_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_rising_threshold` (Number) Enter rising threshold
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
   - Choices: `cisco-phone`, `cts`, `ip-camera`, `media-player`

--- a/examples/resources/iosxe_interface_port_channel/resource.tf
+++ b/examples/resources/iosxe_interface_port_channel/resource.tf
@@ -53,4 +53,31 @@ resource "iosxe_interface_port_channel" "example" {
       direction = "input"
     }
   ]
+  access_session_monitor                                    = true
+  storm_control_broadcast_level_rising_threshold            = 10.5
+  storm_control_broadcast_level_falling_threshold           = 8.5
+  storm_control_broadcast_level_bps_rising_threshold        = "10k"
+  storm_control_broadcast_level_bps_falling_threshold       = "8k"
+  storm_control_broadcast_level_pps_rising_threshold        = "10k"
+  storm_control_broadcast_level_pps_falling_threshold       = "8k"
+  storm_control_multicast_level_rising_threshold            = 10.5
+  storm_control_multicast_level_falling_threshold           = 8.5
+  storm_control_multicast_level_bps_rising_threshold        = "10k"
+  storm_control_multicast_level_bps_falling_threshold       = "8k"
+  storm_control_multicast_level_pps_rising_threshold        = "10k"
+  storm_control_multicast_level_pps_falling_threshold       = "8k"
+  storm_control_unicast_level_rising_threshold              = 10.5
+  storm_control_unicast_level_falling_threshold             = 8.5
+  storm_control_unicast_level_bps_rising_threshold          = "10k"
+  storm_control_unicast_level_bps_falling_threshold         = "8k"
+  storm_control_unicast_level_pps_rising_threshold          = "10k"
+  storm_control_unicast_level_pps_falling_threshold         = "8k"
+  storm_control_unknown_unicast_level_rising_threshold      = 10.5
+  storm_control_unknown_unicast_level_falling_threshold     = 8.5
+  storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+  storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+  storm_control_action_shutdown                             = true
+  storm_control_action_trap                                 = true
 }

--- a/gen/definitions/interface_port_channel.yaml
+++ b/gen/definitions/interface_port_channel.yaml
@@ -369,6 +369,124 @@ attributes:
     tf_name: zone_member_security
     example: INSIDE
     exclude_test: true
+  - yang_name: access-session/monitor
+    example: true
+  - yang_name: storm-control/broadcast/level/threshold/rising-threshold
+    xpath: storm-control/broadcast/level/threshold/rising-threshold
+    tf_name: storm_control_broadcast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/broadcast/level/threshold/falling-threshold
+    xpath: storm-control/broadcast/level/threshold/falling-threshold
+    tf_name: storm_control_broadcast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/broadcast/level/bps/rising-threshold
+    xpath: storm-control/broadcast/level/bps/rising-threshold
+    tf_name: storm_control_broadcast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/broadcast/level/bps/falling-threshold
+    xpath: storm-control/broadcast/level/bps/falling-threshold
+    tf_name: storm_control_broadcast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/broadcast/level/pps/rising-threshold
+    xpath: storm-control/broadcast/level/pps/rising-threshold
+    tf_name: storm_control_broadcast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/broadcast/level/pps/falling-threshold
+    xpath: storm-control/broadcast/level/pps/falling-threshold
+    tf_name: storm_control_broadcast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/multicast/level/threshold/rising-threshold
+    xpath: storm-control/multicast/level/threshold/rising-threshold
+    tf_name: storm_control_multicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/multicast/level/threshold/falling-threshold
+    xpath: storm-control/multicast/level/threshold/falling-threshold
+    tf_name: storm_control_multicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/multicast/level/bps/rising-threshold
+    xpath: storm-control/multicast/level/bps/rising-threshold
+    tf_name: storm_control_multicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/multicast/level/bps/falling-threshold
+    xpath: storm-control/multicast/level/bps/falling-threshold
+    tf_name: storm_control_multicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/multicast/level/pps/rising-threshold
+    xpath: storm-control/multicast/level/pps/rising-threshold
+    tf_name: storm_control_multicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/multicast/level/pps/falling-threshold
+    xpath: storm-control/multicast/level/pps/falling-threshold
+    tf_name: storm_control_multicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unicast/level/threshold/rising-threshold
+    xpath: storm-control/unicast/level/threshold/rising-threshold
+    tf_name: storm_control_unicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unicast/level/threshold/falling-threshold
+    xpath: storm-control/unicast/level/threshold/falling-threshold
+    tf_name: storm_control_unicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unicast/level/bps/rising-threshold
+    xpath: storm-control/unicast/level/bps/rising-threshold
+    tf_name: storm_control_unicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unicast/level/bps/falling-threshold
+    xpath: storm-control/unicast/level/bps/falling-threshold
+    tf_name: storm_control_unicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unicast/level/pps/rising-threshold
+    xpath: storm-control/unicast/level/pps/rising-threshold
+    tf_name: storm_control_unicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unicast/level/pps/falling-threshold
+    xpath: storm-control/unicast/level/pps/falling-threshold
+    tf_name: storm_control_unicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unknown-unicast/level/threshold/rising-threshold
+    xpath: storm-control/unknown-unicast/level/threshold/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unknown-unicast/level/threshold/falling-threshold
+    xpath: storm-control/unknown-unicast/level/threshold/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unknown-unicast/level/bps/rising-threshold
+    xpath: storm-control/unknown-unicast/level/bps/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unknown-unicast/level/bps/falling-threshold
+    xpath: storm-control/unknown-unicast/level/bps/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unknown-unicast/level/pps/rising-threshold
+    xpath: storm-control/unknown-unicast/level/pps/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unknown-unicast/level/pps/falling-threshold
+    xpath: storm-control/unknown-unicast/level/pps/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/action/shutdown
+    example: true
+  - yang_name: storm-control/action/trap
+    example: true
 
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/vrf/definition[name=VRF1]

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -36,11 +36,13 @@ attribute:
   exclude_test: bool(required=False)  # Set to true if the attribute should be excluded from the test
   exclude_example: bool(required=False)  # Set to true if the attribute should be excluded from the example
   description: str(required=False)  # Description of the attribute
-  example: any(str(), int(), bool(), required=False)  # Example value for the attribute
+  example: any(str(), int(), num(), bool(), required=False)  # Example value for the attribute
   allow_import_changes: bool(required=False)  # Set to true if the attribute should be allowed to change during import
   enum_values: list(str(), required=False)  # List of possible enum values
   min_int: int(required=False)  # Minimum value for integer attributes
   max_int: int(required=False)  # Maximum value for integer attributes
+  min_float: num(required=False)  # Minimum value for float attributes
+  max_float: num(required=False)  # Maximum value for float attributes
   string_patterns: list(str(),required=False)  # List of string patterns
   string_min_length: int(required=False)  # Minimum length for string attributes
   string_max_length: int(required=False)  # Maximum length for string attributes

--- a/internal/provider/data_source_iosxe_interface_port_channel.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel.go
@@ -509,6 +509,114 @@ func (d *InterfacePortChannelDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "Security zone",
 				Computed:            true,
 			},
+			"access_session_monitor": schema.BoolAttribute{
+				MarkdownDescription: "Apply interface defined access-session monitor",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_action_shutdown": schema.BoolAttribute{
+				MarkdownDescription: "Shutdown this interface if a storm occurs",
+				Computed:            true,
+			},
+			"storm_control_action_trap": schema.BoolAttribute{
+				MarkdownDescription: "Send SNMP trap if a storm occurs",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_port_channel_test.go
+++ b/internal/provider/data_source_iosxe_interface_port_channel_test.go
@@ -79,6 +79,33 @@ func TestAccDataSourceIosxeInterfacePortChannel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_verify_unicast_source_allow_default", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "ip_flow_monitors.0.direction", "input"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "access_session_monitor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_broadcast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_multicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_action_shutdown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_port_channel.test", "storm_control_action_trap", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -239,6 +266,33 @@ func testAccDataSourceIosxeInterfacePortChannelConfig() string {
 	config += `		name = "MON1"` + "\n"
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
+	config += `	access_session_monitor = true` + "\n"
+	config += `	storm_control_broadcast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_broadcast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_broadcast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_multicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_multicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_action_shutdown = true` + "\n"
+	config += `	storm_control_action_trap = true` + "\n"
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, iosxe_yang.PreReq3, iosxe_yang.PreReq4, iosxe_yang.PreReq5, iosxe_yang.PreReq6, iosxe_yang.PreReq7, iosxe_yang.PreReq8, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_interface_port_channel.go
+++ b/internal/provider/model_iosxe_interface_port_channel.go
@@ -38,89 +38,116 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 type InterfacePortChannel struct {
-	Device                             types.String                                         `tfsdk:"device"`
-	Id                                 types.String                                         `tfsdk:"id"`
-	DeleteMode                         types.String                                         `tfsdk:"delete_mode"`
-	Name                               types.Int64                                          `tfsdk:"name"`
-	Description                        types.String                                         `tfsdk:"description"`
-	Shutdown                           types.Bool                                           `tfsdk:"shutdown"`
-	Mtu                                types.Int64                                          `tfsdk:"mtu"`
-	Switchport                         types.Bool                                           `tfsdk:"switchport"`
-	IpProxyArp                         types.Bool                                           `tfsdk:"ip_proxy_arp"`
-	IpRedirects                        types.Bool                                           `tfsdk:"ip_redirects"`
-	IpUnreachables                     types.Bool                                           `tfsdk:"ip_unreachables"`
-	VrfForwarding                      types.String                                         `tfsdk:"vrf_forwarding"`
-	Ipv4Address                        types.String                                         `tfsdk:"ipv4_address"`
-	Ipv4AddressMask                    types.String                                         `tfsdk:"ipv4_address_mask"`
-	Ipv4AddressDhcp                    types.Bool                                           `tfsdk:"ipv4_address_dhcp"`
-	IpAccessGroupInEnable              types.Bool                                           `tfsdk:"ip_access_group_in_enable"`
-	IpAccessGroupIn                    types.String                                         `tfsdk:"ip_access_group_in"`
-	IpAccessGroupOutEnable             types.Bool                                           `tfsdk:"ip_access_group_out_enable"`
-	IpAccessGroupOut                   types.String                                         `tfsdk:"ip_access_group_out"`
-	IpDhcpRelaySourceInterface         types.String                                         `tfsdk:"ip_dhcp_relay_source_interface"`
-	SpanningTreeGuard                  types.String                                         `tfsdk:"spanning_tree_guard"`
-	AutoQosClassify                    types.Bool                                           `tfsdk:"auto_qos_classify"`
-	AutoQosClassifyPolice              types.Bool                                           `tfsdk:"auto_qos_classify_police"`
-	AutoQosTrust                       types.Bool                                           `tfsdk:"auto_qos_trust"`
-	AutoQosTrustCos                    types.Bool                                           `tfsdk:"auto_qos_trust_cos"`
-	AutoQosTrustDscp                   types.Bool                                           `tfsdk:"auto_qos_trust_dscp"`
-	AutoQosVideoCts                    types.Bool                                           `tfsdk:"auto_qos_video_cts"`
-	AutoQosVideoIpCamera               types.Bool                                           `tfsdk:"auto_qos_video_ip_camera"`
-	AutoQosVideoMediaPlayer            types.Bool                                           `tfsdk:"auto_qos_video_media_player"`
-	AutoQosVoipCiscoPhone              types.Bool                                           `tfsdk:"auto_qos_voip_cisco_phone"`
-	AutoQosVoipCiscoSoftphone          types.Bool                                           `tfsdk:"auto_qos_voip_cisco_softphone"`
-	AutoQosVoipTrust                   types.Bool                                           `tfsdk:"auto_qos_voip_trust"`
-	TrustDevice                        types.String                                         `tfsdk:"trust_device"`
-	HelperAddresses                    []InterfacePortChannelHelperAddresses                `tfsdk:"helper_addresses"`
-	BfdTemplate                        types.String                                         `tfsdk:"bfd_template"`
-	BfdEnable                          types.Bool                                           `tfsdk:"bfd_enable"`
-	BfdLocalAddress                    types.String                                         `tfsdk:"bfd_local_address"`
-	BfdInterval                        types.Int64                                          `tfsdk:"bfd_interval"`
-	BfdIntervalMinRx                   types.Int64                                          `tfsdk:"bfd_interval_min_rx"`
-	BfdIntervalMultiplier              types.Int64                                          `tfsdk:"bfd_interval_multiplier"`
-	BfdEcho                            types.Bool                                           `tfsdk:"bfd_echo"`
-	Ipv6Enable                         types.Bool                                           `tfsdk:"ipv6_enable"`
-	Ipv6Mtu                            types.Int64                                          `tfsdk:"ipv6_mtu"`
-	Ipv6NdRaSuppressAll                types.Bool                                           `tfsdk:"ipv6_nd_ra_suppress_all"`
-	Ipv6AddressAutoconfigDefault       types.Bool                                           `tfsdk:"ipv6_address_autoconfig_default"`
-	Ipv6AddressDhcp                    types.Bool                                           `tfsdk:"ipv6_address_dhcp"`
-	Ipv6DhcpServers                    []InterfacePortChannelIpv6DhcpServers                `tfsdk:"ipv6_dhcp_servers"`
-	Ipv6DhcpClientPd                   types.String                                         `tfsdk:"ipv6_dhcp_client_pd"`
-	Ipv6DhcpClientPdRapidCommit        types.Bool                                           `tfsdk:"ipv6_dhcp_client_pd_rapid_commit"`
-	Ipv6DhcpRelayDestinations          []InterfacePortChannelIpv6DhcpRelayDestinations      `tfsdk:"ipv6_dhcp_relay_destinations"`
-	Ipv6DhcpRelayTrust                 types.Bool                                           `tfsdk:"ipv6_dhcp_relay_trust"`
-	Ipv6DhcpRelayOptionVpn             types.Bool                                           `tfsdk:"ipv6_dhcp_relay_option_vpn"`
-	Ipv6LinkLocalAddresses             []InterfacePortChannelIpv6LinkLocalAddresses         `tfsdk:"ipv6_link_local_addresses"`
-	Ipv6Addresses                      []InterfacePortChannelIpv6Addresses                  `tfsdk:"ipv6_addresses"`
-	Ipv6FlowMonitors                   []InterfacePortChannelIpv6FlowMonitors               `tfsdk:"ipv6_flow_monitors"`
-	ArpTimeout                         types.Int64                                          `tfsdk:"arp_timeout"`
-	IpArpInspectionTrust               types.Bool                                           `tfsdk:"ip_arp_inspection_trust"`
-	IpArpInspectionLimitRate           types.Int64                                          `tfsdk:"ip_arp_inspection_limit_rate"`
-	SpanningTreeLinkType               types.String                                         `tfsdk:"spanning_tree_link_type"`
-	BpduguardEnable                    types.Bool                                           `tfsdk:"bpduguard_enable"`
-	BpduguardDisable                   types.Bool                                           `tfsdk:"bpduguard_disable"`
-	SpanningTreePortfast               types.Bool                                           `tfsdk:"spanning_tree_portfast"`
-	SpanningTreePortfastDisable        types.Bool                                           `tfsdk:"spanning_tree_portfast_disable"`
-	SpanningTreePortfastTrunk          types.Bool                                           `tfsdk:"spanning_tree_portfast_trunk"`
-	SpanningTreePortfastEdge           types.Bool                                           `tfsdk:"spanning_tree_portfast_edge"`
-	IpDhcpSnoopingTrust                types.Bool                                           `tfsdk:"ip_dhcp_snooping_trust"`
-	LoadInterval                       types.Int64                                          `tfsdk:"load_interval"`
-	SnmpTrapLinkStatus                 types.Bool                                           `tfsdk:"snmp_trap_link_status"`
-	LoggingEventLinkStatusEnable       types.Bool                                           `tfsdk:"logging_event_link_status_enable"`
-	DeviceTracking                     types.Bool                                           `tfsdk:"device_tracking"`
-	DeviceTrackingAttachedPolicies     []InterfacePortChannelDeviceTrackingAttachedPolicies `tfsdk:"device_tracking_attached_policies"`
-	NegotiationAuto                    types.Bool                                           `tfsdk:"negotiation_auto"`
-	EvpnEthernetSegments               []InterfacePortChannelEvpnEthernetSegments           `tfsdk:"evpn_ethernet_segments"`
-	EvpnEthernetSegmentsLegacy         []InterfacePortChannelEvpnEthernetSegmentsLegacy     `tfsdk:"evpn_ethernet_segments_legacy"`
-	IpIgmpVersion                      types.Int64                                          `tfsdk:"ip_igmp_version"`
-	IpRouterIsis                       types.String                                         `tfsdk:"ip_router_isis"`
-	IpNatInside                        types.Bool                                           `tfsdk:"ip_nat_inside"`
-	IpNatOutside                       types.Bool                                           `tfsdk:"ip_nat_outside"`
-	IpVerifyUnicastSourceReachableVia  types.String                                         `tfsdk:"ip_verify_unicast_source_reachable_via"`
-	IpVerifyUnicastSourceAllowSelfPing types.Bool                                           `tfsdk:"ip_verify_unicast_source_allow_self_ping"`
-	IpVerifyUnicastSourceAllowDefault  types.Bool                                           `tfsdk:"ip_verify_unicast_source_allow_default"`
-	IpFlowMonitors                     []InterfacePortChannelIpFlowMonitors                 `tfsdk:"ip_flow_monitors"`
-	ZoneMemberSecurity                 types.String                                         `tfsdk:"zone_member_security"`
+	Device                                             types.String                                         `tfsdk:"device"`
+	Id                                                 types.String                                         `tfsdk:"id"`
+	DeleteMode                                         types.String                                         `tfsdk:"delete_mode"`
+	Name                                               types.Int64                                          `tfsdk:"name"`
+	Description                                        types.String                                         `tfsdk:"description"`
+	Shutdown                                           types.Bool                                           `tfsdk:"shutdown"`
+	Mtu                                                types.Int64                                          `tfsdk:"mtu"`
+	Switchport                                         types.Bool                                           `tfsdk:"switchport"`
+	IpProxyArp                                         types.Bool                                           `tfsdk:"ip_proxy_arp"`
+	IpRedirects                                        types.Bool                                           `tfsdk:"ip_redirects"`
+	IpUnreachables                                     types.Bool                                           `tfsdk:"ip_unreachables"`
+	VrfForwarding                                      types.String                                         `tfsdk:"vrf_forwarding"`
+	Ipv4Address                                        types.String                                         `tfsdk:"ipv4_address"`
+	Ipv4AddressMask                                    types.String                                         `tfsdk:"ipv4_address_mask"`
+	Ipv4AddressDhcp                                    types.Bool                                           `tfsdk:"ipv4_address_dhcp"`
+	IpAccessGroupInEnable                              types.Bool                                           `tfsdk:"ip_access_group_in_enable"`
+	IpAccessGroupIn                                    types.String                                         `tfsdk:"ip_access_group_in"`
+	IpAccessGroupOutEnable                             types.Bool                                           `tfsdk:"ip_access_group_out_enable"`
+	IpAccessGroupOut                                   types.String                                         `tfsdk:"ip_access_group_out"`
+	IpDhcpRelaySourceInterface                         types.String                                         `tfsdk:"ip_dhcp_relay_source_interface"`
+	SpanningTreeGuard                                  types.String                                         `tfsdk:"spanning_tree_guard"`
+	AutoQosClassify                                    types.Bool                                           `tfsdk:"auto_qos_classify"`
+	AutoQosClassifyPolice                              types.Bool                                           `tfsdk:"auto_qos_classify_police"`
+	AutoQosTrust                                       types.Bool                                           `tfsdk:"auto_qos_trust"`
+	AutoQosTrustCos                                    types.Bool                                           `tfsdk:"auto_qos_trust_cos"`
+	AutoQosTrustDscp                                   types.Bool                                           `tfsdk:"auto_qos_trust_dscp"`
+	AutoQosVideoCts                                    types.Bool                                           `tfsdk:"auto_qos_video_cts"`
+	AutoQosVideoIpCamera                               types.Bool                                           `tfsdk:"auto_qos_video_ip_camera"`
+	AutoQosVideoMediaPlayer                            types.Bool                                           `tfsdk:"auto_qos_video_media_player"`
+	AutoQosVoipCiscoPhone                              types.Bool                                           `tfsdk:"auto_qos_voip_cisco_phone"`
+	AutoQosVoipCiscoSoftphone                          types.Bool                                           `tfsdk:"auto_qos_voip_cisco_softphone"`
+	AutoQosVoipTrust                                   types.Bool                                           `tfsdk:"auto_qos_voip_trust"`
+	TrustDevice                                        types.String                                         `tfsdk:"trust_device"`
+	HelperAddresses                                    []InterfacePortChannelHelperAddresses                `tfsdk:"helper_addresses"`
+	BfdTemplate                                        types.String                                         `tfsdk:"bfd_template"`
+	BfdEnable                                          types.Bool                                           `tfsdk:"bfd_enable"`
+	BfdLocalAddress                                    types.String                                         `tfsdk:"bfd_local_address"`
+	BfdInterval                                        types.Int64                                          `tfsdk:"bfd_interval"`
+	BfdIntervalMinRx                                   types.Int64                                          `tfsdk:"bfd_interval_min_rx"`
+	BfdIntervalMultiplier                              types.Int64                                          `tfsdk:"bfd_interval_multiplier"`
+	BfdEcho                                            types.Bool                                           `tfsdk:"bfd_echo"`
+	Ipv6Enable                                         types.Bool                                           `tfsdk:"ipv6_enable"`
+	Ipv6Mtu                                            types.Int64                                          `tfsdk:"ipv6_mtu"`
+	Ipv6NdRaSuppressAll                                types.Bool                                           `tfsdk:"ipv6_nd_ra_suppress_all"`
+	Ipv6AddressAutoconfigDefault                       types.Bool                                           `tfsdk:"ipv6_address_autoconfig_default"`
+	Ipv6AddressDhcp                                    types.Bool                                           `tfsdk:"ipv6_address_dhcp"`
+	Ipv6DhcpServers                                    []InterfacePortChannelIpv6DhcpServers                `tfsdk:"ipv6_dhcp_servers"`
+	Ipv6DhcpClientPd                                   types.String                                         `tfsdk:"ipv6_dhcp_client_pd"`
+	Ipv6DhcpClientPdRapidCommit                        types.Bool                                           `tfsdk:"ipv6_dhcp_client_pd_rapid_commit"`
+	Ipv6DhcpRelayDestinations                          []InterfacePortChannelIpv6DhcpRelayDestinations      `tfsdk:"ipv6_dhcp_relay_destinations"`
+	Ipv6DhcpRelayTrust                                 types.Bool                                           `tfsdk:"ipv6_dhcp_relay_trust"`
+	Ipv6DhcpRelayOptionVpn                             types.Bool                                           `tfsdk:"ipv6_dhcp_relay_option_vpn"`
+	Ipv6LinkLocalAddresses                             []InterfacePortChannelIpv6LinkLocalAddresses         `tfsdk:"ipv6_link_local_addresses"`
+	Ipv6Addresses                                      []InterfacePortChannelIpv6Addresses                  `tfsdk:"ipv6_addresses"`
+	Ipv6FlowMonitors                                   []InterfacePortChannelIpv6FlowMonitors               `tfsdk:"ipv6_flow_monitors"`
+	ArpTimeout                                         types.Int64                                          `tfsdk:"arp_timeout"`
+	IpArpInspectionTrust                               types.Bool                                           `tfsdk:"ip_arp_inspection_trust"`
+	IpArpInspectionLimitRate                           types.Int64                                          `tfsdk:"ip_arp_inspection_limit_rate"`
+	SpanningTreeLinkType                               types.String                                         `tfsdk:"spanning_tree_link_type"`
+	BpduguardEnable                                    types.Bool                                           `tfsdk:"bpduguard_enable"`
+	BpduguardDisable                                   types.Bool                                           `tfsdk:"bpduguard_disable"`
+	SpanningTreePortfast                               types.Bool                                           `tfsdk:"spanning_tree_portfast"`
+	SpanningTreePortfastDisable                        types.Bool                                           `tfsdk:"spanning_tree_portfast_disable"`
+	SpanningTreePortfastTrunk                          types.Bool                                           `tfsdk:"spanning_tree_portfast_trunk"`
+	SpanningTreePortfastEdge                           types.Bool                                           `tfsdk:"spanning_tree_portfast_edge"`
+	IpDhcpSnoopingTrust                                types.Bool                                           `tfsdk:"ip_dhcp_snooping_trust"`
+	LoadInterval                                       types.Int64                                          `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus                                 types.Bool                                           `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable                       types.Bool                                           `tfsdk:"logging_event_link_status_enable"`
+	DeviceTracking                                     types.Bool                                           `tfsdk:"device_tracking"`
+	DeviceTrackingAttachedPolicies                     []InterfacePortChannelDeviceTrackingAttachedPolicies `tfsdk:"device_tracking_attached_policies"`
+	NegotiationAuto                                    types.Bool                                           `tfsdk:"negotiation_auto"`
+	EvpnEthernetSegments                               []InterfacePortChannelEvpnEthernetSegments           `tfsdk:"evpn_ethernet_segments"`
+	EvpnEthernetSegmentsLegacy                         []InterfacePortChannelEvpnEthernetSegmentsLegacy     `tfsdk:"evpn_ethernet_segments_legacy"`
+	IpIgmpVersion                                      types.Int64                                          `tfsdk:"ip_igmp_version"`
+	IpRouterIsis                                       types.String                                         `tfsdk:"ip_router_isis"`
+	IpNatInside                                        types.Bool                                           `tfsdk:"ip_nat_inside"`
+	IpNatOutside                                       types.Bool                                           `tfsdk:"ip_nat_outside"`
+	IpVerifyUnicastSourceReachableVia                  types.String                                         `tfsdk:"ip_verify_unicast_source_reachable_via"`
+	IpVerifyUnicastSourceAllowSelfPing                 types.Bool                                           `tfsdk:"ip_verify_unicast_source_allow_self_ping"`
+	IpVerifyUnicastSourceAllowDefault                  types.Bool                                           `tfsdk:"ip_verify_unicast_source_allow_default"`
+	IpFlowMonitors                                     []InterfacePortChannelIpFlowMonitors                 `tfsdk:"ip_flow_monitors"`
+	ZoneMemberSecurity                                 types.String                                         `tfsdk:"zone_member_security"`
+	AccessSessionMonitor                               types.Bool                                           `tfsdk:"access_session_monitor"`
+	StormControlBroadcastLevelRisingThreshold          types.Float64                                        `tfsdk:"storm_control_broadcast_level_rising_threshold"`
+	StormControlBroadcastLevelFallingThreshold         types.Float64                                        `tfsdk:"storm_control_broadcast_level_falling_threshold"`
+	StormControlBroadcastLevelBpsRisingThreshold       types.String                                         `tfsdk:"storm_control_broadcast_level_bps_rising_threshold"`
+	StormControlBroadcastLevelBpsFallingThreshold      types.String                                         `tfsdk:"storm_control_broadcast_level_bps_falling_threshold"`
+	StormControlBroadcastLevelPpsRisingThreshold       types.String                                         `tfsdk:"storm_control_broadcast_level_pps_rising_threshold"`
+	StormControlBroadcastLevelPpsFallingThreshold      types.String                                         `tfsdk:"storm_control_broadcast_level_pps_falling_threshold"`
+	StormControlMulticastLevelRisingThreshold          types.Float64                                        `tfsdk:"storm_control_multicast_level_rising_threshold"`
+	StormControlMulticastLevelFallingThreshold         types.Float64                                        `tfsdk:"storm_control_multicast_level_falling_threshold"`
+	StormControlMulticastLevelBpsRisingThreshold       types.String                                         `tfsdk:"storm_control_multicast_level_bps_rising_threshold"`
+	StormControlMulticastLevelBpsFallingThreshold      types.String                                         `tfsdk:"storm_control_multicast_level_bps_falling_threshold"`
+	StormControlMulticastLevelPpsRisingThreshold       types.String                                         `tfsdk:"storm_control_multicast_level_pps_rising_threshold"`
+	StormControlMulticastLevelPpsFallingThreshold      types.String                                         `tfsdk:"storm_control_multicast_level_pps_falling_threshold"`
+	StormControlUnicastLevelRisingThreshold            types.Float64                                        `tfsdk:"storm_control_unicast_level_rising_threshold"`
+	StormControlUnicastLevelFallingThreshold           types.Float64                                        `tfsdk:"storm_control_unicast_level_falling_threshold"`
+	StormControlUnicastLevelBpsRisingThreshold         types.String                                         `tfsdk:"storm_control_unicast_level_bps_rising_threshold"`
+	StormControlUnicastLevelBpsFallingThreshold        types.String                                         `tfsdk:"storm_control_unicast_level_bps_falling_threshold"`
+	StormControlUnicastLevelPpsRisingThreshold         types.String                                         `tfsdk:"storm_control_unicast_level_pps_rising_threshold"`
+	StormControlUnicastLevelPpsFallingThreshold        types.String                                         `tfsdk:"storm_control_unicast_level_pps_falling_threshold"`
+	StormControlUnknownUnicastLevelRisingThreshold     types.Float64                                        `tfsdk:"storm_control_unknown_unicast_level_rising_threshold"`
+	StormControlUnknownUnicastLevelFallingThreshold    types.Float64                                        `tfsdk:"storm_control_unknown_unicast_level_falling_threshold"`
+	StormControlUnknownUnicastLevelBpsRisingThreshold  types.String                                         `tfsdk:"storm_control_unknown_unicast_level_bps_rising_threshold"`
+	StormControlUnknownUnicastLevelBpsFallingThreshold types.String                                         `tfsdk:"storm_control_unknown_unicast_level_bps_falling_threshold"`
+	StormControlUnknownUnicastLevelPpsRisingThreshold  types.String                                         `tfsdk:"storm_control_unknown_unicast_level_pps_rising_threshold"`
+	StormControlUnknownUnicastLevelPpsFallingThreshold types.String                                         `tfsdk:"storm_control_unknown_unicast_level_pps_falling_threshold"`
+	StormControlActionShutdown                         types.Bool                                           `tfsdk:"storm_control_action_shutdown"`
+	StormControlActionTrap                             types.Bool                                           `tfsdk:"storm_control_action_trap"`
 }
 type InterfacePortChannelHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -164,88 +191,115 @@ type InterfacePortChannelIpFlowMonitors struct {
 }
 
 type InterfacePortChannelData struct {
-	Device                             types.String                                             `tfsdk:"device"`
-	Id                                 types.String                                             `tfsdk:"id"`
-	Name                               types.Int64                                              `tfsdk:"name"`
-	Description                        types.String                                             `tfsdk:"description"`
-	Shutdown                           types.Bool                                               `tfsdk:"shutdown"`
-	Mtu                                types.Int64                                              `tfsdk:"mtu"`
-	Switchport                         types.Bool                                               `tfsdk:"switchport"`
-	IpProxyArp                         types.Bool                                               `tfsdk:"ip_proxy_arp"`
-	IpRedirects                        types.Bool                                               `tfsdk:"ip_redirects"`
-	IpUnreachables                     types.Bool                                               `tfsdk:"ip_unreachables"`
-	VrfForwarding                      types.String                                             `tfsdk:"vrf_forwarding"`
-	Ipv4Address                        types.String                                             `tfsdk:"ipv4_address"`
-	Ipv4AddressMask                    types.String                                             `tfsdk:"ipv4_address_mask"`
-	Ipv4AddressDhcp                    types.Bool                                               `tfsdk:"ipv4_address_dhcp"`
-	IpAccessGroupInEnable              types.Bool                                               `tfsdk:"ip_access_group_in_enable"`
-	IpAccessGroupIn                    types.String                                             `tfsdk:"ip_access_group_in"`
-	IpAccessGroupOutEnable             types.Bool                                               `tfsdk:"ip_access_group_out_enable"`
-	IpAccessGroupOut                   types.String                                             `tfsdk:"ip_access_group_out"`
-	IpDhcpRelaySourceInterface         types.String                                             `tfsdk:"ip_dhcp_relay_source_interface"`
-	SpanningTreeGuard                  types.String                                             `tfsdk:"spanning_tree_guard"`
-	AutoQosClassify                    types.Bool                                               `tfsdk:"auto_qos_classify"`
-	AutoQosClassifyPolice              types.Bool                                               `tfsdk:"auto_qos_classify_police"`
-	AutoQosTrust                       types.Bool                                               `tfsdk:"auto_qos_trust"`
-	AutoQosTrustCos                    types.Bool                                               `tfsdk:"auto_qos_trust_cos"`
-	AutoQosTrustDscp                   types.Bool                                               `tfsdk:"auto_qos_trust_dscp"`
-	AutoQosVideoCts                    types.Bool                                               `tfsdk:"auto_qos_video_cts"`
-	AutoQosVideoIpCamera               types.Bool                                               `tfsdk:"auto_qos_video_ip_camera"`
-	AutoQosVideoMediaPlayer            types.Bool                                               `tfsdk:"auto_qos_video_media_player"`
-	AutoQosVoipCiscoPhone              types.Bool                                               `tfsdk:"auto_qos_voip_cisco_phone"`
-	AutoQosVoipCiscoSoftphone          types.Bool                                               `tfsdk:"auto_qos_voip_cisco_softphone"`
-	AutoQosVoipTrust                   types.Bool                                               `tfsdk:"auto_qos_voip_trust"`
-	TrustDevice                        types.String                                             `tfsdk:"trust_device"`
-	HelperAddresses                    []InterfacePortChannelHelperAddressesData                `tfsdk:"helper_addresses"`
-	BfdTemplate                        types.String                                             `tfsdk:"bfd_template"`
-	BfdEnable                          types.Bool                                               `tfsdk:"bfd_enable"`
-	BfdLocalAddress                    types.String                                             `tfsdk:"bfd_local_address"`
-	BfdInterval                        types.Int64                                              `tfsdk:"bfd_interval"`
-	BfdIntervalMinRx                   types.Int64                                              `tfsdk:"bfd_interval_min_rx"`
-	BfdIntervalMultiplier              types.Int64                                              `tfsdk:"bfd_interval_multiplier"`
-	BfdEcho                            types.Bool                                               `tfsdk:"bfd_echo"`
-	Ipv6Enable                         types.Bool                                               `tfsdk:"ipv6_enable"`
-	Ipv6Mtu                            types.Int64                                              `tfsdk:"ipv6_mtu"`
-	Ipv6NdRaSuppressAll                types.Bool                                               `tfsdk:"ipv6_nd_ra_suppress_all"`
-	Ipv6AddressAutoconfigDefault       types.Bool                                               `tfsdk:"ipv6_address_autoconfig_default"`
-	Ipv6AddressDhcp                    types.Bool                                               `tfsdk:"ipv6_address_dhcp"`
-	Ipv6DhcpServers                    []InterfacePortChannelIpv6DhcpServersData                `tfsdk:"ipv6_dhcp_servers"`
-	Ipv6DhcpClientPd                   types.String                                             `tfsdk:"ipv6_dhcp_client_pd"`
-	Ipv6DhcpClientPdRapidCommit        types.Bool                                               `tfsdk:"ipv6_dhcp_client_pd_rapid_commit"`
-	Ipv6DhcpRelayDestinations          []InterfacePortChannelIpv6DhcpRelayDestinationsData      `tfsdk:"ipv6_dhcp_relay_destinations"`
-	Ipv6DhcpRelayTrust                 types.Bool                                               `tfsdk:"ipv6_dhcp_relay_trust"`
-	Ipv6DhcpRelayOptionVpn             types.Bool                                               `tfsdk:"ipv6_dhcp_relay_option_vpn"`
-	Ipv6LinkLocalAddresses             []InterfacePortChannelIpv6LinkLocalAddressesData         `tfsdk:"ipv6_link_local_addresses"`
-	Ipv6Addresses                      []InterfacePortChannelIpv6AddressesData                  `tfsdk:"ipv6_addresses"`
-	Ipv6FlowMonitors                   []InterfacePortChannelIpv6FlowMonitorsData               `tfsdk:"ipv6_flow_monitors"`
-	ArpTimeout                         types.Int64                                              `tfsdk:"arp_timeout"`
-	IpArpInspectionTrust               types.Bool                                               `tfsdk:"ip_arp_inspection_trust"`
-	IpArpInspectionLimitRate           types.Int64                                              `tfsdk:"ip_arp_inspection_limit_rate"`
-	SpanningTreeLinkType               types.String                                             `tfsdk:"spanning_tree_link_type"`
-	BpduguardEnable                    types.Bool                                               `tfsdk:"bpduguard_enable"`
-	BpduguardDisable                   types.Bool                                               `tfsdk:"bpduguard_disable"`
-	SpanningTreePortfast               types.Bool                                               `tfsdk:"spanning_tree_portfast"`
-	SpanningTreePortfastDisable        types.Bool                                               `tfsdk:"spanning_tree_portfast_disable"`
-	SpanningTreePortfastTrunk          types.Bool                                               `tfsdk:"spanning_tree_portfast_trunk"`
-	SpanningTreePortfastEdge           types.Bool                                               `tfsdk:"spanning_tree_portfast_edge"`
-	IpDhcpSnoopingTrust                types.Bool                                               `tfsdk:"ip_dhcp_snooping_trust"`
-	LoadInterval                       types.Int64                                              `tfsdk:"load_interval"`
-	SnmpTrapLinkStatus                 types.Bool                                               `tfsdk:"snmp_trap_link_status"`
-	LoggingEventLinkStatusEnable       types.Bool                                               `tfsdk:"logging_event_link_status_enable"`
-	DeviceTracking                     types.Bool                                               `tfsdk:"device_tracking"`
-	DeviceTrackingAttachedPolicies     []InterfacePortChannelDeviceTrackingAttachedPoliciesData `tfsdk:"device_tracking_attached_policies"`
-	NegotiationAuto                    types.Bool                                               `tfsdk:"negotiation_auto"`
-	EvpnEthernetSegments               []InterfacePortChannelEvpnEthernetSegmentsData           `tfsdk:"evpn_ethernet_segments"`
-	EvpnEthernetSegmentsLegacy         []InterfacePortChannelEvpnEthernetSegmentsLegacyData     `tfsdk:"evpn_ethernet_segments_legacy"`
-	IpIgmpVersion                      types.Int64                                              `tfsdk:"ip_igmp_version"`
-	IpRouterIsis                       types.String                                             `tfsdk:"ip_router_isis"`
-	IpNatInside                        types.Bool                                               `tfsdk:"ip_nat_inside"`
-	IpNatOutside                       types.Bool                                               `tfsdk:"ip_nat_outside"`
-	IpVerifyUnicastSourceReachableVia  types.String                                             `tfsdk:"ip_verify_unicast_source_reachable_via"`
-	IpVerifyUnicastSourceAllowSelfPing types.Bool                                               `tfsdk:"ip_verify_unicast_source_allow_self_ping"`
-	IpVerifyUnicastSourceAllowDefault  types.Bool                                               `tfsdk:"ip_verify_unicast_source_allow_default"`
-	IpFlowMonitors                     []InterfacePortChannelIpFlowMonitorsData                 `tfsdk:"ip_flow_monitors"`
-	ZoneMemberSecurity                 types.String                                             `tfsdk:"zone_member_security"`
+	Device                                             types.String                                             `tfsdk:"device"`
+	Id                                                 types.String                                             `tfsdk:"id"`
+	Name                                               types.Int64                                              `tfsdk:"name"`
+	Description                                        types.String                                             `tfsdk:"description"`
+	Shutdown                                           types.Bool                                               `tfsdk:"shutdown"`
+	Mtu                                                types.Int64                                              `tfsdk:"mtu"`
+	Switchport                                         types.Bool                                               `tfsdk:"switchport"`
+	IpProxyArp                                         types.Bool                                               `tfsdk:"ip_proxy_arp"`
+	IpRedirects                                        types.Bool                                               `tfsdk:"ip_redirects"`
+	IpUnreachables                                     types.Bool                                               `tfsdk:"ip_unreachables"`
+	VrfForwarding                                      types.String                                             `tfsdk:"vrf_forwarding"`
+	Ipv4Address                                        types.String                                             `tfsdk:"ipv4_address"`
+	Ipv4AddressMask                                    types.String                                             `tfsdk:"ipv4_address_mask"`
+	Ipv4AddressDhcp                                    types.Bool                                               `tfsdk:"ipv4_address_dhcp"`
+	IpAccessGroupInEnable                              types.Bool                                               `tfsdk:"ip_access_group_in_enable"`
+	IpAccessGroupIn                                    types.String                                             `tfsdk:"ip_access_group_in"`
+	IpAccessGroupOutEnable                             types.Bool                                               `tfsdk:"ip_access_group_out_enable"`
+	IpAccessGroupOut                                   types.String                                             `tfsdk:"ip_access_group_out"`
+	IpDhcpRelaySourceInterface                         types.String                                             `tfsdk:"ip_dhcp_relay_source_interface"`
+	SpanningTreeGuard                                  types.String                                             `tfsdk:"spanning_tree_guard"`
+	AutoQosClassify                                    types.Bool                                               `tfsdk:"auto_qos_classify"`
+	AutoQosClassifyPolice                              types.Bool                                               `tfsdk:"auto_qos_classify_police"`
+	AutoQosTrust                                       types.Bool                                               `tfsdk:"auto_qos_trust"`
+	AutoQosTrustCos                                    types.Bool                                               `tfsdk:"auto_qos_trust_cos"`
+	AutoQosTrustDscp                                   types.Bool                                               `tfsdk:"auto_qos_trust_dscp"`
+	AutoQosVideoCts                                    types.Bool                                               `tfsdk:"auto_qos_video_cts"`
+	AutoQosVideoIpCamera                               types.Bool                                               `tfsdk:"auto_qos_video_ip_camera"`
+	AutoQosVideoMediaPlayer                            types.Bool                                               `tfsdk:"auto_qos_video_media_player"`
+	AutoQosVoipCiscoPhone                              types.Bool                                               `tfsdk:"auto_qos_voip_cisco_phone"`
+	AutoQosVoipCiscoSoftphone                          types.Bool                                               `tfsdk:"auto_qos_voip_cisco_softphone"`
+	AutoQosVoipTrust                                   types.Bool                                               `tfsdk:"auto_qos_voip_trust"`
+	TrustDevice                                        types.String                                             `tfsdk:"trust_device"`
+	HelperAddresses                                    []InterfacePortChannelHelperAddressesData                `tfsdk:"helper_addresses"`
+	BfdTemplate                                        types.String                                             `tfsdk:"bfd_template"`
+	BfdEnable                                          types.Bool                                               `tfsdk:"bfd_enable"`
+	BfdLocalAddress                                    types.String                                             `tfsdk:"bfd_local_address"`
+	BfdInterval                                        types.Int64                                              `tfsdk:"bfd_interval"`
+	BfdIntervalMinRx                                   types.Int64                                              `tfsdk:"bfd_interval_min_rx"`
+	BfdIntervalMultiplier                              types.Int64                                              `tfsdk:"bfd_interval_multiplier"`
+	BfdEcho                                            types.Bool                                               `tfsdk:"bfd_echo"`
+	Ipv6Enable                                         types.Bool                                               `tfsdk:"ipv6_enable"`
+	Ipv6Mtu                                            types.Int64                                              `tfsdk:"ipv6_mtu"`
+	Ipv6NdRaSuppressAll                                types.Bool                                               `tfsdk:"ipv6_nd_ra_suppress_all"`
+	Ipv6AddressAutoconfigDefault                       types.Bool                                               `tfsdk:"ipv6_address_autoconfig_default"`
+	Ipv6AddressDhcp                                    types.Bool                                               `tfsdk:"ipv6_address_dhcp"`
+	Ipv6DhcpServers                                    []InterfacePortChannelIpv6DhcpServersData                `tfsdk:"ipv6_dhcp_servers"`
+	Ipv6DhcpClientPd                                   types.String                                             `tfsdk:"ipv6_dhcp_client_pd"`
+	Ipv6DhcpClientPdRapidCommit                        types.Bool                                               `tfsdk:"ipv6_dhcp_client_pd_rapid_commit"`
+	Ipv6DhcpRelayDestinations                          []InterfacePortChannelIpv6DhcpRelayDestinationsData      `tfsdk:"ipv6_dhcp_relay_destinations"`
+	Ipv6DhcpRelayTrust                                 types.Bool                                               `tfsdk:"ipv6_dhcp_relay_trust"`
+	Ipv6DhcpRelayOptionVpn                             types.Bool                                               `tfsdk:"ipv6_dhcp_relay_option_vpn"`
+	Ipv6LinkLocalAddresses                             []InterfacePortChannelIpv6LinkLocalAddressesData         `tfsdk:"ipv6_link_local_addresses"`
+	Ipv6Addresses                                      []InterfacePortChannelIpv6AddressesData                  `tfsdk:"ipv6_addresses"`
+	Ipv6FlowMonitors                                   []InterfacePortChannelIpv6FlowMonitorsData               `tfsdk:"ipv6_flow_monitors"`
+	ArpTimeout                                         types.Int64                                              `tfsdk:"arp_timeout"`
+	IpArpInspectionTrust                               types.Bool                                               `tfsdk:"ip_arp_inspection_trust"`
+	IpArpInspectionLimitRate                           types.Int64                                              `tfsdk:"ip_arp_inspection_limit_rate"`
+	SpanningTreeLinkType                               types.String                                             `tfsdk:"spanning_tree_link_type"`
+	BpduguardEnable                                    types.Bool                                               `tfsdk:"bpduguard_enable"`
+	BpduguardDisable                                   types.Bool                                               `tfsdk:"bpduguard_disable"`
+	SpanningTreePortfast                               types.Bool                                               `tfsdk:"spanning_tree_portfast"`
+	SpanningTreePortfastDisable                        types.Bool                                               `tfsdk:"spanning_tree_portfast_disable"`
+	SpanningTreePortfastTrunk                          types.Bool                                               `tfsdk:"spanning_tree_portfast_trunk"`
+	SpanningTreePortfastEdge                           types.Bool                                               `tfsdk:"spanning_tree_portfast_edge"`
+	IpDhcpSnoopingTrust                                types.Bool                                               `tfsdk:"ip_dhcp_snooping_trust"`
+	LoadInterval                                       types.Int64                                              `tfsdk:"load_interval"`
+	SnmpTrapLinkStatus                                 types.Bool                                               `tfsdk:"snmp_trap_link_status"`
+	LoggingEventLinkStatusEnable                       types.Bool                                               `tfsdk:"logging_event_link_status_enable"`
+	DeviceTracking                                     types.Bool                                               `tfsdk:"device_tracking"`
+	DeviceTrackingAttachedPolicies                     []InterfacePortChannelDeviceTrackingAttachedPoliciesData `tfsdk:"device_tracking_attached_policies"`
+	NegotiationAuto                                    types.Bool                                               `tfsdk:"negotiation_auto"`
+	EvpnEthernetSegments                               []InterfacePortChannelEvpnEthernetSegmentsData           `tfsdk:"evpn_ethernet_segments"`
+	EvpnEthernetSegmentsLegacy                         []InterfacePortChannelEvpnEthernetSegmentsLegacyData     `tfsdk:"evpn_ethernet_segments_legacy"`
+	IpIgmpVersion                                      types.Int64                                              `tfsdk:"ip_igmp_version"`
+	IpRouterIsis                                       types.String                                             `tfsdk:"ip_router_isis"`
+	IpNatInside                                        types.Bool                                               `tfsdk:"ip_nat_inside"`
+	IpNatOutside                                       types.Bool                                               `tfsdk:"ip_nat_outside"`
+	IpVerifyUnicastSourceReachableVia                  types.String                                             `tfsdk:"ip_verify_unicast_source_reachable_via"`
+	IpVerifyUnicastSourceAllowSelfPing                 types.Bool                                               `tfsdk:"ip_verify_unicast_source_allow_self_ping"`
+	IpVerifyUnicastSourceAllowDefault                  types.Bool                                               `tfsdk:"ip_verify_unicast_source_allow_default"`
+	IpFlowMonitors                                     []InterfacePortChannelIpFlowMonitorsData                 `tfsdk:"ip_flow_monitors"`
+	ZoneMemberSecurity                                 types.String                                             `tfsdk:"zone_member_security"`
+	AccessSessionMonitor                               types.Bool                                               `tfsdk:"access_session_monitor"`
+	StormControlBroadcastLevelRisingThreshold          types.Float64                                            `tfsdk:"storm_control_broadcast_level_rising_threshold"`
+	StormControlBroadcastLevelFallingThreshold         types.Float64                                            `tfsdk:"storm_control_broadcast_level_falling_threshold"`
+	StormControlBroadcastLevelBpsRisingThreshold       types.String                                             `tfsdk:"storm_control_broadcast_level_bps_rising_threshold"`
+	StormControlBroadcastLevelBpsFallingThreshold      types.String                                             `tfsdk:"storm_control_broadcast_level_bps_falling_threshold"`
+	StormControlBroadcastLevelPpsRisingThreshold       types.String                                             `tfsdk:"storm_control_broadcast_level_pps_rising_threshold"`
+	StormControlBroadcastLevelPpsFallingThreshold      types.String                                             `tfsdk:"storm_control_broadcast_level_pps_falling_threshold"`
+	StormControlMulticastLevelRisingThreshold          types.Float64                                            `tfsdk:"storm_control_multicast_level_rising_threshold"`
+	StormControlMulticastLevelFallingThreshold         types.Float64                                            `tfsdk:"storm_control_multicast_level_falling_threshold"`
+	StormControlMulticastLevelBpsRisingThreshold       types.String                                             `tfsdk:"storm_control_multicast_level_bps_rising_threshold"`
+	StormControlMulticastLevelBpsFallingThreshold      types.String                                             `tfsdk:"storm_control_multicast_level_bps_falling_threshold"`
+	StormControlMulticastLevelPpsRisingThreshold       types.String                                             `tfsdk:"storm_control_multicast_level_pps_rising_threshold"`
+	StormControlMulticastLevelPpsFallingThreshold      types.String                                             `tfsdk:"storm_control_multicast_level_pps_falling_threshold"`
+	StormControlUnicastLevelRisingThreshold            types.Float64                                            `tfsdk:"storm_control_unicast_level_rising_threshold"`
+	StormControlUnicastLevelFallingThreshold           types.Float64                                            `tfsdk:"storm_control_unicast_level_falling_threshold"`
+	StormControlUnicastLevelBpsRisingThreshold         types.String                                             `tfsdk:"storm_control_unicast_level_bps_rising_threshold"`
+	StormControlUnicastLevelBpsFallingThreshold        types.String                                             `tfsdk:"storm_control_unicast_level_bps_falling_threshold"`
+	StormControlUnicastLevelPpsRisingThreshold         types.String                                             `tfsdk:"storm_control_unicast_level_pps_rising_threshold"`
+	StormControlUnicastLevelPpsFallingThreshold        types.String                                             `tfsdk:"storm_control_unicast_level_pps_falling_threshold"`
+	StormControlUnknownUnicastLevelRisingThreshold     types.Float64                                            `tfsdk:"storm_control_unknown_unicast_level_rising_threshold"`
+	StormControlUnknownUnicastLevelFallingThreshold    types.Float64                                            `tfsdk:"storm_control_unknown_unicast_level_falling_threshold"`
+	StormControlUnknownUnicastLevelBpsRisingThreshold  types.String                                             `tfsdk:"storm_control_unknown_unicast_level_bps_rising_threshold"`
+	StormControlUnknownUnicastLevelBpsFallingThreshold types.String                                             `tfsdk:"storm_control_unknown_unicast_level_bps_falling_threshold"`
+	StormControlUnknownUnicastLevelPpsRisingThreshold  types.String                                             `tfsdk:"storm_control_unknown_unicast_level_pps_rising_threshold"`
+	StormControlUnknownUnicastLevelPpsFallingThreshold types.String                                             `tfsdk:"storm_control_unknown_unicast_level_pps_falling_threshold"`
+	StormControlActionShutdown                         types.Bool                                               `tfsdk:"storm_control_action_shutdown"`
+	StormControlActionTrap                             types.Bool                                               `tfsdk:"storm_control_action_trap"`
 }
 type InterfacePortChannelHelperAddressesData struct {
 	Address types.String `tfsdk:"address"`
@@ -822,6 +876,95 @@ func (data InterfacePortChannel) addToBodyXML(ctx context.Context, config Interf
 	}
 	if !data.ZoneMemberSecurity.IsNull() && !data.ZoneMemberSecurity.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security", data.ZoneMemberSecurity.ValueString())
+	}
+	if !data.AccessSessionMonitor.IsNull() && !data.AccessSessionMonitor.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/access-session/monitor", data.AccessSessionMonitor.ValueBool())
+	}
+	if !data.StormControlBroadcastLevelRisingThreshold.IsNull() && !data.StormControlBroadcastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlBroadcastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlBroadcastLevelFallingThreshold.IsNull() && !data.StormControlBroadcastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlBroadcastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() && !data.StormControlBroadcastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold", data.StormControlBroadcastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() && !data.StormControlBroadcastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold", data.StormControlBroadcastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() && !data.StormControlBroadcastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold", data.StormControlBroadcastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() && !data.StormControlBroadcastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold", data.StormControlBroadcastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelRisingThreshold.IsNull() && !data.StormControlMulticastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlMulticastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlMulticastLevelFallingThreshold.IsNull() && !data.StormControlMulticastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlMulticastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() && !data.StormControlMulticastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold", data.StormControlMulticastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() && !data.StormControlMulticastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold", data.StormControlMulticastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() && !data.StormControlMulticastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold", data.StormControlMulticastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() && !data.StormControlMulticastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold", data.StormControlMulticastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelRisingThreshold.IsNull() && !data.StormControlUnicastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlUnicastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnicastLevelFallingThreshold.IsNull() && !data.StormControlUnicastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlUnicastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() && !data.StormControlUnicastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold", data.StormControlUnicastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() && !data.StormControlUnicastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold", data.StormControlUnicastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() && !data.StormControlUnicastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold", data.StormControlUnicastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() && !data.StormControlUnicastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold", data.StormControlUnicastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlUnknownUnicastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlUnknownUnicastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold", data.StormControlUnknownUnicastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold", data.StormControlUnknownUnicastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold", data.StormControlUnknownUnicastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold", data.StormControlUnknownUnicastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlActionShutdown.IsNull() && !data.StormControlActionShutdown.IsUnknown() {
+		if data.StormControlActionShutdown.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/action/shutdown", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/storm-control/action/shutdown")
+		}
+	}
+	if !data.StormControlActionTrap.IsNull() && !data.StormControlActionTrap.IsUnknown() {
+		if data.StormControlActionTrap.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/action/trap", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/storm-control/action/trap")
+		}
 	}
 	return body
 }
@@ -1699,6 +1842,151 @@ func (data *InterfacePortChannel) updateFromBodyXML(ctx context.Context, res xml
 	} else {
 		data.ZoneMemberSecurity = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); !data.AccessSessionMonitor.IsNull() {
+		if value.Exists() {
+			data.AccessSessionMonitor = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); !data.StormControlActionShutdown.IsNull() {
+		if value.Exists() {
+			data.StormControlActionShutdown = types.BoolValue(true)
+		} else {
+			data.StormControlActionShutdown = types.BoolValue(false)
+		}
+	} else {
+		data.StormControlActionShutdown = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); !data.StormControlActionTrap.IsNull() {
+		if value.Exists() {
+			data.StormControlActionTrap = types.BoolValue(true)
+		} else {
+			data.StormControlActionTrap = types.BoolValue(false)
+		}
+	} else {
+		data.StormControlActionTrap = types.BoolNull()
+	}
 }
 
 // End of section. //template:end updateFromBodyXML
@@ -2152,6 +2440,93 @@ func (data *InterfacePortChannel) fromBodyXML(ctx context.Context, res xmldot.Re
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security"); value.Exists() {
 		data.ZoneMemberSecurity = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); value.Exists() {
+		data.AccessSessionMonitor = types.BoolValue(value.Bool())
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); value.Exists() {
+		data.StormControlActionShutdown = types.BoolValue(true)
+	} else {
+		data.StormControlActionShutdown = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); value.Exists() {
+		data.StormControlActionTrap = types.BoolValue(true)
+	} else {
+		data.StormControlActionTrap = types.BoolValue(false)
 	}
 }
 
@@ -2607,6 +2982,93 @@ func (data *InterfacePortChannelData) fromBodyXML(ctx context.Context, res xmldo
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security"); value.Exists() {
 		data.ZoneMemberSecurity = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); value.Exists() {
+		data.AccessSessionMonitor = types.BoolValue(value.Bool())
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); value.Exists() {
+		data.StormControlActionShutdown = types.BoolValue(true)
+	} else {
+		data.StormControlActionShutdown = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); value.Exists() {
+		data.StormControlActionTrap = types.BoolValue(true)
+	} else {
+		data.StormControlActionTrap = types.BoolValue(false)
+	}
 }
 
 // End of section. //template:end fromBodyDataXML
@@ -2615,6 +3077,87 @@ func (data *InterfacePortChannelData) fromBodyXML(ctx context.Context, res xmldo
 
 func (data *InterfacePortChannel) addDeletedItemsXML(ctx context.Context, state InterfacePortChannel, body string) string {
 	b := netconf.NewBody(body)
+	if !state.StormControlActionTrap.IsNull() && data.StormControlActionTrap.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/action/trap")
+	}
+	if !state.StormControlActionShutdown.IsNull() && data.StormControlActionShutdown.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/action/shutdown")
+	}
+	if !state.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelPpsFallingThreshold.IsNull() && data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelPpsRisingThreshold.IsNull() && data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelBpsFallingThreshold.IsNull() && data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelBpsRisingThreshold.IsNull() && data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelFallingThreshold.IsNull() && data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelRisingThreshold.IsNull() && data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelPpsFallingThreshold.IsNull() && data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelPpsRisingThreshold.IsNull() && data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelBpsFallingThreshold.IsNull() && data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelBpsRisingThreshold.IsNull() && data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelFallingThreshold.IsNull() && data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelRisingThreshold.IsNull() && data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelPpsFallingThreshold.IsNull() && data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelPpsRisingThreshold.IsNull() && data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelBpsFallingThreshold.IsNull() && data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelBpsRisingThreshold.IsNull() && data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelFallingThreshold.IsNull() && data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelRisingThreshold.IsNull() && data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold")
+	}
+	if !state.AccessSessionMonitor.IsNull() && data.AccessSessionMonitor.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/access-session/monitor")
+	}
 	if !state.ZoneMemberSecurity.IsNull() && data.ZoneMemberSecurity.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security")
 	}
@@ -3188,6 +3731,87 @@ func (data *InterfacePortChannel) addDeletedItemsXML(ctx context.Context, state 
 
 func (data *InterfacePortChannel) addDeletePathsXML(ctx context.Context, body string) string {
 	b := netconf.NewBody(body)
+	if !data.StormControlActionTrap.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/action/trap")
+	}
+	if !data.StormControlActionShutdown.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/action/shutdown")
+	}
+	if !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold")
+	}
+	if !data.AccessSessionMonitor.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/access-session/monitor")
+	}
 	if !data.ZoneMemberSecurity.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security")
 	}

--- a/internal/provider/resource_iosxe_interface_port_channel.go
+++ b/internal/provider/resource_iosxe_interface_port_channel.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -621,6 +622,186 @@ func (r *InterfacePortChannelResource) Schema(ctx context.Context, req resource.
 			},
 			"zone_member_security": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Security zone").String,
+				Optional:            true,
+			},
+			"access_session_monitor": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Apply interface defined access-session monitor").String,
+				Optional:            true,
+			},
+			"storm_control_broadcast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_broadcast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_broadcast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_multicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_multicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unknown_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unknown_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_action_shutdown": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Shutdown this interface if a storm occurs").String,
+				Optional:            true,
+			},
+			"storm_control_action_trap": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Send SNMP trap if a storm occurs").String,
 				Optional:            true,
 			},
 		},

--- a/internal/provider/resource_iosxe_interface_port_channel_test.go
+++ b/internal/provider/resource_iosxe_interface_port_channel_test.go
@@ -82,6 +82,33 @@ func TestAccIosxeInterfacePortChannel(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_verify_unicast_source_allow_default", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_flow_monitors.0.name", "MON1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "ip_flow_monitors.0.direction", "input"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "access_session_monitor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_broadcast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_multicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_unknown_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_action_shutdown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_port_channel.test", "storm_control_action_trap", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -279,6 +306,33 @@ func testAccIosxeInterfacePortChannelConfig_all() string {
 	config += `		name = "MON1"` + "\n"
 	config += `		direction = "input"` + "\n"
 	config += `	}]` + "\n"
+	config += `	access_session_monitor = true` + "\n"
+	config += `	storm_control_broadcast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_broadcast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_broadcast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_multicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_multicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_action_shutdown = true` + "\n"
+	config += `	storm_control_action_trap = true` + "\n"
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, iosxe_yang.PreReq3, iosxe_yang.PreReq4, iosxe_yang.PreReq5, iosxe_yang.PreReq6, iosxe_yang.PreReq7, iosxe_yang.PreReq8, ]` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
## ✔️ Type of Change

- [x] 🚀 New feature (new resource/data source, new attributes to existing resource)
- [ ] 🐛 Bug fix (corrects an issue in resource behavior, RESTCONF/NETCONF handling)
- [ ] ⚠️ Breaking change (modifies existing resource schema or removes attributes)
- [ ] 📄 Documentation update (resource docs, examples, registry docs)
- [ ] 🛠️ Refactoring / tech debt (internal improvements, no user-facing changes)
- [ ] ⚙️ Other (please describe):

## 🔗 Related Issue(s)

Fixes #615

Depends on #634 (`min_float`/`max_float` schema keys — required for the range validators on this PR's threshold attributes)

## 📝 Proposed Changes

Adds `access_session_monitor` and 26 storm-control attributes to `iosxe_interface_port_channel`, covering all 4 traffic classes (`broadcast`, `multicast`, `unicast`, `unknown-unicast`) × 3 representations (`threshold` percentage, `bps`, `pps`) × rising/falling, plus the 2 storm-control actions (`shutdown`, `trap`). 27 new attributes total.

YANG paths, e.g.:
- `storm-control/broadcast/level/threshold/rising-threshold`
- `storm-control/broadcast/level/bps/rising-threshold`
- `storm-control/broadcast/level/pps/rising-threshold`
- (same shape repeated for `multicast`, `unicast`, `unknown-unicast`)
- `storm-control/action/shutdown`, `storm-control/action/trap`
- `access-session/monitor`

The `threshold` (percentage) attributes use the new `min_float: 0` / `max_float: 100` keys from #634 to get client-side range validation (`float64validator.Between(0, 100)`), matching the device's actual `0..100` range.

### Known Limitations

Several device-side constraints aren't enforced client-side yet — mutual exclusivity between `level`/`bps`/`pps` representations, `falling_threshold` presence/magnitude vs `rising_threshold`, and a datastore-staleness issue when switching representations across applies. All confirmed on hardware; none block this PR. Full write-up and workarounds: #635.

`iosxe_interface_ethernet` has the identical storm-control/access-session gap; deliberately out of scope here, planned as a fast follow using this same pattern.

---

## 🧪 Testing Evidence

- [ ] N/A — this PR does not touch definitions, generated code, or provider logic (e.g., docs-only, CI, chore)

### 1. Code Generation

```bash
make gen NAME="Interface Port Channel"
go build ./...
go vet ./...
```

- [x] `make gen` completes without errors
- [x] Generated code matches YANG model expectations

### 2. Acceptance Tests

Hardware-tested on lab switch (C9200L-24P-4G, IOS-XE 17.15.4). No automated `TestAcc` added; manual coverage:

- Decimal round-trip (`10.5`/`8.5`) — no drift.
- Range boundaries — `0.0`/`100.0` apply; `101.0` rejected client-side.
- `access_session_monitor` — `true`/`false` both confirmed on-device, no drift.
- All 27 attributes exercised, grouped by representation (`threshold`/`bps`/`pps`) to avoid the known mutual-exclusivity conflict — all applied cleanly.
- Representation switching and falling>rising — both reproduced; see Known Limitations / #635.

- [ ] Acceptance tests pass against a real device
- [x] Device type and IOS-XE version: **C9200L-24P-4G, IOS-XE 17.15.4**

---

## 🔗 Cross-Repo Links

- Module PR: n/a
- Schema PR: n/a (provider-repo prerequisite is #634, not a separate `netascode/nac-iosxe` schema PR)

## ✅ Checklist

### Pre-Submission

- [x] I have merged/rebased from `main` and resolved all merge conflicts
- [x] `make gen` runs cleanly for affected resources
- [ ] Acceptance tests pass against a real IOS-XE device
  *(manual hardware testing done, see Testing Evidence above; no automated TestAcc added)*
- [x] `go build ./...` compiles without errors

### Code Quality

- [x] Definition YAML follows existing patterns in `gen/definitions/`
- [x] YANG paths are correct and validated against YangSuite
  *(not YangSuite specifically — validated via generator output and hardware confirmation)*
- [x] Examples in `examples/resources/` are updated for new/changed attributes
- [x] Resource documentation in `docs/` is regenerated and accurate

### Labels & Assignment

- [ ] I have assigned at least one label that aligns with `release.yaml` categories: `feature`, `enhancement`, `bug`, `fix`, `breaking-change`, `documentation`, `refactor`, `tech-debt`, `chore`, or `dependencies`
- [ ] Label(s) match the linked GitHub issue label(s) where applicable
- [ ] PR is assigned to myself
- [ ] One or more reviewers are assigned