### PR TITLE
feat: add storm-control and access-session attributes to interface_ethernet

### DIFF
--- a/docs/data-sources/interface_ethernet.md
+++ b/docs/data-sources/interface_ethernet.md
@@ -33,6 +33,7 @@ data "iosxe_interface_ethernet" "example" {
 
 ### Read-Only
 
+- `access_session_monitor` (Boolean) Apply interface defined access-session monitor
 - `arp_timeout` (Number) Set ARP cache timeout
 - `authentication_event_fail_action_authorize_vlan` (Number) Configure Authentication Fail vlan
 - `authentication_event_fail_action_next_method` (Boolean) Move to next authentication method
@@ -175,6 +176,32 @@ data "iosxe_interface_ethernet" "example" {
 - `speed_40000` (Boolean) 40000 Mbps operation
 - `speed_5000` (Boolean) 5000 Mbps operation
 - `speed_nonegotiate` (Boolean)
+- `storm_control_action_shutdown` (Boolean) Shutdown this interface if a storm occurs
+- `storm_control_action_trap` (Boolean) Send SNMP trap if a storm occurs
+- `storm_control_broadcast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_broadcast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_multicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_multicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unknown_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unknown_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_rising_threshold` (Number) Enter rising threshold
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
 - `unnumbered` (String) Enable IP processing without an explicit address

--- a/docs/resources/interface_ethernet.md
+++ b/docs/resources/interface_ethernet.md
@@ -91,7 +91,34 @@ resource "iosxe_interface_ethernet" "example" {
       queue_length = 50
     }
   ]
-  ip_igmp_version = 3
+  ip_igmp_version                                           = 3
+  access_session_monitor                                    = true
+  storm_control_broadcast_level_rising_threshold            = 10.5
+  storm_control_broadcast_level_falling_threshold           = 8.5
+  storm_control_broadcast_level_bps_rising_threshold        = "10k"
+  storm_control_broadcast_level_bps_falling_threshold       = "8k"
+  storm_control_broadcast_level_pps_rising_threshold        = "10k"
+  storm_control_broadcast_level_pps_falling_threshold       = "8k"
+  storm_control_multicast_level_rising_threshold            = 10.5
+  storm_control_multicast_level_falling_threshold           = 8.5
+  storm_control_multicast_level_bps_rising_threshold        = "10k"
+  storm_control_multicast_level_bps_falling_threshold       = "8k"
+  storm_control_multicast_level_pps_rising_threshold        = "10k"
+  storm_control_multicast_level_pps_falling_threshold       = "8k"
+  storm_control_unicast_level_rising_threshold              = 10.5
+  storm_control_unicast_level_falling_threshold             = 8.5
+  storm_control_unicast_level_bps_rising_threshold          = "10k"
+  storm_control_unicast_level_bps_falling_threshold         = "8k"
+  storm_control_unicast_level_pps_rising_threshold          = "10k"
+  storm_control_unicast_level_pps_falling_threshold         = "8k"
+  storm_control_unknown_unicast_level_rising_threshold      = 10.5
+  storm_control_unknown_unicast_level_falling_threshold     = 8.5
+  storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+  storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+  storm_control_action_shutdown                             = true
+  storm_control_action_trap                                 = true
 }
 ```
 
@@ -106,6 +133,7 @@ resource "iosxe_interface_ethernet" "example" {
 
 ### Optional
 
+- `access_session_monitor` (Boolean) Apply interface defined access-session monitor
 - `arp_timeout` (Number) Set ARP cache timeout
   - Range: `0`-`2147483`
 - `authentication_event_fail_action_authorize_vlan` (Number) Configure Authentication Fail vlan
@@ -280,6 +308,32 @@ resource "iosxe_interface_ethernet" "example" {
 - `speed_40000` (Boolean) 40000 Mbps operation
 - `speed_5000` (Boolean) 5000 Mbps operation
 - `speed_nonegotiate` (Boolean)
+- `storm_control_action_shutdown` (Boolean) Shutdown this interface if a storm occurs
+- `storm_control_action_trap` (Boolean) Send SNMP trap if a storm occurs
+- `storm_control_broadcast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_broadcast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_multicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_multicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unknown_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unknown_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_rising_threshold` (Number) Enter rising threshold
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
   - Choices: `cisco-phone`, `cts`, `ip-camera`, `media-player`

--- a/docs/resources/interface_ethernets.md
+++ b/docs/resources/interface_ethernets.md
@@ -91,7 +91,34 @@ resource "iosxe_interface_ethernets" "example" {
           queue_length = 50
         }
       ]
-      ip_igmp_version = 3
+      ip_igmp_version                                           = 3
+      access_session_monitor                                    = true
+      storm_control_broadcast_level_rising_threshold            = 10.5
+      storm_control_broadcast_level_falling_threshold           = 8.5
+      storm_control_broadcast_level_bps_rising_threshold        = "10k"
+      storm_control_broadcast_level_bps_falling_threshold       = "8k"
+      storm_control_broadcast_level_pps_rising_threshold        = "10k"
+      storm_control_broadcast_level_pps_falling_threshold       = "8k"
+      storm_control_multicast_level_rising_threshold            = 10.5
+      storm_control_multicast_level_falling_threshold           = 8.5
+      storm_control_multicast_level_bps_rising_threshold        = "10k"
+      storm_control_multicast_level_bps_falling_threshold       = "8k"
+      storm_control_multicast_level_pps_rising_threshold        = "10k"
+      storm_control_multicast_level_pps_falling_threshold       = "8k"
+      storm_control_unicast_level_rising_threshold              = 10.5
+      storm_control_unicast_level_falling_threshold             = 8.5
+      storm_control_unicast_level_bps_rising_threshold          = "10k"
+      storm_control_unicast_level_bps_falling_threshold         = "8k"
+      storm_control_unicast_level_pps_rising_threshold          = "10k"
+      storm_control_unicast_level_pps_falling_threshold         = "8k"
+      storm_control_unknown_unicast_level_rising_threshold      = 10.5
+      storm_control_unknown_unicast_level_falling_threshold     = 8.5
+      storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+      storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+      storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+      storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+      storm_control_action_shutdown                             = true
+      storm_control_action_trap                                 = true
     }
   }
 }
@@ -116,6 +143,7 @@ resource "iosxe_interface_ethernets" "example" {
 
 Optional:
 
+- `access_session_monitor` (Boolean) Apply interface defined access-session monitor
 - `arp_timeout` (Number) Set ARP cache timeout
   - Range: `0`-`2147483`
 - `authentication_event_fail_action_authorize_vlan` (Number) Configure Authentication Fail vlan
@@ -289,6 +317,32 @@ Optional:
 - `speed_40000` (Boolean) 40000 Mbps operation
 - `speed_5000` (Boolean) 5000 Mbps operation
 - `speed_nonegotiate` (Boolean)
+- `storm_control_action_shutdown` (Boolean) Shutdown this interface if a storm occurs
+- `storm_control_action_trap` (Boolean) Send SNMP trap if a storm occurs
+- `storm_control_broadcast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_broadcast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_broadcast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_broadcast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_multicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_multicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_multicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_multicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unicast_level_rising_threshold` (Number) Enter rising threshold
+- `storm_control_unknown_unicast_level_bps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_bps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>
+- `storm_control_unknown_unicast_level_falling_threshold` (Number) Enter falling threshold
+- `storm_control_unknown_unicast_level_pps_falling_threshold` (String) Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_pps_rising_threshold` (String) Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]
+- `storm_control_unknown_unicast_level_rising_threshold` (Number) Enter rising threshold
 - `switchport` (Boolean)
 - `trust_device` (String) trusted device class
   - Choices: `cisco-phone`, `cts`, `ip-camera`, `media-player`

--- a/examples/resources/iosxe_interface_ethernet/resource.tf
+++ b/examples/resources/iosxe_interface_ethernet/resource.tf
@@ -76,5 +76,32 @@ resource "iosxe_interface_ethernet" "example" {
       queue_length = 50
     }
   ]
-  ip_igmp_version = 3
+  ip_igmp_version                                           = 3
+  access_session_monitor                                    = true
+  storm_control_broadcast_level_rising_threshold            = 10.5
+  storm_control_broadcast_level_falling_threshold           = 8.5
+  storm_control_broadcast_level_bps_rising_threshold        = "10k"
+  storm_control_broadcast_level_bps_falling_threshold       = "8k"
+  storm_control_broadcast_level_pps_rising_threshold        = "10k"
+  storm_control_broadcast_level_pps_falling_threshold       = "8k"
+  storm_control_multicast_level_rising_threshold            = 10.5
+  storm_control_multicast_level_falling_threshold           = 8.5
+  storm_control_multicast_level_bps_rising_threshold        = "10k"
+  storm_control_multicast_level_bps_falling_threshold       = "8k"
+  storm_control_multicast_level_pps_rising_threshold        = "10k"
+  storm_control_multicast_level_pps_falling_threshold       = "8k"
+  storm_control_unicast_level_rising_threshold              = 10.5
+  storm_control_unicast_level_falling_threshold             = 8.5
+  storm_control_unicast_level_bps_rising_threshold          = "10k"
+  storm_control_unicast_level_bps_falling_threshold         = "8k"
+  storm_control_unicast_level_pps_rising_threshold          = "10k"
+  storm_control_unicast_level_pps_falling_threshold         = "8k"
+  storm_control_unknown_unicast_level_rising_threshold      = 10.5
+  storm_control_unknown_unicast_level_falling_threshold     = 8.5
+  storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+  storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+  storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+  storm_control_action_shutdown                             = true
+  storm_control_action_trap                                 = true
 }

--- a/examples/resources/iosxe_interface_ethernets/resource.tf
+++ b/examples/resources/iosxe_interface_ethernets/resource.tf
@@ -76,7 +76,34 @@ resource "iosxe_interface_ethernets" "example" {
           queue_length = 50
         }
       ]
-      ip_igmp_version = 3
+      ip_igmp_version                                           = 3
+      access_session_monitor                                    = true
+      storm_control_broadcast_level_rising_threshold            = 10.5
+      storm_control_broadcast_level_falling_threshold           = 8.5
+      storm_control_broadcast_level_bps_rising_threshold        = "10k"
+      storm_control_broadcast_level_bps_falling_threshold       = "8k"
+      storm_control_broadcast_level_pps_rising_threshold        = "10k"
+      storm_control_broadcast_level_pps_falling_threshold       = "8k"
+      storm_control_multicast_level_rising_threshold            = 10.5
+      storm_control_multicast_level_falling_threshold           = 8.5
+      storm_control_multicast_level_bps_rising_threshold        = "10k"
+      storm_control_multicast_level_bps_falling_threshold       = "8k"
+      storm_control_multicast_level_pps_rising_threshold        = "10k"
+      storm_control_multicast_level_pps_falling_threshold       = "8k"
+      storm_control_unicast_level_rising_threshold              = 10.5
+      storm_control_unicast_level_falling_threshold             = 8.5
+      storm_control_unicast_level_bps_rising_threshold          = "10k"
+      storm_control_unicast_level_bps_falling_threshold         = "8k"
+      storm_control_unicast_level_pps_rising_threshold          = "10k"
+      storm_control_unicast_level_pps_falling_threshold         = "8k"
+      storm_control_unknown_unicast_level_rising_threshold      = 10.5
+      storm_control_unknown_unicast_level_falling_threshold     = 8.5
+      storm_control_unknown_unicast_level_bps_rising_threshold  = "10k"
+      storm_control_unknown_unicast_level_bps_falling_threshold = "8k"
+      storm_control_unknown_unicast_level_pps_rising_threshold  = "10k"
+      storm_control_unknown_unicast_level_pps_falling_threshold = "8k"
+      storm_control_action_shutdown                             = true
+      storm_control_action_trap                                 = true
     }
   }
 }

--- a/gen/definitions/interface_ethernet.yaml
+++ b/gen/definitions/interface_ethernet.yaml
@@ -656,6 +656,124 @@ attributes:
     example: INSIDE
     exclude_test: true
 
+  - yang_name: access-session/monitor
+    example: true
+  - yang_name: storm-control/broadcast/level/threshold/rising-threshold
+    xpath: storm-control/broadcast/level/threshold/rising-threshold
+    tf_name: storm_control_broadcast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/broadcast/level/threshold/falling-threshold
+    xpath: storm-control/broadcast/level/threshold/falling-threshold
+    tf_name: storm_control_broadcast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/broadcast/level/bps/rising-threshold
+    xpath: storm-control/broadcast/level/bps/rising-threshold
+    tf_name: storm_control_broadcast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/broadcast/level/bps/falling-threshold
+    xpath: storm-control/broadcast/level/bps/falling-threshold
+    tf_name: storm_control_broadcast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/broadcast/level/pps/rising-threshold
+    xpath: storm-control/broadcast/level/pps/rising-threshold
+    tf_name: storm_control_broadcast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/broadcast/level/pps/falling-threshold
+    xpath: storm-control/broadcast/level/pps/falling-threshold
+    tf_name: storm_control_broadcast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/multicast/level/threshold/rising-threshold
+    xpath: storm-control/multicast/level/threshold/rising-threshold
+    tf_name: storm_control_multicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/multicast/level/threshold/falling-threshold
+    xpath: storm-control/multicast/level/threshold/falling-threshold
+    tf_name: storm_control_multicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/multicast/level/bps/rising-threshold
+    xpath: storm-control/multicast/level/bps/rising-threshold
+    tf_name: storm_control_multicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/multicast/level/bps/falling-threshold
+    xpath: storm-control/multicast/level/bps/falling-threshold
+    tf_name: storm_control_multicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/multicast/level/pps/rising-threshold
+    xpath: storm-control/multicast/level/pps/rising-threshold
+    tf_name: storm_control_multicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/multicast/level/pps/falling-threshold
+    xpath: storm-control/multicast/level/pps/falling-threshold
+    tf_name: storm_control_multicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unicast/level/threshold/rising-threshold
+    xpath: storm-control/unicast/level/threshold/rising-threshold
+    tf_name: storm_control_unicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unicast/level/threshold/falling-threshold
+    xpath: storm-control/unicast/level/threshold/falling-threshold
+    tf_name: storm_control_unicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unicast/level/bps/rising-threshold
+    xpath: storm-control/unicast/level/bps/rising-threshold
+    tf_name: storm_control_unicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unicast/level/bps/falling-threshold
+    xpath: storm-control/unicast/level/bps/falling-threshold
+    tf_name: storm_control_unicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unicast/level/pps/rising-threshold
+    xpath: storm-control/unicast/level/pps/rising-threshold
+    tf_name: storm_control_unicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unicast/level/pps/falling-threshold
+    xpath: storm-control/unicast/level/pps/falling-threshold
+    tf_name: storm_control_unicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unknown-unicast/level/threshold/rising-threshold
+    xpath: storm-control/unknown-unicast/level/threshold/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_rising_threshold
+    example: 10.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unknown-unicast/level/threshold/falling-threshold
+    xpath: storm-control/unknown-unicast/level/threshold/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_falling_threshold
+    example: 8.5
+    min_float: 0
+    max_float: 100
+  - yang_name: storm-control/unknown-unicast/level/bps/rising-threshold
+    xpath: storm-control/unknown-unicast/level/bps/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_bps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unknown-unicast/level/bps/falling-threshold
+    xpath: storm-control/unknown-unicast/level/bps/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_bps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/unknown-unicast/level/pps/rising-threshold
+    xpath: storm-control/unknown-unicast/level/pps/rising-threshold
+    tf_name: storm_control_unknown_unicast_level_pps_rising_threshold
+    example: "10k"
+  - yang_name: storm-control/unknown-unicast/level/pps/falling-threshold
+    xpath: storm-control/unknown-unicast/level/pps/falling-threshold
+    tf_name: storm_control_unknown_unicast_level_pps_falling_threshold
+    example: "8k"
+  - yang_name: storm-control/action/shutdown
+    example: true
+  - yang_name: storm-control/action/trap
+    example: true
 test_prerequisites:
   - path: /Cisco-IOS-XE-native:native/vrf/definition[name=VRF1]
     no_delete: true

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -36,11 +36,13 @@ attribute:
   exclude_test: bool(required=False)  # Set to true if the attribute should be excluded from the test
   exclude_example: bool(required=False)  # Set to true if the attribute should be excluded from the example
   description: str(required=False)  # Description of the attribute
-  example: any(str(), int(), bool(), required=False)  # Example value for the attribute
+  example: any(str(), int(), num(), bool(), required=False)  # Example value for the attribute
   allow_import_changes: bool(required=False)  # Set to true if the attribute should be allowed to change during import
   enum_values: list(str(), required=False)  # List of possible enum values
   min_int: int(required=False)  # Minimum value for integer attributes
   max_int: int(required=False)  # Maximum value for integer attributes
+  min_float: num(required=False)  # Minimum value for float attributes
+  max_float: num(required=False)  # Maximum value for float attributes
   string_patterns: list(str(),required=False)  # List of string patterns
   string_min_length: int(required=False)  # Minimum length for string attributes
   string_max_length: int(required=False)  # Maximum length for string attributes

--- a/internal/provider/data_source_iosxe_interface_ethernet.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet.go
@@ -813,6 +813,114 @@ func (d *InterfaceEthernetDataSource) Schema(ctx context.Context, req datasource
 				MarkdownDescription: "Security zone",
 				Computed:            true,
 			},
+			"access_session_monitor": schema.BoolAttribute{
+				MarkdownDescription: "Apply interface defined access-session monitor",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_broadcast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_multicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter rising threshold",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: "Enter falling threshold",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]",
+				Computed:            true,
+			},
+			"storm_control_unknown_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: "Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ",
+				Computed:            true,
+			},
+			"storm_control_action_shutdown": schema.BoolAttribute{
+				MarkdownDescription: "Shutdown this interface if a storm occurs",
+				Computed:            true,
+			},
+			"storm_control_action_trap": schema.BoolAttribute{
+				MarkdownDescription: "Send SNMP trap if a storm occurs",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_iosxe_interface_ethernet_test.go
+++ b/internal/provider/data_source_iosxe_interface_ethernet_test.go
@@ -103,6 +103,33 @@ func TestAccDataSourceIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "hold_queues.0.direction", "in"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "hold_queues.0.queue_length", "50"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "ip_igmp_version", "3"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "access_session_monitor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_broadcast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_multicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_action_shutdown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxe_interface_ethernet.test", "storm_control_action_trap", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -258,6 +285,33 @@ func testAccDataSourceIosxeInterfaceEthernetConfig() string {
 	config += `		queue_length = 50` + "\n"
 	config += `	}]` + "\n"
 	config += `	ip_igmp_version = 3` + "\n"
+	config += `	access_session_monitor = true` + "\n"
+	config += `	storm_control_broadcast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_broadcast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_broadcast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_multicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_multicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_action_shutdown = true` + "\n"
+	config += `	storm_control_action_trap = true` + "\n"
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, iosxe_yang.PreReq3, iosxe_yang.PreReq4, iosxe_yang.PreReq5, ]` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/model_iosxe_interface_ethernet.go
+++ b/internal/provider/model_iosxe_interface_ethernet.go
@@ -188,6 +188,33 @@ type InterfaceEthernet struct {
 	IpIgmpVersion                                       types.Int64                                       `tfsdk:"ip_igmp_version"`
 	IpRouterIsis                                        types.String                                      `tfsdk:"ip_router_isis"`
 	ZoneMemberSecurity                                  types.String                                      `tfsdk:"zone_member_security"`
+	AccessSessionMonitor                                types.Bool                                        `tfsdk:"access_session_monitor"`
+	StormControlBroadcastLevelRisingThreshold           types.Float64                                     `tfsdk:"storm_control_broadcast_level_rising_threshold"`
+	StormControlBroadcastLevelFallingThreshold          types.Float64                                     `tfsdk:"storm_control_broadcast_level_falling_threshold"`
+	StormControlBroadcastLevelBpsRisingThreshold        types.String                                      `tfsdk:"storm_control_broadcast_level_bps_rising_threshold"`
+	StormControlBroadcastLevelBpsFallingThreshold       types.String                                      `tfsdk:"storm_control_broadcast_level_bps_falling_threshold"`
+	StormControlBroadcastLevelPpsRisingThreshold        types.String                                      `tfsdk:"storm_control_broadcast_level_pps_rising_threshold"`
+	StormControlBroadcastLevelPpsFallingThreshold       types.String                                      `tfsdk:"storm_control_broadcast_level_pps_falling_threshold"`
+	StormControlMulticastLevelRisingThreshold           types.Float64                                     `tfsdk:"storm_control_multicast_level_rising_threshold"`
+	StormControlMulticastLevelFallingThreshold          types.Float64                                     `tfsdk:"storm_control_multicast_level_falling_threshold"`
+	StormControlMulticastLevelBpsRisingThreshold        types.String                                      `tfsdk:"storm_control_multicast_level_bps_rising_threshold"`
+	StormControlMulticastLevelBpsFallingThreshold       types.String                                      `tfsdk:"storm_control_multicast_level_bps_falling_threshold"`
+	StormControlMulticastLevelPpsRisingThreshold        types.String                                      `tfsdk:"storm_control_multicast_level_pps_rising_threshold"`
+	StormControlMulticastLevelPpsFallingThreshold       types.String                                      `tfsdk:"storm_control_multicast_level_pps_falling_threshold"`
+	StormControlUnicastLevelRisingThreshold             types.Float64                                     `tfsdk:"storm_control_unicast_level_rising_threshold"`
+	StormControlUnicastLevelFallingThreshold            types.Float64                                     `tfsdk:"storm_control_unicast_level_falling_threshold"`
+	StormControlUnicastLevelBpsRisingThreshold          types.String                                      `tfsdk:"storm_control_unicast_level_bps_rising_threshold"`
+	StormControlUnicastLevelBpsFallingThreshold         types.String                                      `tfsdk:"storm_control_unicast_level_bps_falling_threshold"`
+	StormControlUnicastLevelPpsRisingThreshold          types.String                                      `tfsdk:"storm_control_unicast_level_pps_rising_threshold"`
+	StormControlUnicastLevelPpsFallingThreshold         types.String                                      `tfsdk:"storm_control_unicast_level_pps_falling_threshold"`
+	StormControlUnknownUnicastLevelRisingThreshold      types.Float64                                     `tfsdk:"storm_control_unknown_unicast_level_rising_threshold"`
+	StormControlUnknownUnicastLevelFallingThreshold     types.Float64                                     `tfsdk:"storm_control_unknown_unicast_level_falling_threshold"`
+	StormControlUnknownUnicastLevelBpsRisingThreshold   types.String                                      `tfsdk:"storm_control_unknown_unicast_level_bps_rising_threshold"`
+	StormControlUnknownUnicastLevelBpsFallingThreshold  types.String                                      `tfsdk:"storm_control_unknown_unicast_level_bps_falling_threshold"`
+	StormControlUnknownUnicastLevelPpsRisingThreshold   types.String                                      `tfsdk:"storm_control_unknown_unicast_level_pps_rising_threshold"`
+	StormControlUnknownUnicastLevelPpsFallingThreshold  types.String                                      `tfsdk:"storm_control_unknown_unicast_level_pps_falling_threshold"`
+	StormControlActionShutdown                          types.Bool                                        `tfsdk:"storm_control_action_shutdown"`
+	StormControlActionTrap                              types.Bool                                        `tfsdk:"storm_control_action_trap"`
 }
 type InterfaceEthernetHelperAddresses struct {
 	Address types.String `tfsdk:"address"`
@@ -391,6 +418,33 @@ type InterfaceEthernetData struct {
 	IpIgmpVersion                                       types.Int64                                           `tfsdk:"ip_igmp_version"`
 	IpRouterIsis                                        types.String                                          `tfsdk:"ip_router_isis"`
 	ZoneMemberSecurity                                  types.String                                          `tfsdk:"zone_member_security"`
+	AccessSessionMonitor                                types.Bool                                            `tfsdk:"access_session_monitor"`
+	StormControlBroadcastLevelRisingThreshold           types.Float64                                         `tfsdk:"storm_control_broadcast_level_rising_threshold"`
+	StormControlBroadcastLevelFallingThreshold          types.Float64                                         `tfsdk:"storm_control_broadcast_level_falling_threshold"`
+	StormControlBroadcastLevelBpsRisingThreshold        types.String                                          `tfsdk:"storm_control_broadcast_level_bps_rising_threshold"`
+	StormControlBroadcastLevelBpsFallingThreshold       types.String                                          `tfsdk:"storm_control_broadcast_level_bps_falling_threshold"`
+	StormControlBroadcastLevelPpsRisingThreshold        types.String                                          `tfsdk:"storm_control_broadcast_level_pps_rising_threshold"`
+	StormControlBroadcastLevelPpsFallingThreshold       types.String                                          `tfsdk:"storm_control_broadcast_level_pps_falling_threshold"`
+	StormControlMulticastLevelRisingThreshold           types.Float64                                         `tfsdk:"storm_control_multicast_level_rising_threshold"`
+	StormControlMulticastLevelFallingThreshold          types.Float64                                         `tfsdk:"storm_control_multicast_level_falling_threshold"`
+	StormControlMulticastLevelBpsRisingThreshold        types.String                                          `tfsdk:"storm_control_multicast_level_bps_rising_threshold"`
+	StormControlMulticastLevelBpsFallingThreshold       types.String                                          `tfsdk:"storm_control_multicast_level_bps_falling_threshold"`
+	StormControlMulticastLevelPpsRisingThreshold        types.String                                          `tfsdk:"storm_control_multicast_level_pps_rising_threshold"`
+	StormControlMulticastLevelPpsFallingThreshold       types.String                                          `tfsdk:"storm_control_multicast_level_pps_falling_threshold"`
+	StormControlUnicastLevelRisingThreshold             types.Float64                                         `tfsdk:"storm_control_unicast_level_rising_threshold"`
+	StormControlUnicastLevelFallingThreshold            types.Float64                                         `tfsdk:"storm_control_unicast_level_falling_threshold"`
+	StormControlUnicastLevelBpsRisingThreshold          types.String                                          `tfsdk:"storm_control_unicast_level_bps_rising_threshold"`
+	StormControlUnicastLevelBpsFallingThreshold         types.String                                          `tfsdk:"storm_control_unicast_level_bps_falling_threshold"`
+	StormControlUnicastLevelPpsRisingThreshold          types.String                                          `tfsdk:"storm_control_unicast_level_pps_rising_threshold"`
+	StormControlUnicastLevelPpsFallingThreshold         types.String                                          `tfsdk:"storm_control_unicast_level_pps_falling_threshold"`
+	StormControlUnknownUnicastLevelRisingThreshold      types.Float64                                         `tfsdk:"storm_control_unknown_unicast_level_rising_threshold"`
+	StormControlUnknownUnicastLevelFallingThreshold     types.Float64                                         `tfsdk:"storm_control_unknown_unicast_level_falling_threshold"`
+	StormControlUnknownUnicastLevelBpsRisingThreshold   types.String                                          `tfsdk:"storm_control_unknown_unicast_level_bps_rising_threshold"`
+	StormControlUnknownUnicastLevelBpsFallingThreshold  types.String                                          `tfsdk:"storm_control_unknown_unicast_level_bps_falling_threshold"`
+	StormControlUnknownUnicastLevelPpsRisingThreshold   types.String                                          `tfsdk:"storm_control_unknown_unicast_level_pps_rising_threshold"`
+	StormControlUnknownUnicastLevelPpsFallingThreshold  types.String                                          `tfsdk:"storm_control_unknown_unicast_level_pps_falling_threshold"`
+	StormControlActionShutdown                          types.Bool                                            `tfsdk:"storm_control_action_shutdown"`
+	StormControlActionTrap                              types.Bool                                            `tfsdk:"storm_control_action_trap"`
 }
 type InterfaceEthernetHelperAddressesData struct {
 	Address types.String `tfsdk:"address"`
@@ -1350,6 +1404,95 @@ func (data InterfaceEthernet) addToBodyXML(ctx context.Context, config Interface
 	}
 	if !data.ZoneMemberSecurity.IsNull() && !data.ZoneMemberSecurity.IsUnknown() {
 		body = helpers.SetFromXPath(body, data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security", data.ZoneMemberSecurity.ValueString())
+	}
+	if !data.AccessSessionMonitor.IsNull() && !data.AccessSessionMonitor.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/access-session/monitor", data.AccessSessionMonitor.ValueBool())
+	}
+	if !data.StormControlBroadcastLevelRisingThreshold.IsNull() && !data.StormControlBroadcastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlBroadcastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlBroadcastLevelFallingThreshold.IsNull() && !data.StormControlBroadcastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlBroadcastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() && !data.StormControlBroadcastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold", data.StormControlBroadcastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() && !data.StormControlBroadcastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold", data.StormControlBroadcastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() && !data.StormControlBroadcastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold", data.StormControlBroadcastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() && !data.StormControlBroadcastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold", data.StormControlBroadcastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelRisingThreshold.IsNull() && !data.StormControlMulticastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlMulticastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlMulticastLevelFallingThreshold.IsNull() && !data.StormControlMulticastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlMulticastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() && !data.StormControlMulticastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold", data.StormControlMulticastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() && !data.StormControlMulticastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold", data.StormControlMulticastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() && !data.StormControlMulticastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold", data.StormControlMulticastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() && !data.StormControlMulticastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold", data.StormControlMulticastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelRisingThreshold.IsNull() && !data.StormControlUnicastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlUnicastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnicastLevelFallingThreshold.IsNull() && !data.StormControlUnicastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlUnicastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() && !data.StormControlUnicastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold", data.StormControlUnicastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() && !data.StormControlUnicastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold", data.StormControlUnicastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() && !data.StormControlUnicastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold", data.StormControlUnicastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() && !data.StormControlUnicastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold", data.StormControlUnicastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold", strconv.FormatFloat(data.StormControlUnknownUnicastLevelRisingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold", strconv.FormatFloat(data.StormControlUnknownUnicastLevelFallingThreshold.ValueFloat64(), 'f', 1, 64))
+	}
+	if !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold", data.StormControlUnknownUnicastLevelBpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold", data.StormControlUnknownUnicastLevelBpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold", data.StormControlUnknownUnicastLevelPpsRisingThreshold.ValueString())
+	}
+	if !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() && !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsUnknown() {
+		body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold", data.StormControlUnknownUnicastLevelPpsFallingThreshold.ValueString())
+	}
+	if !data.StormControlActionShutdown.IsNull() && !data.StormControlActionShutdown.IsUnknown() {
+		if data.StormControlActionShutdown.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/action/shutdown", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/storm-control/action/shutdown")
+		}
+	}
+	if !data.StormControlActionTrap.IsNull() && !data.StormControlActionTrap.IsUnknown() {
+		if data.StormControlActionTrap.ValueBool() {
+			body = helpers.SetFromXPath(body, data.getXPath()+"/storm-control/action/trap", "")
+		} else {
+			body = helpers.RemoveFromXPath(body, data.getXPath()+"/storm-control/action/trap")
+		}
 	}
 	return body
 }
@@ -2786,6 +2929,151 @@ func (data *InterfaceEthernet) updateFromBodyXML(ctx context.Context, res xmldot
 	} else {
 		data.ZoneMemberSecurity = types.StringNull()
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); !data.AccessSessionMonitor.IsNull() {
+		if value.Exists() {
+			data.AccessSessionMonitor = types.BoolValue(value.Bool())
+		}
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() && !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() && !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	} else {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Null()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() && !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	} else {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); !data.StormControlActionShutdown.IsNull() {
+		if value.Exists() {
+			data.StormControlActionShutdown = types.BoolValue(true)
+		} else {
+			data.StormControlActionShutdown = types.BoolValue(false)
+		}
+	} else {
+		data.StormControlActionShutdown = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); !data.StormControlActionTrap.IsNull() {
+		if value.Exists() {
+			data.StormControlActionTrap = types.BoolValue(true)
+		} else {
+			data.StormControlActionTrap = types.BoolValue(false)
+		}
+	} else {
+		data.StormControlActionTrap = types.BoolNull()
+	}
 }
 
 // End of section. //template:end updateFromBodyXML
@@ -3550,6 +3838,93 @@ func (data *InterfaceEthernet) fromBodyXML(ctx context.Context, res xmldot.Resul
 	}
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security"); value.Exists() {
 		data.ZoneMemberSecurity = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); value.Exists() {
+		data.AccessSessionMonitor = types.BoolValue(value.Bool())
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); value.Exists() {
+		data.StormControlActionShutdown = types.BoolValue(true)
+	} else {
+		data.StormControlActionShutdown = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); value.Exists() {
+		data.StormControlActionTrap = types.BoolValue(true)
+	} else {
+		data.StormControlActionTrap = types.BoolValue(false)
 	}
 }
 
@@ -4316,6 +4691,93 @@ func (data *InterfaceEthernetData) fromBodyXML(ctx context.Context, res xmldot.R
 	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security"); value.Exists() {
 		data.ZoneMemberSecurity = types.StringValue(value.String())
 	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/access-session/monitor"); value.Exists() {
+		data.AccessSessionMonitor = types.BoolValue(value.Bool())
+	} else {
+		data.AccessSessionMonitor = types.BoolNull()
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlBroadcastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlMulticastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelRisingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelFallingThreshold = types.Float64Value(value.Float())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelBpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsRisingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold"); value.Exists() {
+		data.StormControlUnknownUnicastLevelPpsFallingThreshold = types.StringValue(value.String())
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/shutdown"); value.Exists() {
+		data.StormControlActionShutdown = types.BoolValue(true)
+	} else {
+		data.StormControlActionShutdown = types.BoolValue(false)
+	}
+	if value := helpers.GetFromXPath(res, "data"+data.getXPath()+"/storm-control/action/trap"); value.Exists() {
+		data.StormControlActionTrap = types.BoolValue(true)
+	} else {
+		data.StormControlActionTrap = types.BoolValue(false)
+	}
 }
 
 // End of section. //template:end fromBodyDataXML
@@ -4324,6 +4786,87 @@ func (data *InterfaceEthernetData) fromBodyXML(ctx context.Context, res xmldot.R
 
 func (data *InterfaceEthernet) addDeletedItemsXML(ctx context.Context, state InterfaceEthernet, body string) string {
 	b := netconf.NewBody(body)
+	if !state.StormControlActionTrap.IsNull() && data.StormControlActionTrap.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/action/trap")
+	}
+	if !state.StormControlActionShutdown.IsNull() && data.StormControlActionShutdown.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/action/shutdown")
+	}
+	if !state.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelFallingThreshold.IsNull() && data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlUnknownUnicastLevelRisingThreshold.IsNull() && data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelPpsFallingThreshold.IsNull() && data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelPpsRisingThreshold.IsNull() && data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelBpsFallingThreshold.IsNull() && data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelBpsRisingThreshold.IsNull() && data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlUnicastLevelFallingThreshold.IsNull() && data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlUnicastLevelRisingThreshold.IsNull() && data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelPpsFallingThreshold.IsNull() && data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/pps/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelPpsRisingThreshold.IsNull() && data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/pps/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelBpsFallingThreshold.IsNull() && data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/bps/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelBpsRisingThreshold.IsNull() && data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/bps/rising-threshold")
+	}
+	if !state.StormControlMulticastLevelFallingThreshold.IsNull() && data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlMulticastLevelRisingThreshold.IsNull() && data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelPpsFallingThreshold.IsNull() && data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelPpsRisingThreshold.IsNull() && data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelBpsFallingThreshold.IsNull() && data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelBpsRisingThreshold.IsNull() && data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold")
+	}
+	if !state.StormControlBroadcastLevelFallingThreshold.IsNull() && data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold")
+	}
+	if !state.StormControlBroadcastLevelRisingThreshold.IsNull() && data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold")
+	}
+	if !state.AccessSessionMonitor.IsNull() && data.AccessSessionMonitor.IsNull() {
+		b = helpers.RemoveFromXPath(b, state.getXPath()+"/access-session/monitor")
+	}
 	if !state.ZoneMemberSecurity.IsNull() && data.ZoneMemberSecurity.IsNull() {
 		b = helpers.RemoveFromXPath(b, state.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security")
 	}
@@ -5167,6 +5710,87 @@ func (data *InterfaceEthernet) addDeletedItemsXML(ctx context.Context, state Int
 
 func (data *InterfaceEthernet) addDeletePathsXML(ctx context.Context, body string) string {
 	b := netconf.NewBody(body)
+	if !data.StormControlActionTrap.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/action/trap")
+	}
+	if !data.StormControlActionShutdown.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/action/shutdown")
+	}
+	if !data.StormControlUnknownUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlUnknownUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unknown-unicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlUnicastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlUnicastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/unicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/pps/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/pps/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/bps/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/bps/rising-threshold")
+	}
+	if !data.StormControlMulticastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlMulticastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/multicast/level/threshold/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelPpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/pps/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelPpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/pps/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelBpsFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/bps/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelBpsRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/bps/rising-threshold")
+	}
+	if !data.StormControlBroadcastLevelFallingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/threshold/falling-threshold")
+	}
+	if !data.StormControlBroadcastLevelRisingThreshold.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/storm-control/broadcast/level/threshold/rising-threshold")
+	}
+	if !data.AccessSessionMonitor.IsNull() {
+		b = helpers.RemoveFromXPath(b, data.getXPath()+"/access-session/monitor")
+	}
 	if !data.ZoneMemberSecurity.IsNull() {
 		b = helpers.RemoveFromXPath(b, data.getXPath()+"/Cisco-IOS-XE-zone:zone-member/security")
 	}

--- a/internal/provider/model_iosxe_interface_ethernets.go
+++ b/internal/provider/model_iosxe_interface_ethernets.go
@@ -191,6 +191,33 @@ type InterfaceEthernetsItems struct {
 	IpIgmpVersion                                       types.Int64                                       `tfsdk:"ip_igmp_version"`
 	IpRouterIsis                                        types.String                                      `tfsdk:"ip_router_isis"`
 	ZoneMemberSecurity                                  types.String                                      `tfsdk:"zone_member_security"`
+	AccessSessionMonitor                                types.Bool                                        `tfsdk:"access_session_monitor"`
+	StormControlBroadcastLevelRisingThreshold           types.Float64                                     `tfsdk:"storm_control_broadcast_level_rising_threshold"`
+	StormControlBroadcastLevelFallingThreshold          types.Float64                                     `tfsdk:"storm_control_broadcast_level_falling_threshold"`
+	StormControlBroadcastLevelBpsRisingThreshold        types.String                                      `tfsdk:"storm_control_broadcast_level_bps_rising_threshold"`
+	StormControlBroadcastLevelBpsFallingThreshold       types.String                                      `tfsdk:"storm_control_broadcast_level_bps_falling_threshold"`
+	StormControlBroadcastLevelPpsRisingThreshold        types.String                                      `tfsdk:"storm_control_broadcast_level_pps_rising_threshold"`
+	StormControlBroadcastLevelPpsFallingThreshold       types.String                                      `tfsdk:"storm_control_broadcast_level_pps_falling_threshold"`
+	StormControlMulticastLevelRisingThreshold           types.Float64                                     `tfsdk:"storm_control_multicast_level_rising_threshold"`
+	StormControlMulticastLevelFallingThreshold          types.Float64                                     `tfsdk:"storm_control_multicast_level_falling_threshold"`
+	StormControlMulticastLevelBpsRisingThreshold        types.String                                      `tfsdk:"storm_control_multicast_level_bps_rising_threshold"`
+	StormControlMulticastLevelBpsFallingThreshold       types.String                                      `tfsdk:"storm_control_multicast_level_bps_falling_threshold"`
+	StormControlMulticastLevelPpsRisingThreshold        types.String                                      `tfsdk:"storm_control_multicast_level_pps_rising_threshold"`
+	StormControlMulticastLevelPpsFallingThreshold       types.String                                      `tfsdk:"storm_control_multicast_level_pps_falling_threshold"`
+	StormControlUnicastLevelRisingThreshold             types.Float64                                     `tfsdk:"storm_control_unicast_level_rising_threshold"`
+	StormControlUnicastLevelFallingThreshold            types.Float64                                     `tfsdk:"storm_control_unicast_level_falling_threshold"`
+	StormControlUnicastLevelBpsRisingThreshold          types.String                                      `tfsdk:"storm_control_unicast_level_bps_rising_threshold"`
+	StormControlUnicastLevelBpsFallingThreshold         types.String                                      `tfsdk:"storm_control_unicast_level_bps_falling_threshold"`
+	StormControlUnicastLevelPpsRisingThreshold          types.String                                      `tfsdk:"storm_control_unicast_level_pps_rising_threshold"`
+	StormControlUnicastLevelPpsFallingThreshold         types.String                                      `tfsdk:"storm_control_unicast_level_pps_falling_threshold"`
+	StormControlUnknownUnicastLevelRisingThreshold      types.Float64                                     `tfsdk:"storm_control_unknown_unicast_level_rising_threshold"`
+	StormControlUnknownUnicastLevelFallingThreshold     types.Float64                                     `tfsdk:"storm_control_unknown_unicast_level_falling_threshold"`
+	StormControlUnknownUnicastLevelBpsRisingThreshold   types.String                                      `tfsdk:"storm_control_unknown_unicast_level_bps_rising_threshold"`
+	StormControlUnknownUnicastLevelBpsFallingThreshold  types.String                                      `tfsdk:"storm_control_unknown_unicast_level_bps_falling_threshold"`
+	StormControlUnknownUnicastLevelPpsRisingThreshold   types.String                                      `tfsdk:"storm_control_unknown_unicast_level_pps_rising_threshold"`
+	StormControlUnknownUnicastLevelPpsFallingThreshold  types.String                                      `tfsdk:"storm_control_unknown_unicast_level_pps_falling_threshold"`
+	StormControlActionShutdown                          types.Bool                                        `tfsdk:"storm_control_action_shutdown"`
+	StormControlActionTrap                              types.Bool                                        `tfsdk:"storm_control_action_trap"`
 }
 
 // End of section. //template:end types
@@ -382,6 +409,33 @@ func (data InterfaceEthernets) toSingle(key string, item InterfaceEthernetsItems
 	single.IpIgmpVersion = item.IpIgmpVersion
 	single.IpRouterIsis = item.IpRouterIsis
 	single.ZoneMemberSecurity = item.ZoneMemberSecurity
+	single.AccessSessionMonitor = item.AccessSessionMonitor
+	single.StormControlBroadcastLevelRisingThreshold = item.StormControlBroadcastLevelRisingThreshold
+	single.StormControlBroadcastLevelFallingThreshold = item.StormControlBroadcastLevelFallingThreshold
+	single.StormControlBroadcastLevelBpsRisingThreshold = item.StormControlBroadcastLevelBpsRisingThreshold
+	single.StormControlBroadcastLevelBpsFallingThreshold = item.StormControlBroadcastLevelBpsFallingThreshold
+	single.StormControlBroadcastLevelPpsRisingThreshold = item.StormControlBroadcastLevelPpsRisingThreshold
+	single.StormControlBroadcastLevelPpsFallingThreshold = item.StormControlBroadcastLevelPpsFallingThreshold
+	single.StormControlMulticastLevelRisingThreshold = item.StormControlMulticastLevelRisingThreshold
+	single.StormControlMulticastLevelFallingThreshold = item.StormControlMulticastLevelFallingThreshold
+	single.StormControlMulticastLevelBpsRisingThreshold = item.StormControlMulticastLevelBpsRisingThreshold
+	single.StormControlMulticastLevelBpsFallingThreshold = item.StormControlMulticastLevelBpsFallingThreshold
+	single.StormControlMulticastLevelPpsRisingThreshold = item.StormControlMulticastLevelPpsRisingThreshold
+	single.StormControlMulticastLevelPpsFallingThreshold = item.StormControlMulticastLevelPpsFallingThreshold
+	single.StormControlUnicastLevelRisingThreshold = item.StormControlUnicastLevelRisingThreshold
+	single.StormControlUnicastLevelFallingThreshold = item.StormControlUnicastLevelFallingThreshold
+	single.StormControlUnicastLevelBpsRisingThreshold = item.StormControlUnicastLevelBpsRisingThreshold
+	single.StormControlUnicastLevelBpsFallingThreshold = item.StormControlUnicastLevelBpsFallingThreshold
+	single.StormControlUnicastLevelPpsRisingThreshold = item.StormControlUnicastLevelPpsRisingThreshold
+	single.StormControlUnicastLevelPpsFallingThreshold = item.StormControlUnicastLevelPpsFallingThreshold
+	single.StormControlUnknownUnicastLevelRisingThreshold = item.StormControlUnknownUnicastLevelRisingThreshold
+	single.StormControlUnknownUnicastLevelFallingThreshold = item.StormControlUnknownUnicastLevelFallingThreshold
+	single.StormControlUnknownUnicastLevelBpsRisingThreshold = item.StormControlUnknownUnicastLevelBpsRisingThreshold
+	single.StormControlUnknownUnicastLevelBpsFallingThreshold = item.StormControlUnknownUnicastLevelBpsFallingThreshold
+	single.StormControlUnknownUnicastLevelPpsRisingThreshold = item.StormControlUnknownUnicastLevelPpsRisingThreshold
+	single.StormControlUnknownUnicastLevelPpsFallingThreshold = item.StormControlUnknownUnicastLevelPpsFallingThreshold
+	single.StormControlActionShutdown = item.StormControlActionShutdown
+	single.StormControlActionTrap = item.StormControlActionTrap
 	single.Id = types.StringValue(single.getPath())
 	return single
 }
@@ -535,6 +589,33 @@ func (data InterfaceEthernets) toItem(single InterfaceEthernet) InterfaceEtherne
 	item.IpIgmpVersion = single.IpIgmpVersion
 	item.IpRouterIsis = single.IpRouterIsis
 	item.ZoneMemberSecurity = single.ZoneMemberSecurity
+	item.AccessSessionMonitor = single.AccessSessionMonitor
+	item.StormControlBroadcastLevelRisingThreshold = single.StormControlBroadcastLevelRisingThreshold
+	item.StormControlBroadcastLevelFallingThreshold = single.StormControlBroadcastLevelFallingThreshold
+	item.StormControlBroadcastLevelBpsRisingThreshold = single.StormControlBroadcastLevelBpsRisingThreshold
+	item.StormControlBroadcastLevelBpsFallingThreshold = single.StormControlBroadcastLevelBpsFallingThreshold
+	item.StormControlBroadcastLevelPpsRisingThreshold = single.StormControlBroadcastLevelPpsRisingThreshold
+	item.StormControlBroadcastLevelPpsFallingThreshold = single.StormControlBroadcastLevelPpsFallingThreshold
+	item.StormControlMulticastLevelRisingThreshold = single.StormControlMulticastLevelRisingThreshold
+	item.StormControlMulticastLevelFallingThreshold = single.StormControlMulticastLevelFallingThreshold
+	item.StormControlMulticastLevelBpsRisingThreshold = single.StormControlMulticastLevelBpsRisingThreshold
+	item.StormControlMulticastLevelBpsFallingThreshold = single.StormControlMulticastLevelBpsFallingThreshold
+	item.StormControlMulticastLevelPpsRisingThreshold = single.StormControlMulticastLevelPpsRisingThreshold
+	item.StormControlMulticastLevelPpsFallingThreshold = single.StormControlMulticastLevelPpsFallingThreshold
+	item.StormControlUnicastLevelRisingThreshold = single.StormControlUnicastLevelRisingThreshold
+	item.StormControlUnicastLevelFallingThreshold = single.StormControlUnicastLevelFallingThreshold
+	item.StormControlUnicastLevelBpsRisingThreshold = single.StormControlUnicastLevelBpsRisingThreshold
+	item.StormControlUnicastLevelBpsFallingThreshold = single.StormControlUnicastLevelBpsFallingThreshold
+	item.StormControlUnicastLevelPpsRisingThreshold = single.StormControlUnicastLevelPpsRisingThreshold
+	item.StormControlUnicastLevelPpsFallingThreshold = single.StormControlUnicastLevelPpsFallingThreshold
+	item.StormControlUnknownUnicastLevelRisingThreshold = single.StormControlUnknownUnicastLevelRisingThreshold
+	item.StormControlUnknownUnicastLevelFallingThreshold = single.StormControlUnknownUnicastLevelFallingThreshold
+	item.StormControlUnknownUnicastLevelBpsRisingThreshold = single.StormControlUnknownUnicastLevelBpsRisingThreshold
+	item.StormControlUnknownUnicastLevelBpsFallingThreshold = single.StormControlUnknownUnicastLevelBpsFallingThreshold
+	item.StormControlUnknownUnicastLevelPpsRisingThreshold = single.StormControlUnknownUnicastLevelPpsRisingThreshold
+	item.StormControlUnknownUnicastLevelPpsFallingThreshold = single.StormControlUnknownUnicastLevelPpsFallingThreshold
+	item.StormControlActionShutdown = single.StormControlActionShutdown
+	item.StormControlActionTrap = single.StormControlActionTrap
 	return item
 }
 

--- a/internal/provider/resource_iosxe_interface_ethernet.go
+++ b/internal/provider/resource_iosxe_interface_ethernet.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-iosxe/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -1000,6 +1001,186 @@ func (r *InterfaceEthernetResource) Schema(ctx context.Context, req resource.Sch
 			},
 			"zone_member_security": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Security zone").String,
+				Optional:            true,
+			},
+			"access_session_monitor": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Apply interface defined access-session monitor").String,
+				Optional:            true,
+			},
+			"storm_control_broadcast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_broadcast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_broadcast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_broadcast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_multicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_multicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_multicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_rising_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unknown_unicast_level_falling_threshold": schema.Float64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+				Optional:            true,
+				Validators: []validator.Float64{
+					float64validator.Between(0, 100),
+				},
+			},
+			"storm_control_unknown_unicast_level_bps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_bps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_pps_rising_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_unknown_unicast_level_pps_falling_threshold": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+				},
+			},
+			"storm_control_action_shutdown": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Shutdown this interface if a storm occurs").String,
+				Optional:            true,
+			},
+			"storm_control_action_trap": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Send SNMP trap if a storm occurs").String,
 				Optional:            true,
 			},
 		},

--- a/internal/provider/resource_iosxe_interface_ethernet_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernet_test.go
@@ -106,6 +106,33 @@ func TestAccIosxeInterfaceEthernet(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "hold_queues.0.direction", "in"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "hold_queues.0.queue_length", "50"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "ip_igmp_version", "3"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "access_session_monitor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_broadcast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_multicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_unknown_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_action_shutdown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernet.test", "storm_control_action_trap", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -299,6 +326,33 @@ func testAccIosxeInterfaceEthernetConfig_all() string {
 	config += `		queue_length = 50` + "\n"
 	config += `	}]` + "\n"
 	config += `	ip_igmp_version = 3` + "\n"
+	config += `	access_session_monitor = true` + "\n"
+	config += `	storm_control_broadcast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_broadcast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_broadcast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_broadcast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_multicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_multicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_multicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_multicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `	storm_control_unknown_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `	storm_control_action_shutdown = true` + "\n"
+	config += `	storm_control_action_trap = true` + "\n"
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, iosxe_yang.PreReq3, iosxe_yang.PreReq4, iosxe_yang.PreReq5, ]` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_iosxe_interface_ethernets.go
+++ b/internal/provider/resource_iosxe_interface_ethernets.go
@@ -986,6 +986,162 @@ func (r *InterfaceEthernetsResource) Schema(ctx context.Context, req resource.Sc
 							MarkdownDescription: helpers.NewAttributeDescription("Security zone").String,
 							Optional:            true,
 						},
+						"access_session_monitor": schema.BoolAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Apply interface defined access-session monitor").String,
+							Optional:            true,
+						},
+						"storm_control_broadcast_level_rising_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+							Optional:            true,
+						},
+						"storm_control_broadcast_level_falling_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+							Optional:            true,
+						},
+						"storm_control_broadcast_level_bps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_broadcast_level_bps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_broadcast_level_pps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_broadcast_level_pps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_multicast_level_rising_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+							Optional:            true,
+						},
+						"storm_control_multicast_level_falling_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+							Optional:            true,
+						},
+						"storm_control_multicast_level_bps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_multicast_level_bps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_multicast_level_pps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_multicast_level_pps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unicast_level_rising_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+							Optional:            true,
+						},
+						"storm_control_unicast_level_falling_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+							Optional:            true,
+						},
+						"storm_control_unicast_level_bps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unicast_level_bps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unicast_level_pps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unicast_level_pps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unknown_unicast_level_rising_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold").String,
+							Optional:            true,
+						},
+						"storm_control_unknown_unicast_level_falling_threshold": schema.Float64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold").String,
+							Optional:            true,
+						},
+						"storm_control_unknown_unicast_level_bps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]>").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unknown_unicast_level_bps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g]> ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unknown_unicast_level_pps_rising_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter rising threshold - <0.0 - 10000000000.0>[k|m|g]").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_unknown_unicast_level_pps_falling_threshold": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Enter falling threshold - <0.0 - 10000000000.0>[k|m|g] ").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`[0-9]+.?[0-9]*[k|m|g]?`), ""),
+							},
+						},
+						"storm_control_action_shutdown": schema.BoolAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Shutdown this interface if a storm occurs").String,
+							Optional:            true,
+						},
+						"storm_control_action_trap": schema.BoolAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Send SNMP trap if a storm occurs").String,
+							Optional:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_iosxe_interface_ethernets_test.go
+++ b/internal/provider/resource_iosxe_interface_ethernets_test.go
@@ -105,6 +105,33 @@ func TestAccIosxeInterfaceEthernets(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.hold_queues.0.direction", "in"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.hold_queues.0.queue_length", "50"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.ip_igmp_version", "3"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.access_session_monitor", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_broadcast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_multicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_rising_threshold", "10.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_falling_threshold", "8.5"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_bps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_bps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_pps_rising_threshold", "10k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_unknown_unicast_level_pps_falling_threshold", "8k"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_action_shutdown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxe_interface_ethernets.test", "items.GigabitEthernet;3.storm_control_action_trap", "true"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -242,6 +269,33 @@ func testAccIosxeInterfaceEthernetsConfig_all() string {
 	config += `				queue_length = 50` + "\n"
 	config += `			}]` + "\n"
 	config += `			ip_igmp_version = 3` + "\n"
+	config += `			access_session_monitor = true` + "\n"
+	config += `			storm_control_broadcast_level_rising_threshold = 10.5` + "\n"
+	config += `			storm_control_broadcast_level_falling_threshold = 8.5` + "\n"
+	config += `			storm_control_broadcast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_broadcast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_broadcast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_broadcast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_multicast_level_rising_threshold = 10.5` + "\n"
+	config += `			storm_control_multicast_level_falling_threshold = 8.5` + "\n"
+	config += `			storm_control_multicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_multicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_multicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_multicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `			storm_control_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `			storm_control_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_unknown_unicast_level_rising_threshold = 10.5` + "\n"
+	config += `			storm_control_unknown_unicast_level_falling_threshold = 8.5` + "\n"
+	config += `			storm_control_unknown_unicast_level_bps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_unknown_unicast_level_bps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_unknown_unicast_level_pps_rising_threshold = "10k"` + "\n"
+	config += `			storm_control_unknown_unicast_level_pps_falling_threshold = "8k"` + "\n"
+	config += `			storm_control_action_shutdown = true` + "\n"
+	config += `			storm_control_action_trap = true` + "\n"
 	config += `		}` + "\n"
 	config += `	}` + "\n"
 	config += `	depends_on = [iosxe_yang.PreReq0, iosxe_yang.PreReq1, iosxe_yang.PreReq2, iosxe_yang.PreReq3, iosxe_yang.PreReq4, iosxe_yang.PreReq5, ]` + "\n"


### PR DESCRIPTION
## ✔️ Type of Change

- [x] 🚀 New feature (new resource/data source, new attributes to existing resource)
- [ ] 🐛 Bug fix (corrects an issue in resource behavior, RESTCONF/NETCONF handling)
- [ ] ⚠️ Breaking change (modifies existing resource schema or removes attributes)
- [ ] 📄 Documentation update (resource docs, examples, registry docs)
- [ ] 🛠️ Refactoring / tech debt (internal improvements, no user-facing changes)
- [ ] ⚙️ Other (please describe):

## 🔗 Related Issue(s)

Same pattern as #636/#615, applied to `iosxe_interface_ethernet`. No dedicated tracking issue filed for the ethernet gap specifically — flagged as a fast-follow in #636's PR description.

Depends on #634 (`min_float`/`max_float` schema keys — required for the range validators on this PR's threshold attributes)

## 📝 Proposed Changes

Adds `access_session_monitor` and 26 storm-control attributes to `iosxe_interface_ethernet`, covering all 4 traffic classes (`broadcast`, `multicast`, `unicast`, `unknown-unicast`) × 3 representations (`threshold` percentage, `bps`, `pps`) × rising/falling, plus the 2 storm-control actions (`shutdown`, `trap`). 27 new attributes total — identical shape to #636.

YANG paths, e.g.:

- `storm-control/broadcast/level/threshold/rising-threshold`
- `storm-control/broadcast/level/bps/rising-threshold`
- `storm-control/broadcast/level/pps/rising-threshold`
- (same shape repeated for `multicast`, `unicast`, `unknown-unicast`)
- `storm-control/action/shutdown`, `storm-control/action/trap`
- `access-session/monitor`

The `threshold` (percentage) attributes use `min_float: 0` / `max_float: 100` from #634 to get client-side range validation (`float64validator.Between(0, 100)`), matching the device's actual `0..100` range.

### Known Limitations

Same device-side constraints as #636, confirmed to reproduce identically on `iosxe_interface_ethernet`:

- `level`/`bps`/`pps` mutual exclusivity per traffic class (silent overwrite) — unenforced client-side.
- `falling_threshold` presence/magnitude vs `rising_threshold` — unenforced client-side, rejected at commit by the device if `falling > rising`.
- **`FormatFloat` 1-decimal precision truncation** (previously confirmed on port-channel): the shared template rounds `threshold` values to 1 decimal regardless of the YANG's actual 2-decimal precision. Confirmed here too — `10.55` applied as `10.6`, silently, no plan drift. Only affects `threshold`; `bps`/`pps` are plain strings, unaffected.

All three are tracked as provider-wide follow-ups (`also_requires`/`conflicts_with` generator support, and the `FormatFloat` precision fix), not blocking this PR.

---

## 🧪 Testing Evidence

- [ ] N/A — this PR does not touch definitions, generated code, or provider logic (e.g., docs-only, CI, chore)

### 1. Code Generation

```
make gen NAME="Interface Ethernet"
go build ./...
go vet ./...
```

- [x] `make gen` completes without errors
- [x] Generated code matches YANG model expectations

### 2. Acceptance Tests

Hardware-tested on lab switch (C9200L-24P-4G, IOS-XE 17.15.4), interface GigabitEthernet1/0/10. No automated `TestAcc` added; manual coverage:

- Range boundaries — `0.0`/`100.0` apply without error.
- `access_session_monitor` — confirmed on-device, no drift.
- Decimal precision — `10.55` on a `threshold` attribute applies as `10.6` (see Known Limitations above); this is the pre-existing provider-wide `FormatFloat` truncation, not new to ethernet.
- Mutual exclusivity and representation switching — same behavior as #636/#635, reproduces identically on this resource.
- Storm-control and access-session attributes exercised individually, grouped by representation, to avoid the known mutual-exclusivity conflict.

- [ ] Acceptance tests pass against a real device
- [x] Device type and IOS-XE version: **C9200L-24P-4G, IOS-XE 17.15.4**

---

## 🔗 Cross-Repo Links

- Module PR: n/a
- Schema PR: n/a (provider-repo prerequisite is #634, not a separate `netascode/nac-iosxe` schema PR)

## ✅ Checklist

### Pre-Submission

- [x] I have merged/rebased from `main` and resolved all merge conflicts
- [x] `make gen` runs cleanly for affected resources
- [ ] Acceptance tests pass against a real IOS-XE device
      *(manual hardware testing done, see Testing Evidence above; no automated TestAcc added)*
- [x] `go build ./...` compiles without errors

### Code Quality

- [x] Definition YAML follows existing patterns in `gen/definitions/`
- [x] YANG paths are correct and validated against YangSuite
      *(not YangSuite specifically — validated via generator output and hardware confirmation)*
- [x] Examples in `examples/resources/` are updated for new/changed attributes
- [x] Resource documentation in `docs/` is regenerated and accurate

### Labels & Assignment

- [ ] I have assigned at least one label that aligns with `release.yaml` categories
- [ ] Label(s) match the linked GitHub issue label(s) where applicable
- [ ] PR is assigned to myself
- [ ] One or more reviewers are assigned